### PR TITLE
Enable refine widget via prompt.

### DIFF
--- a/internal/dashboard/ai.go
+++ b/internal/dashboard/ai.go
@@ -1,14 +1,13 @@
 package dashboard
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
-	"text/template"
 
+	"github.com/marianogappa/screpdb/internal/dashboard/dashdb"
+	"github.com/marianogappa/screpdb/internal/dashboard/history"
 	"github.com/marianogappa/screpdb/internal/storage"
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
@@ -16,57 +15,36 @@ import (
 )
 
 type AI struct {
-	ctx   context.Context
-	llm   *openai.LLM
-	store storage.Storage
-	// conversations []Conversation
+	ctx                context.Context
+	llm                *openai.LLM
+	store              storage.Storage
+	promptHistoryStore *history.PromptHistoryStorage
+	debug              bool
 }
 
-func NewAI(ctx context.Context, openaiAPIKey string, store storage.Storage) (*AI, error) {
+func NewAI(ctx context.Context, openaiAPIKey string, store storage.Storage, queries *dashdb.Queries, debug bool) (*AI, error) {
 	llm, err := openai.New(openai.WithToken(openaiAPIKey), openai.WithResponseFormat(responseFormat))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-	return &AI{ctx: ctx, llm: llm, store: store}, nil
+	promptHistoryStore := history.NewPromptHistoryStorage(queries, true)
+	return &AI{ctx: ctx, llm: llm, store: store, promptHistoryStore: promptHistoryStore, debug: debug}, nil
 }
 
 type Conversation struct {
-	ai      *AI
-	history []llms.MessageContent
+	ai             *AI
+	storeForWidget *history.PromptHistoryStorageForWidget
 }
 
-func (a *AI) NewConversation() (*Conversation, error) {
-	var sp bytes.Buffer
-	if err := systemPromptTpl.Execute(&sp, struct{}{}); err != nil {
+func (a *AI) NewConversation(widgetID int64) (*Conversation, error) {
+	storeForWidget, err := a.promptHistoryStore.ForWidgetID(a.ctx, widgetID)
+	if err != nil {
 		return nil, err
 	}
-
 	return &Conversation{
-		ai:      a,
-		history: []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeSystem, sp.String())},
+		ai:             a,
+		storeForWidget: storeForWidget,
 	}, nil
-}
-
-func (c *Conversation) addHumanPrompt(prompt string) {
-	log.Printf("Adding human prompt: %s\n", prompt)
-	c.history = append(c.history, llms.TextParts(llms.ChatMessageTypeHuman, prompt))
-}
-
-func (c *Conversation) addMessageContents(mcs []llms.MessageContent) {
-	for _, mc := range mcs {
-		log.Printf("Adding AI message content: %+v\n", mc)
-	}
-	c.history = append(c.history, mcs...)
-}
-
-func (c *Conversation) addContentChoice(contentChoice *llms.ContentChoice) {
-	log.Printf("Adding AI content: %s\n", contentChoice.Content)
-	assistantResponse := llms.TextParts(llms.ChatMessageTypeAI, contentChoice.Content)
-	for _, tc := range contentChoice.ToolCalls {
-		log.Printf("Adding AI response part: %+v\n", tc)
-		assistantResponse.Parts = append(assistantResponse.Parts, tc)
-	}
-	c.history = append(c.history, assistantResponse)
 }
 
 type StructuredResponse struct {
@@ -76,27 +54,35 @@ type StructuredResponse struct {
 	Description string       `json:"description"`
 }
 
-// TODO: don't save history in memory
 func (c *Conversation) Prompt(prompt string) (StructuredResponse, error) {
 	definedParser, err := outputparser.NewDefined(StructuredResponse{})
 	if err != nil {
 		return StructuredResponse{}, err
 	}
-	c.addHumanPrompt(fmt.Sprintf("%s\n%s", prompt, definedParser.GetFormatInstructions()))
+	if err := c.storeForWidget.AddHumanPrompt(fmt.Sprintf("%s\n%s", prompt, definedParser.GetFormatInstructions())); err != nil {
+		return StructuredResponse{}, err
+	}
 	for {
+		history, err := c.storeForWidget.Get()
 		resp, err := c.ai.llm.GenerateContent(
 			c.ai.ctx,
-			c.history,
+			history,
 			llms.WithTools(availableTools),
 			llms.WithModel("gpt-4o-2024-08-06"),
 		)
+		c.ai.logf("sent request to OpenAI with history with %v entries...\n", len(history))
 		if err != nil {
 			return StructuredResponse{}, err
 		}
 		respchoice := resp.Choices[0]
-		c.addContentChoice(respchoice)
-		c.addMessageContents(c.ai.respondToToolCalls(respchoice.ToolCalls))
+		if err := c.storeForWidget.AddContentChoice(respchoice); err != nil {
+			return StructuredResponse{}, err
+		}
+		if err := c.storeForWidget.AddMessageContents(c.ai.respondToToolCalls(respchoice.ToolCalls)); err != nil {
+			return StructuredResponse{}, err
+		}
 		if len(respchoice.ToolCalls) > 0 {
+			c.ai.logf("response from OpenAI has %v tool calls so looping...\n", len(respchoice.ToolCalls))
 			continue
 		}
 
@@ -108,510 +94,9 @@ func (c *Conversation) Prompt(prompt string) (StructuredResponse, error) {
 	}
 }
 
-func (a *AI) respondToToolCalls(tcs []llms.ToolCall) []llms.MessageContent {
-	messageHistory := []llms.MessageContent{}
-	for _, tc := range tcs {
-		switch tc.FunctionCall.Name {
-		case "query_database":
-			var args struct {
-				SQL string `json:"sql"`
-			}
-			if err := json.Unmarshal([]byte(tc.FunctionCall.Arguments), &args); err != nil {
-				toolResponse := llms.MessageContent{
-					Role: llms.ChatMessageTypeTool,
-					Parts: []llms.ContentPart{
-						llms.ToolCallResponse{
-							ToolCallID: tc.ID,
-							Name:       tc.FunctionCall.Name,
-							Content:    fmt.Sprintf("failed to unmarshal arguments: %v", err),
-						},
-					},
-				}
-				messageHistory = append(messageHistory, toolResponse)
-				continue
-			}
-			queryResult, err := a.store.Query(a.ctx, args.SQL)
-			if err != nil {
-				toolResponse := llms.MessageContent{
-					Role: llms.ChatMessageTypeTool,
-					Parts: []llms.ContentPart{
-						llms.ToolCallResponse{
-							ToolCallID: tc.ID,
-							Name:       tc.FunctionCall.Name,
-							Content:    fmt.Sprintf("error running query: %v", err),
-						},
-					},
-				}
-				messageHistory = append(messageHistory, toolResponse)
-			} else {
-				toolResponse := llms.MessageContent{
-					Role: llms.ChatMessageTypeTool,
-					Parts: []llms.ContentPart{
-						llms.ToolCallResponse{
-							ToolCallID: tc.ID,
-							Name:       tc.FunctionCall.Name,
-							Content:    formatQueryResults(queryResult),
-						},
-					},
-				}
-				messageHistory = append(messageHistory, toolResponse)
-			}
-		case "get_database_schema":
-			schema, err := a.store.GetDatabaseSchema(a.ctx)
-			if err != nil {
-				toolResponse := llms.MessageContent{
-					Role: llms.ChatMessageTypeTool,
-					Parts: []llms.ContentPart{
-						llms.ToolCallResponse{
-							ToolCallID: tc.ID,
-							Name:       tc.FunctionCall.Name,
-							Content:    fmt.Sprintf("failed to get database schema: %v", err),
-						},
-					},
-				}
-				messageHistory = append(messageHistory, toolResponse)
-				continue
-			}
-			toolResponse := llms.MessageContent{
-				Role: llms.ChatMessageTypeTool,
-				Parts: []llms.ContentPart{
-					llms.ToolCallResponse{
-						ToolCallID: tc.ID,
-						Name:       tc.FunctionCall.Name,
-						Content:    fmt.Sprintf("%v\n%v", schema, schemaObservations),
-					},
-				},
-			}
-			messageHistory = append(messageHistory, toolResponse)
-		case "get_starcraft_knowledge":
-			toolResponse := llms.MessageContent{
-				Role: llms.ChatMessageTypeTool,
-				Parts: []llms.ContentPart{
-					llms.ToolCallResponse{
-						ToolCallID: tc.ID,
-						Name:       tc.FunctionCall.Name,
-						Content:    starcraftKnowledge,
-					},
-				},
-			}
-			messageHistory = append(messageHistory, toolResponse)
-		default:
-			toolResponse := llms.MessageContent{
-				Role: llms.ChatMessageTypeTool,
-				Parts: []llms.ContentPart{
-					llms.ToolCallResponse{
-						ToolCallID: tc.ID,
-						Name:       tc.FunctionCall.Name,
-						Content:    "error: unknown function call",
-					},
-				},
-			}
-			messageHistory = append(messageHistory, toolResponse)
-		}
+func (s *AI) logf(message string, args ...any) {
+	if !s.debug {
+		return
 	}
-	return messageHistory
+	log.Printf(message, args...)
 }
-
-// availableTools simulates the tools/functions we're making available for
-// the model.
-var availableTools = []llms.Tool{
-	{
-		Type: "function",
-		Function: &llms.FunctionDefinition{
-			Name:        "query_database",
-			Description: "Execute SQL queries against the StarCraft replay database. The database contains tables: replays (metadata), players (player info) & commands (game events). Use this tool to analyze replay statistics, player performance, unit usage, and game patterns.",
-			Parameters: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"sql": map[string]any{
-						"type":        "string",
-						"description": "PostgresSQL query to execute against the StarCraft replay database",
-					},
-				},
-				"required": []string{"sql"},
-			},
-		},
-	},
-	{
-		Type: "function",
-		Function: &llms.FunctionDefinition{
-			Name:        "get_database_schema",
-			Description: "Detailed information about the StarCraft replay database schema including table structures, relationships obtained by querying the database itself.",
-			Parameters:  map[string]any{},
-		},
-	},
-	{
-		Type: "function",
-		Function: &llms.FunctionDefinition{
-			Name:        "get_starcraft_knowledge",
-			Description: "Summary of StarCraft knowledge useful for knowing how to answer questions and make reports.",
-			Parameters:  map[string]any{},
-		},
-	},
-}
-
-// formatQueryResults formats query results for display
-func formatQueryResults(results []map[string]any) string {
-	if len(results) == 0 {
-		return "No results found."
-	}
-
-	// Get column names from first row
-	var columns []string
-	for col := range results[0] {
-		columns = append(columns, col)
-	}
-
-	// Create table format
-	var output strings.Builder
-	output.WriteString("Query Results:\n\n")
-
-	// Header
-	for i, col := range columns {
-		if i > 0 {
-			output.WriteString(" | ")
-		}
-		output.WriteString(col)
-	}
-	output.WriteString("\n")
-
-	// Separator
-	for i, col := range columns {
-		if i > 0 {
-			output.WriteString(" | ")
-		}
-		for j := 0; j < len(col); j++ {
-			output.WriteString("-")
-		}
-	}
-	output.WriteString("\n")
-
-	// Data rows
-	for _, row := range results {
-		for i, col := range columns {
-			if i > 0 {
-				output.WriteString(" | ")
-			}
-			value := fmt.Sprintf("%v", row[col])
-			output.WriteString(value)
-		}
-		output.WriteString("\n")
-	}
-
-	output.WriteString(fmt.Sprintf("\nTotal rows: %d", len(results)))
-
-	return output.String()
-}
-
-const (
-	schemaObservations = `
-	- Replays have up to 8 players (and up to 4 observers) and a sequential list of commands/actions (like Chess). Command timing is tracked in "frames" since game start and also with a timestamp.
-	- The commands table has action-type-specific fields, so for a given row many fields are null.
-
-	- JOIN patterns:
-		- players.replay_id = replays.id
-		- commands.replay_id = replays.id
-		- commands.player_id = players.id
-
-	- Common WHERE clauses:
-		- players.type = 'Human' (i.e. skip 'Computer' players)
-		- players.is_observer = false (i.e. Observer players are not part of the game)
-
-	action_types:
-		- Build
-		- Land
-		- RightClick
-		- TargetedOrder
-		- Train
-		- BuildInterceptorOrScarab
-		- MinimapPing
-		- CancelTrain
-		- UnitMorph
-		- Tech
-		- Upgrade
-		- GameSpeed
-		- Hotkey
-		- Chat
-		- Vision
-		- Alliance
-		- LeaveGame
-		- Stop
-		- CarrierStop
-		- ReaverStop
-		- ReturnCargo
-		- UnloadAll
-		- HoldPosition
-		- Burrow
-		- Unburrow
-		- Siege
-		- Unsiege
-		- Cloack
-		- Decloack
-		- Cheat
-
-	unit_types:
-
-		- Supply Depot
-		- Forge
-		- Hydralisk Den
-		- Siege Tank (Tank Mode)
-		- Barracks
-		- Reaver
-		- Engineering Bay
-		- ComSat
-		- Valkyrie
-		- Corsair
-		- Creep Colony
-		- Extractor
-		- Covert Ops
-		- Gateway
-		- Ultralisk
-		- Academy
-		- Nuclear Missile
-		- Defiler Mound
-		- Guardian
-		- Spore Colony
-		- Templar Archives
-		- Arbiter
-		- Hive
-		- Firebat
-		- Zealot
-		- Arbiter Tribunal
-		- Cybernetics Core
-		- Wraith
-		- Overlord
-		- Evolution Chamber
-		- Stargate
-		- Physics Lab
-		- Spawning Pool
-		- Science Facility
-		- Fleet Beacon
-		- Goliath
-		- Probe
-		- Missile Turret
-		- Sunken Colony
-		- Robotics Support Bay
-		- Vulture
-		- Nuclear Silo
-		- Medic
-		- Observatory
-		- Queen
-		- High Templar
-		- Starport
-		- Ghost
-		- Spire
-		- Armory
-		- Factory
-		- Nexus
-		- Marine
-		- Bunker
-		- Battlecruiser
-		- Shield Battery
-		- Robotics Facility
-		- Mutalisk
-		- Carrier
-		- Hydralisk
-		- Shuttle
-		- Scourge
-		- Observer
-		- Greater Spire
-		- Devourer
-		- Scout
-		- Drone
-		- Machine Shop
-		- Lair
-		- Refinery
-		- Dark Templar
-		- SCV
-		- Nydus Canal
-		- Queens Nest
-		- Dropship
-		- Hatchery
-		- Ultralisk Cavern
-		- Assimilator
-		- Science Vessel
-		- Dragoon
-		- Photon Cannon
-		- Lurker
-		- Defiler
-		- Pylon
-		- Control Tower
-		- Zergling
-		- Citadel of Adun
-		- Command Center
-	`
-
-	starcraftKnowledge = `
-"StarCraft: Remastered" is a real-time strategy game where players choose a race (Terran, Protoss or Zerg), build economies, form armies, sometimes ally other players, and battle for map control until one side destroys all opponent buildings to win.
-
-Game Mechanics
-
-- Economy: workers mine → resources → spend on units/buildings
-- Tech tree: unlocks progressively with buildings
-- Army control: composition, micro, positioning
-- Fog of war: vision-limited
-- Win condition: destroy all opponent buildings
-- Maximum supply count: 200. Workers cost 1. Heavier units cost 2, 4, etc.
-
-Units: combat, workers, spellcasters, transports, detectors
-Resources: minerals, vespene gas, supply (food cap)
-Buildings: tech tree enablers, production, economy, defense
-Worker units: Drone (Zerg), Probe (Protoss), SCV (Terran)
-Main building: Nexus (Protoss), Command Center (Terran), Hatchery/Lair/Hive (Zerg). Resources are gathered to these buildings.
-
-Replay Essentials
-
-- Timeline of actions (build orders, expansions, engagements)
-- APM (actions per minute), supply, resources, spending efficiency
-- Army composition over time
-- Map size is in tiles (128x128, 96x256) but (x, y) is in pixels. 1 tile = 32 pixels.
-- Map control, scouting, expansions
-
-Macro vs Micro
-
-- These commands are macro: Build, Train, BuildInterceptorOrScarab, UnitMorph, Tech, Upgrade
-- These commands are micro: RightClick, TargetedOrder, Hotkey, UnloadAll, HoldPosition, Burrow, Unburrow, Siege, Unsiege, Cloack, Decloack
-
-Report Metrics
-
-- If you're asked to report on players, stick to "players.type = 'Human'" (skip Computer)
-- 'players.is_winner' is not too accurate. Players may leave game after winning, replays may be incomplete.
-- Resource collection & spending efficiency
-- Player performance stats (APM, using hotkeys, macro vs micro balance, time to first building, time to first combat unit, time to expansion)
-- Better players: have higher APMs, use hotkeys, > micro actions, if they have more workers they make more units/buildings.
-- Build order timings (e.g. “2 Hatch Muta,” “1 Gate Expand”)
-
-Meta terms
-
-- "rush": when a player attacks another (e.g. RightClick, TargetedOrder w/ order_name Attack*) within a few minutes of game start
-- "timing push": deliberate attack launched at a specific moment when a build order hits a temporary power spike (e.g. first tanks with siege, zealots become fast, mutalisks get +1 attack).
-- "tech switch": Rapidly shifting production to a different unit tech path to exploit an opponent’s weak counters (e.g. mutalisks → lurkers, marine+medic → tank+goliath).
-- "natural": The first "expansion" (main building) to gather more resources, which is in close proximity to the main starting location.
-- "expa/expansion": Another expansion which is not necessarily the "natural".
-- Main building starting locations are usually conveyed in o'clock positions (like 3, 6, 9, 12).
-
-	`
-	systemPromptTemplate = `You help to create Starcraft: Remastered dashboards. The prompts ask to create dashboard widgets. Each widget is a UI component fed from one SQL query.
-
-You must choose ONE of the following widget types and provide the appropriate configuration:
-1. gauge - Shows a single numeric value (e.g., total games, average APM)
-2. table - Shows data in rows and columns
-3. pie_chart - Shows proportions as pie slices (label, value columns)
-4. bar_chart - Shows values as bars (label, value columns, optionally horizontal)
-5. line_chart - Shows one or more series over time (x column, y columns, optional x-axis type like "seconds_from_game_start")
-6. scatter_plot - Shows points on X/Y axes (x column, y column, optional size/color columns)
-7. histogram - Shows distribution of values (value column, optional bins count)
-8. heatmap - Shows 2D data as colored cells (x column, y column, value column)
-
-The responses must be structured JSON which return:
-- widget title
-- widget description
-- widget PostgreSQL query
-- widget config (object with type and type-specific fields)
-
-IMPORTANT CONFIGURATION RULES:
-- For gauge: Set "type": "gauge", "gauge_value_column" to the column name with the value, optionally "gauge_min"/"gauge_max"/"gauge_label"
-- For table: Set "type": "table", optionally "table_columns" array (empty = all columns)
-- For pie_chart: Set "type": "pie_chart", "pie_label_column" and "pie_value_column"
-- For bar_chart: Set "type": "bar_chart", "bar_label_column" and "bar_value_column", optionally "bar_horizontal": true
-- For line_chart: Set "type": "line_chart", "line_x_column", "line_y_columns" (array), optionally "line_y_axis_from_zero": true, "line_x_axis_type": "seconds_from_game_start"|"timestamp"|"numeric"
-- For scatter_plot: Set "type": "scatter_plot", "scatter_x_column", "scatter_y_column", optionally "scatter_size_column" and "scatter_color_column"
-- For histogram: Set "type": "histogram", "histogram_value_column", optionally "histogram_bins" (number)
-- For heatmap: Set "type": "heatmap", "heatmap_x_column", "heatmap_y_column", "heatmap_value_column"
-- Optionally set "colors" array for custom color palette (default palettes used if not provided)
-
-You must first use the available tools to figure out how to construct the query, and then to run it and make sure that the results make sense. The query must return columns that match the config you specify (e.g., if you set "pie_label_column": "race", the query must return a "race" column).
-`
-)
-
-var (
-	systemPromptTpl, _ = template.New("").Parse(systemPromptTemplate)
-	responseFormat     = &openai.ResponseFormat{
-		Type: "json_schema",
-		JSONSchema: &openai.ResponseFormatJSONSchema{
-			Name:   "widget_schema",
-			Strict: false,
-			Schema: &openai.ResponseFormatJSONSchemaProperty{
-				Type: "object",
-				Properties: map[string]*openai.ResponseFormatJSONSchemaProperty{
-					"title": {
-						Type:        "string",
-						Description: "Widget's title",
-					},
-					"description": {
-						Type:        "string",
-						Description: "Succinct description of the widget's content",
-					},
-					"sql_query": {
-						Type:        "string",
-						Description: "A valid PostgreSQL query that returns the rows that feed into the widget",
-					},
-					"config": {
-						Type:        "object",
-						Description: "Widget configuration specifying type and type-specific fields",
-						Properties: map[string]*openai.ResponseFormatJSONSchemaProperty{
-							"type": {
-								Type:        "string",
-								Description: "Widget type: gauge, table, pie_chart, bar_chart, line_chart, scatter_plot, histogram, or heatmap",
-								Enum:        []any{"gauge", "table", "pie_chart", "bar_chart", "line_chart", "scatter_plot", "histogram", "heatmap"},
-							},
-							"colors": {
-								Type:        "array",
-								Description: "Optional color palette array",
-								Items: &openai.ResponseFormatJSONSchemaProperty{
-									Type: "string",
-								},
-							},
-							"gauge_value_column": {Type: "string", Description: "For gauge: column name for the value"},
-							"gauge_min":          {Type: "number", Description: "For gauge: optional minimum value"},
-							"gauge_max":          {Type: "number", Description: "For gauge: optional maximum value"},
-							"gauge_label":        {Type: "string", Description: "For gauge: optional label"},
-							"table_columns": {
-								Type:        "array",
-								Description: "For table: optional column names to display (empty = all)",
-								Items: &openai.ResponseFormatJSONSchemaProperty{
-									Type: "string",
-								},
-							},
-							"pie_label_column": {Type: "string", Description: "For pie_chart: column name for slice labels"},
-							"pie_value_column": {Type: "string", Description: "For pie_chart: column name for slice values"},
-							"bar_label_column": {Type: "string", Description: "For bar_chart: column name for bar labels"},
-							"bar_value_column": {Type: "string", Description: "For bar_chart: column name for bar values"},
-							"bar_horizontal":   {Type: "boolean", Description: "For bar_chart: horizontal bars (default: false)"},
-							"line_x_column": {
-								Type:        "string",
-								Description: "For line_chart: column name for X axis",
-							},
-							"line_y_columns": {
-								Type:        "array",
-								Description: "For line_chart: column names for Y axis (multiple series)",
-								Items: &openai.ResponseFormatJSONSchemaProperty{
-									Type: "string",
-								},
-							},
-							"line_y_axis_from_zero": {
-								Type:        "boolean",
-								Description: "For line_chart: start Y axis from zero (default: false)",
-							},
-							"line_x_axis_type": {
-								Type:        "string",
-								Description: "For line_chart: x-axis type: seconds_from_game_start, timestamp, or numeric",
-							},
-							"scatter_x_column":       {Type: "string", Description: "For scatter_plot: column name for X axis"},
-							"scatter_y_column":       {Type: "string", Description: "For scatter_plot: column name for Y axis"},
-							"scatter_size_column":    {Type: "string", Description: "For scatter_plot: optional column for point size"},
-							"scatter_color_column":   {Type: "string", Description: "For scatter_plot: optional column for point color"},
-							"histogram_value_column": {Type: "string", Description: "For histogram: column name for values to bin"},
-							"histogram_bins":         {Type: "number", Description: "For histogram: optional number of bins"},
-							"heatmap_x_column":       {Type: "string", Description: "For heatmap: column name for X axis categories"},
-							"heatmap_y_column":       {Type: "string", Description: "For heatmap: column name for Y axis categories"},
-							"heatmap_value_column":   {Type: "string", Description: "For heatmap: column name for cell values"},
-						},
-						Required: []string{"type"},
-					},
-				},
-				Required: []string{"title", "description", "sql_query", "config"},
-			},
-		},
-	}
-)

--- a/internal/dashboard/ai_consts.go
+++ b/internal/dashboard/ai_consts.go
@@ -1,0 +1,191 @@
+package dashboard
+
+const (
+	schemaObservations = `
+	- Replays have up to 8 players (and up to 4 observers) and a sequential list of commands/actions (like Chess). Command timing is tracked in "frames" since game start and also with a timestamp.
+	- The commands table has action-type-specific fields, so for a given row many fields are null.
+
+	- JOIN patterns:
+		- players.replay_id = replays.id
+		- commands.replay_id = replays.id
+		- commands.player_id = players.id
+
+	- Common WHERE clauses:
+		- players.type = 'Human' (i.e. skip 'Computer' players)
+		- players.is_observer = false (i.e. Observer players are not part of the game)
+
+	action_types:
+		- Build
+		- Land
+		- RightClick
+		- TargetedOrder
+		- Train
+		- BuildInterceptorOrScarab
+		- MinimapPing
+		- CancelTrain
+		- UnitMorph
+		- Tech
+		- Upgrade
+		- GameSpeed
+		- Hotkey
+		- Chat
+		- Vision
+		- Alliance
+		- LeaveGame
+		- Stop
+		- CarrierStop
+		- ReaverStop
+		- ReturnCargo
+		- UnloadAll
+		- HoldPosition
+		- Burrow
+		- Unburrow
+		- Siege
+		- Unsiege
+		- Cloack
+		- Decloack
+		- Cheat
+
+	unit_types:
+
+		- Supply Depot
+		- Forge
+		- Hydralisk Den
+		- Siege Tank (Tank Mode)
+		- Barracks
+		- Reaver
+		- Engineering Bay
+		- ComSat
+		- Valkyrie
+		- Corsair
+		- Creep Colony
+		- Extractor
+		- Covert Ops
+		- Gateway
+		- Ultralisk
+		- Academy
+		- Nuclear Missile
+		- Defiler Mound
+		- Guardian
+		- Spore Colony
+		- Templar Archives
+		- Arbiter
+		- Hive
+		- Firebat
+		- Zealot
+		- Arbiter Tribunal
+		- Cybernetics Core
+		- Wraith
+		- Overlord
+		- Evolution Chamber
+		- Stargate
+		- Physics Lab
+		- Spawning Pool
+		- Science Facility
+		- Fleet Beacon
+		- Goliath
+		- Probe
+		- Missile Turret
+		- Sunken Colony
+		- Robotics Support Bay
+		- Vulture
+		- Nuclear Silo
+		- Medic
+		- Observatory
+		- Queen
+		- High Templar
+		- Starport
+		- Ghost
+		- Spire
+		- Armory
+		- Factory
+		- Nexus
+		- Marine
+		- Bunker
+		- Battlecruiser
+		- Shield Battery
+		- Robotics Facility
+		- Mutalisk
+		- Carrier
+		- Hydralisk
+		- Shuttle
+		- Scourge
+		- Observer
+		- Greater Spire
+		- Devourer
+		- Scout
+		- Drone
+		- Machine Shop
+		- Lair
+		- Refinery
+		- Dark Templar
+		- SCV
+		- Nydus Canal
+		- Queens Nest
+		- Dropship
+		- Hatchery
+		- Ultralisk Cavern
+		- Assimilator
+		- Science Vessel
+		- Dragoon
+		- Photon Cannon
+		- Lurker
+		- Defiler
+		- Pylon
+		- Control Tower
+		- Zergling
+		- Citadel of Adun
+		- Command Center
+	`
+
+	starcraftKnowledge = `
+"StarCraft: Remastered" is a real-time strategy game where players choose a race (Terran, Protoss or Zerg), build economies, form armies, sometimes ally other players, and battle for map control until one side destroys all opponent buildings to win.
+
+Game Mechanics
+
+- Economy: workers mine → resources → spend on units/buildings
+- Tech tree: unlocks progressively with buildings
+- Army control: composition, micro, positioning
+- Fog of war: vision-limited
+- Win condition: destroy all opponent buildings
+- Maximum supply count: 200. Workers cost 1. Heavier units cost 2, 4, etc.
+
+Units: combat, workers, spellcasters, transports, detectors
+Resources: minerals, vespene gas, supply (food cap)
+Buildings: tech tree enablers, production, economy, defense
+Worker units: Drone (Zerg), Probe (Protoss), SCV (Terran)
+Main building: Nexus (Protoss), Command Center (Terran), Hatchery/Lair/Hive (Zerg). Resources are gathered to these buildings.
+
+Replay Essentials
+
+- Timeline of actions (build orders, expansions, engagements)
+- APM (actions per minute), supply, resources, spending efficiency
+- Army composition over time
+- Map size is in tiles (128x128, 96x256) but (x, y) is in pixels. 1 tile = 32 pixels.
+- Map control, scouting, expansions
+
+Macro vs Micro
+
+- These commands are macro: Build, Train, BuildInterceptorOrScarab, UnitMorph, Tech, Upgrade
+- These commands are micro: RightClick, TargetedOrder, Hotkey, UnloadAll, HoldPosition, Burrow, Unburrow, Siege, Unsiege, Cloack, Decloack
+
+Report Metrics
+
+- If you're asked to report on players, stick to "players.type = 'Human'" (skip Computer)
+- 'players.is_winner' is not too accurate. Players may leave game after winning, replays may be incomplete.
+- Resource collection & spending efficiency
+- Player performance stats (APM, using hotkeys, macro vs micro balance, time to first building, time to first combat unit, time to expansion)
+- Better players: have higher APMs, use hotkeys, > micro actions, if they have more workers they make more units/buildings.
+- Build order timings (e.g. “2 Hatch Muta,” “1 Gate Expand”)
+
+Meta terms
+
+- "rush": when a player attacks another (e.g. RightClick, TargetedOrder w/ order_name Attack*) within a few minutes of game start
+- "timing push": deliberate attack launched at a specific moment when a build order hits a temporary power spike (e.g. first tanks with siege, zealots become fast, mutalisks get +1 attack).
+- "tech switch": Rapidly shifting production to a different unit tech path to exploit an opponent’s weak counters (e.g. mutalisks → lurkers, marine+medic → tank+goliath).
+- "natural": The first "expansion" (main building) to gather more resources, which is in close proximity to the main starting location.
+- "expa/expansion": Another expansion which is not necessarily the "natural".
+- Main building starting locations are usually conveyed in o'clock positions (like 3, 6, 9, 12).
+
+	`
+)

--- a/internal/dashboard/ai_response_format.go
+++ b/internal/dashboard/ai_response_format.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"github.com/tmc/langchaingo/llms/openai"
+)
+
+var (
+	responseFormat = &openai.ResponseFormat{
+		Type: "json_schema",
+		JSONSchema: &openai.ResponseFormatJSONSchema{
+			Name:   "widget_schema",
+			Strict: false,
+			Schema: &openai.ResponseFormatJSONSchemaProperty{
+				Type: "object",
+				Properties: map[string]*openai.ResponseFormatJSONSchemaProperty{
+					"title": {
+						Type:        "string",
+						Description: "Widget's title",
+					},
+					"description": {
+						Type:        "string",
+						Description: "Succinct description of the widget's content",
+					},
+					"sql_query": {
+						Type:        "string",
+						Description: "A valid PostgreSQL query that returns the rows that feed into the widget",
+					},
+					"config": {
+						Type:        "object",
+						Description: "Widget configuration specifying type and type-specific fields",
+						Properties: map[string]*openai.ResponseFormatJSONSchemaProperty{
+							"type": {
+								Type:        "string",
+								Description: "Widget type: gauge, table, pie_chart, bar_chart, line_chart, scatter_plot, histogram, or heatmap",
+								Enum:        []any{"gauge", "table", "pie_chart", "bar_chart", "line_chart", "scatter_plot", "histogram", "heatmap"},
+							},
+							"colors": {
+								Type:        "array",
+								Description: "Optional color palette array",
+								Items: &openai.ResponseFormatJSONSchemaProperty{
+									Type: "string",
+								},
+							},
+							"gauge_value_column": {Type: "string", Description: "For gauge: column name for the value"},
+							"gauge_min":          {Type: "number", Description: "For gauge: optional minimum value"},
+							"gauge_max":          {Type: "number", Description: "For gauge: optional maximum value"},
+							"gauge_label":        {Type: "string", Description: "For gauge: optional label"},
+							"table_columns": {
+								Type:        "array",
+								Description: "For table: optional column names to display (empty = all)",
+								Items: &openai.ResponseFormatJSONSchemaProperty{
+									Type: "string",
+								},
+							},
+							"pie_label_column": {Type: "string", Description: "For pie_chart: column name for slice labels"},
+							"pie_value_column": {Type: "string", Description: "For pie_chart: column name for slice values"},
+							"bar_label_column": {Type: "string", Description: "For bar_chart: column name for bar labels"},
+							"bar_value_column": {Type: "string", Description: "For bar_chart: column name for bar values"},
+							"bar_horizontal":   {Type: "boolean", Description: "For bar_chart: horizontal bars (default: false)"},
+							"line_x_column": {
+								Type:        "string",
+								Description: "For line_chart: column name for X axis",
+							},
+							"line_y_columns": {
+								Type:        "array",
+								Description: "For line_chart: column names for Y axis (multiple series)",
+								Items: &openai.ResponseFormatJSONSchemaProperty{
+									Type: "string",
+								},
+							},
+							"line_y_axis_from_zero": {
+								Type:        "boolean",
+								Description: "For line_chart: start Y axis from zero (default: false)",
+							},
+							"line_x_axis_type": {
+								Type:        "string",
+								Description: "For line_chart: x-axis type: seconds_from_game_start, timestamp, or numeric",
+							},
+							"scatter_x_column":       {Type: "string", Description: "For scatter_plot: column name for X axis"},
+							"scatter_y_column":       {Type: "string", Description: "For scatter_plot: column name for Y axis"},
+							"scatter_size_column":    {Type: "string", Description: "For scatter_plot: optional column for point size"},
+							"scatter_color_column":   {Type: "string", Description: "For scatter_plot: optional column for point color"},
+							"histogram_value_column": {Type: "string", Description: "For histogram: column name for values to bin"},
+							"histogram_bins":         {Type: "number", Description: "For histogram: optional number of bins"},
+							"heatmap_x_column":       {Type: "string", Description: "For heatmap: column name for X axis categories"},
+							"heatmap_y_column":       {Type: "string", Description: "For heatmap: column name for Y axis categories"},
+							"heatmap_value_column":   {Type: "string", Description: "For heatmap: column name for cell values"},
+						},
+						Required: []string{"type"},
+					},
+				},
+				Required: []string{"title", "description", "sql_query", "config"},
+			},
+		},
+	}
+)

--- a/internal/dashboard/ai_tools.go
+++ b/internal/dashboard/ai_tools.go
@@ -1,0 +1,94 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+// availableTools simulates the tools/functions we're making available for
+// the model.
+var availableTools = []llms.Tool{
+	{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "query_database",
+			Description: "Execute SQL queries against the StarCraft replay database. The database contains tables: replays (metadata), players (player info) & commands (game events). Use this tool to analyze replay statistics, player performance, unit usage, and game patterns.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"sql": map[string]any{
+						"type":        "string",
+						"description": "PostgresSQL query to execute against the StarCraft replay database",
+					},
+				},
+				"required": []string{"sql"},
+			},
+		},
+	},
+	{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "get_database_schema",
+			Description: "Detailed information about the StarCraft replay database schema including table structures, relationships obtained by querying the database itself.",
+			Parameters:  map[string]any{},
+		},
+	},
+	{
+		Type: "function",
+		Function: &llms.FunctionDefinition{
+			Name:        "get_starcraft_knowledge",
+			Description: "Summary of StarCraft knowledge useful for knowing how to answer questions and make reports.",
+			Parameters:  map[string]any{},
+		},
+	},
+}
+
+func (a *AI) respondToToolCalls(tcs []llms.ToolCall) []llms.MessageContent {
+	messageHistory := []llms.MessageContent{}
+	for _, tc := range tcs {
+		a.logf("AI called the %v tool\n", tc.FunctionCall.Name)
+		switch tc.FunctionCall.Name {
+		case "query_database":
+			var args struct {
+				SQL string `json:"sql"`
+			}
+			if err := json.Unmarshal([]byte(tc.FunctionCall.Arguments), &args); err != nil {
+				messageHistory = append(messageHistory, buildResponse(tc, fmt.Sprintf("failed to unmarshal arguments: %v", err)))
+				continue
+			}
+			queryResult, err := a.store.Query(a.ctx, args.SQL)
+			if err != nil {
+				messageHistory = append(messageHistory, buildResponse(tc, fmt.Sprintf("error running query: %v", err)))
+			} else {
+				messageHistory = append(messageHistory, buildResponse(tc, formatQueryResults(queryResult)))
+			}
+		case "get_database_schema":
+			schema, err := a.store.GetDatabaseSchema(a.ctx)
+			if err != nil {
+				messageHistory = append(messageHistory, buildResponse(tc, fmt.Sprintf("failed to get database schema: %v", err)))
+				continue
+			}
+			messageHistory = append(messageHistory, buildResponse(tc, fmt.Sprintf("%v\n%v", schema, schemaObservations)))
+		case "get_starcraft_knowledge":
+			messageHistory = append(messageHistory, buildResponse(tc, starcraftKnowledge))
+		default:
+			messageHistory = append(messageHistory, buildResponse(tc, "error: unknown function call"))
+		}
+	}
+	return messageHistory
+}
+
+func buildResponse(tc llms.ToolCall, content string) llms.MessageContent {
+	return llms.MessageContent{
+		Role: llms.ChatMessageTypeTool,
+		Parts: []llms.ContentPart{
+			llms.ToolCallResponse{
+				ToolCallID: tc.ID,
+				Name:       tc.FunctionCall.Name,
+				Content:    content,
+			},
+		},
+	}
+}

--- a/internal/dashboard/dashdb/models.go
+++ b/internal/dashboard/dashdb/models.go
@@ -13,6 +13,7 @@ type Dashboard struct {
 	Name        string           `json:"name"`
 	Description pgtype.Text      `json:"description"`
 	CreatedAt   pgtype.Timestamp `json:"created_at"`
+	UpdatedAt   pgtype.Timestamp `json:"updated_at"`
 }
 
 type DashboardWidget struct {
@@ -25,4 +26,12 @@ type DashboardWidget struct {
 	Query       string           `json:"query"`
 	CreatedAt   pgtype.Timestamp `json:"created_at"`
 	UpdatedAt   pgtype.Timestamp `json:"updated_at"`
+}
+
+type DashboardWidgetPromptHistory struct {
+	ID            int64            `json:"id"`
+	WidgetID      int64            `json:"widget_id"`
+	PromptHistory []byte           `json:"prompt_history"`
+	CreatedAt     pgtype.Timestamp `json:"created_at"`
+	UpdatedAt     pgtype.Timestamp `json:"updated_at"`
 }

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -85,6 +85,9 @@ function App() {
   };
 
   const handleUpdateWidget = async (widgetId, data) => {
+    if (data.prompt) {
+      data = { prompt: data.prompt }
+    }
     try {
       await api.updateWidget(currentDashboardUrl, widgetId, data);
       await loadDashboard(currentDashboardUrl);
@@ -99,10 +102,10 @@ function App() {
 
   const sortedWidgets = dashboard?.widgets
     ? [...dashboard.widgets].sort((a, b) => {
-        const orderA = a.widget_order?.valid ? a.widget_order.int64 : 0;
-        const orderB = b.widget_order?.valid ? b.widget_order.int64 : 0;
-        return orderA - orderB;
-      })
+      const orderA = a.widget_order?.valid ? a.widget_order.int64 : 0;
+      const orderB = b.widget_order?.valid ? b.widget_order.int64 : 0;
+      return orderA - orderB;
+    })
     : [];
 
   if (loading && !dashboard) {
@@ -116,7 +119,7 @@ function App() {
   return (
     <div className="app">
       <div className="stars-background"></div>
-      
+
       <div className="dashboard-container">
         <div className="dashboard-header">
           <div className="dashboard-title">
@@ -150,7 +153,7 @@ function App() {
               </button>
             </div>
           </div>
-          
+
           <form onSubmit={handleCreateWidget} className="prompt-form">
             <input
               type="text"

--- a/internal/dashboard/frontend/src/components/EditWidgetModal.jsx
+++ b/internal/dashboard/frontend/src/components/EditWidgetModal.jsx
@@ -12,6 +12,7 @@ const WIDGET_TYPES = [
 ];
 
 function EditWidgetModal({ widget, onClose, onSave }) {
+  const [prompt, setPrompt] = useState('');
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [query, setQuery] = useState('');
@@ -22,6 +23,7 @@ function EditWidgetModal({ widget, onClose, onSave }) {
 
   useEffect(() => {
     if (widget) {
+      setPrompt(widget.prompt || '');
       setName(widget.name || '');
       setDescription(widget.description?.valid ? widget.description.string || '' : '');
       setQuery(widget.query || '');
@@ -36,6 +38,7 @@ function EditWidgetModal({ widget, onClose, onSave }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     onSave({
+      prompt,
       name,
       description: description || null,
       query,
@@ -119,6 +122,16 @@ function EditWidgetModal({ widget, onClose, onSave }) {
                 type="text"
                 value={config.pie_value_column || ''}
                 onChange={(e) => updateConfig('pie_value_column', e.target.value)}
+                className="form-input"
+                placeholder="column_name"
+              />
+            </div>
+            <div className="form-group">
+              <label>Refine via AI with Prompt</label>
+              <input
+                type="text"
+                value={prompt || ''}
+                onChange={(e) => setPrompt(e.target.value)}
                 className="form-input"
                 placeholder="column_name"
               />
@@ -323,7 +336,7 @@ function EditWidgetModal({ widget, onClose, onSave }) {
           <h2>Edit Widget</h2>
           <button onClick={onClose} className="btn-close">×</button>
         </div>
-        
+
         <form onSubmit={handleSubmit} className="edit-form">
           <div className="form-group">
             <label>Name</label>

--- a/internal/dashboard/history/prompt_history_storage.go
+++ b/internal/dashboard/history/prompt_history_storage.go
@@ -1,0 +1,180 @@
+package history
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"text/template"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/marianogappa/screpdb/internal/dashboard/dashdb"
+	"github.com/tmc/langchaingo/llms"
+)
+
+type PromptHistoryStorage struct {
+	queries   *dashdb.Queries
+	histories map[int64][]llms.MessageContent
+	mutex     sync.Mutex
+	debug     bool
+}
+
+func NewPromptHistoryStorage(queries *dashdb.Queries, debug bool) *PromptHistoryStorage {
+	return &PromptHistoryStorage{
+		queries:   queries,
+		histories: map[int64][]llms.MessageContent{},
+		mutex:     sync.Mutex{},
+		debug:     debug,
+	}
+}
+
+func (s *PromptHistoryStorage) get(ctx context.Context, widgetID int64) ([]llms.MessageContent, error) {
+	history, ok := s.getFromMem(widgetID)
+	if ok {
+		return history, nil
+	}
+	history, ok, err := s.getFromDB(ctx, widgetID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		history, err := generateNewHistory()
+		if err != nil {
+			return nil, fmt.Errorf("error generating new history: %w", err)
+		}
+		err = s.set(ctx, widgetID, history)
+		return history, err
+	}
+	s.setOnMem(widgetID, history)
+	return history, nil
+}
+
+func (s *PromptHistoryStorage) set(ctx context.Context, widgetID int64, history []llms.MessageContent) error {
+	s.setOnMem(widgetID, history)
+	return s.setOnDB(ctx, widgetID, history)
+}
+
+func (s *PromptHistoryStorage) getFromMem(widgetID int64) ([]llms.MessageContent, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	history, ok := s.histories[widgetID]
+	return history, ok
+}
+
+func (s *PromptHistoryStorage) setOnMem(widgetID int64, history []llms.MessageContent) {
+	s.mutex.Lock()
+	s.histories[widgetID] = history
+	s.mutex.Unlock()
+}
+
+func (s *PromptHistoryStorage) addOnMem(widgetID int64, history []llms.MessageContent) {
+	s.mutex.Lock()
+	s.histories[widgetID] = append(s.histories[widgetID], history...)
+	s.mutex.Unlock()
+}
+
+func (s *PromptHistoryStorage) add(ctx context.Context, widgetID int64, history []llms.MessageContent) error {
+	if _, err := s.get(ctx, widgetID); err != nil {
+		return err
+	}
+	s.addOnMem(widgetID, history)
+	allHistory, _ := s.getFromMem(widgetID)
+	s.logf("added %v entries; total is now %v", len(history), len(allHistory))
+	return s.set(ctx, widgetID, allHistory)
+}
+
+func (s *PromptHistoryStorage) setOnDB(ctx context.Context, widgetID int64, history []llms.MessageContent) error {
+	return s.queries.UpsertDashboardWidgetPromptHistory(ctx, dashdb.UpsertDashboardWidgetPromptHistoryParams{WidgetID: widgetID, PromptHistory: historyToBytes(history)})
+}
+
+func (s *PromptHistoryStorage) getFromDB(ctx context.Context, widgetID int64) ([]llms.MessageContent, bool, error) {
+	historyRow, err := s.queries.GetDashboardWidgetPromptHistory(ctx, widgetID)
+	if err == pgx.ErrNoRows {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	history, err := bytesToHistory(historyRow.PromptHistory)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal prompt history bytes: %w", err)
+	}
+	return history, true, nil
+}
+
+func historyToBytes(history []llms.MessageContent) []byte {
+	byts, _ := json.Marshal(history)
+	return byts
+}
+
+func bytesToHistory(byts []byte) ([]llms.MessageContent, error) {
+	history := []llms.MessageContent{}
+	err := json.Unmarshal(byts, &history)
+	return history, err
+}
+
+func generateNewHistory() ([]llms.MessageContent, error) {
+	var sp bytes.Buffer
+	if err := systemPromptTpl.Execute(&sp, struct{}{}); err != nil {
+		return nil, err
+	}
+
+	return []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeSystem, sp.String())}, nil
+}
+
+func (s *PromptHistoryStorage) ForWidgetID(ctx context.Context, widgetID int64) (*PromptHistoryStorageForWidget, error) {
+	phsw := &PromptHistoryStorageForWidget{
+		phs:      s,
+		ctx:      ctx,
+		widgetID: widgetID,
+	}
+	_, err := phsw.phs.get(ctx, widgetID)
+	return phsw, err
+}
+
+func (s *PromptHistoryStorage) logf(message string, args ...any) {
+	if !s.debug {
+		return
+	}
+	log.Printf(message, args...)
+}
+
+const (
+	systemPromptTemplate = `You help to create Starcraft: Remastered dashboards. The prompts ask to create dashboard widgets. Each widget is a UI component fed from one SQL query.
+
+You must choose ONE of the following widget types and provide the appropriate configuration:
+1. gauge - Shows a single numeric value (e.g., total games, average APM)
+2. table - Shows data in rows and columns
+3. pie_chart - Shows proportions as pie slices (label, value columns)
+4. bar_chart - Shows values as bars (label, value columns, optionally horizontal)
+5. line_chart - Shows one or more series over time (x column, y columns, optional x-axis type like "seconds_from_game_start")
+6. scatter_plot - Shows points on X/Y axes (x column, y column, optional size/color columns)
+7. histogram - Shows distribution of values (value column, optional bins count)
+8. heatmap - Shows 2D data as colored cells (x column, y column, value column)
+
+The responses must be structured JSON which return:
+- widget title
+- widget description
+- widget PostgreSQL query
+- widget config (object with type and type-specific fields)
+
+IMPORTANT CONFIGURATION RULES:
+- For gauge: Set "type": "gauge", "gauge_value_column" to the column name with the value, optionally "gauge_min"/"gauge_max"/"gauge_label"
+- For table: Set "type": "table", optionally "table_columns" array (empty = all columns)
+- For pie_chart: Set "type": "pie_chart", "pie_label_column" and "pie_value_column"
+- For bar_chart: Set "type": "bar_chart", "bar_label_column" and "bar_value_column", optionally "bar_horizontal": true
+- For line_chart: Set "type": "line_chart", "line_x_column", "line_y_columns" (array), optionally "line_y_axis_from_zero": true, "line_x_axis_type": "seconds_from_game_start"|"timestamp"|"numeric"
+- For scatter_plot: Set "type": "scatter_plot", "scatter_x_column", "scatter_y_column", optionally "scatter_size_column" and "scatter_color_column"
+- For histogram: Set "type": "histogram", "histogram_value_column", optionally "histogram_bins" (number)
+- For heatmap: Set "type": "heatmap", "heatmap_x_column", "heatmap_y_column", "heatmap_value_column"
+- Optionally set "colors" array for custom color palette (default palettes used if not provided)
+
+You must first use the available tools to figure out how to construct the query, and then to run it and make sure that the results make sense. The query must return columns that match the config you specify (e.g., if you set "pie_label_column": "race", the query must return a "race" column).
+`
+)
+
+var (
+	systemPromptTpl, _ = template.New("").Parse(systemPromptTemplate)
+)

--- a/internal/dashboard/history/prompt_history_storage_for_widget.go
+++ b/internal/dashboard/history/prompt_history_storage_for_widget.go
@@ -1,0 +1,33 @@
+package history
+
+import (
+	"context"
+
+	"github.com/tmc/langchaingo/llms"
+)
+
+type PromptHistoryStorageForWidget struct {
+	phs      *PromptHistoryStorage
+	ctx      context.Context
+	widgetID int64
+}
+
+func (s *PromptHistoryStorageForWidget) Get() ([]llms.MessageContent, error) {
+	return s.phs.get(s.ctx, s.widgetID)
+}
+
+func (s *PromptHistoryStorageForWidget) AddHumanPrompt(prompt string) error {
+	return s.phs.add(s.ctx, s.widgetID, []llms.MessageContent{llms.TextParts(llms.ChatMessageTypeHuman, prompt)})
+}
+
+func (s *PromptHistoryStorageForWidget) AddMessageContents(mcs []llms.MessageContent) error {
+	return s.phs.add(s.ctx, s.widgetID, mcs)
+}
+
+func (s *PromptHistoryStorageForWidget) AddContentChoice(contentChoice *llms.ContentChoice) error {
+	assistantResponse := llms.TextParts(llms.ChatMessageTypeAI, contentChoice.Content)
+	for _, tc := range contentChoice.ToolCalls {
+		assistantResponse.Parts = append(assistantResponse.Parts, tc)
+	}
+	return s.phs.add(s.ctx, s.widgetID, []llms.MessageContent{assistantResponse})
+}

--- a/internal/dashboard/migrations/000001_squash.up.sql
+++ b/internal/dashboard/migrations/000001_squash.up.sql
@@ -5,6 +5,7 @@ CREATE TABLE dashboards (
     name TEXT NOT NULL,
     description TEXT,
     created_at TIMESTAMP DEFAULT current_timestamp,
+    updated_at TIMESTAMP DEFAULT current_timestamp,
     CONSTRAINT url_safe_check CHECK (url ~ '^[a-zA-Z0-9_-]+$')
 );
 
@@ -21,7 +22,17 @@ CREATE TABLE dashboard_widgets (
     FOREIGN KEY (dashboard_id) REFERENCES dashboards(url) ON DELETE CASCADE
 );
 
+CREATE TABLE dashboard_widget_prompt_history (
+    id BIGSERIAL PRIMARY KEY,
+    widget_id BIGINT NOT NULL, 
+    prompt_history JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT current_timestamp,
+    updated_at TIMESTAMP DEFAULT current_timestamp,
+    FOREIGN KEY (widget_id) REFERENCES dashboard_widgets(id) ON DELETE CASCADE
+);
+
 CREATE UNIQUE INDEX idx_dashboard_widgets_dashboard_id_widget_order ON dashboard_widgets (dashboard_id, widget_order);
+CREATE UNIQUE INDEX idx_dashboard_widget_prompt_history_widget_id ON dashboard_widget_prompt_history (widget_id);
 CREATE INDEX idx_dashboard_widgets_dashboard_id ON dashboard_widgets (dashboard_id);
 
 INSERT INTO dashboards (url, name, description) VALUES ('default', 'Default Dashboard', 'The default dashboard');

--- a/internal/dashboard/sqlc/queries.sql
+++ b/internal/dashboard/sqlc/queries.sql
@@ -20,6 +20,10 @@ WHERE url = $1;
 SELECT * FROM dashboard_widgets
 WHERE id = $1;
 
+-- name: GetDashboardWidgetPromptHistory :one
+SELECT * FROM dashboard_widget_prompt_history
+WHERE id = $1;
+
 -- name: GetDashboardWidgetNextWidgetOrder :one
 SELECT COALESCE(MAX(widget_order), 0)+1 next_widget_order FROM dashboard_widgets
 WHERE dashboard_id = $1;
@@ -59,3 +63,8 @@ WHERE id = $1;
 -- name: DeleteDashboardWidgetsOfDashboard :exec
 DELETE FROM dashboard_widgets
 WHERE dashboard_id = $1;
+
+-- name: UpsertDashboardWidgetPromptHistory :exec
+INSERT INTO dashboard_widget_prompt_history (widget_id, prompt_history, updated_at)
+VALUES ($1, $2, NOW())
+ON CONFLICT (widget_id) DO UPDATE SET prompt_history = $2, updated_at = NOW();

--- a/internal/dashboard/utils.go
+++ b/internal/dashboard/utils.go
@@ -1,0 +1,59 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// formatQueryResults formats query results for display
+func formatQueryResults(results []map[string]any) string {
+	if len(results) == 0 {
+		return "No results found."
+	}
+
+	// Get column names from first row
+	var columns []string
+	for col := range results[0] {
+		columns = append(columns, col)
+	}
+
+	// Create table format
+	var output strings.Builder
+	output.WriteString("Query Results:\n\n")
+
+	// Header
+	for i, col := range columns {
+		if i > 0 {
+			output.WriteString(" | ")
+		}
+		output.WriteString(col)
+	}
+	output.WriteString("\n")
+
+	// Separator
+	for i, col := range columns {
+		if i > 0 {
+			output.WriteString(" | ")
+		}
+		for j := 0; j < len(col); j++ {
+			output.WriteString("-")
+		}
+	}
+	output.WriteString("\n")
+
+	// Data rows
+	for _, row := range results {
+		for i, col := range columns {
+			if i > 0 {
+				output.WriteString(" | ")
+			}
+			value := fmt.Sprintf("%v", row[col])
+			output.WriteString(value)
+		}
+		output.WriteString("\n")
+	}
+
+	output.WriteString(fmt.Sprintf("\nTotal rows: %d", len(results)))
+
+	return output.String()
+}


### PR DESCRIPTION
fixes https://github.com/marianogappa/screpdb/issues/21

This PR enables:
- Saving of prompt history for each widget. It is now saved in Postgres rather than in memory.
- Endpoints are updated to allow client to refine a dashboard widget via a prompt.
- An initial modification of the FE allows Pie charts to be refined via re-prompting.

A decision was made not to limit the number of refinements for now. This limitation will exist anyway as the number of tokens sent per request will hit the rate limits and error that way, or exceed the context window and error that way.

Further work:
- Better UI for re-prompting.
- Allowing any chart type to be refined, not just Pie charts.
- It seems like losing the previous configuration forever is problematic. Although annoying, checkpoint history should probably be saved.