### PR TITLE
Implement default replay directory strategy.

### DIFF
--- a/cmd/ingest.go
+++ b/cmd/ingest.go
@@ -39,7 +39,7 @@ var (
 
 func init() {
 	ingestCmd.Flags().StringVarP(&inputDir, "input-dir", "i", fileops.GetDefaultReplayDir(), "Input directory containing replay files")
-	ingestCmd.Flags().StringVarP(&postgresConnString, "postgres-connection-string", "p", "", "PostgreSQL connection string (e.g., 'host=localhost port=5432 user=marianol dbname=screpdb sslmode=disable')")
+	ingestCmd.Flags().StringVarP(&postgresConnString, "postgres-connection-string", "p", "", "PostgreSQL connection string (e.g., 'host=localhost port=5432 user=postgres dbname=screpdb sslmode=disable')")
 	ingestCmd.Flags().BoolVarP(&watch, "watch", "w", false, "Watch for new files and ingest them as they appear")
 	ingestCmd.Flags().IntVarP(&stopAfterN, "stop-after-n-reps", "n", 0, "Stop after processing N replay files (0 = no limit)")
 	ingestCmd.Flags().StringVarP(&upToDate, "up-to-yyyy-mm-dd", "d", "", "Only process files up to this date (YYYY-MM-DD format)")

--- a/internal/fileops/default_replay_dir.go
+++ b/internal/fileops/default_replay_dir.go
@@ -1,0 +1,68 @@
+package fileops
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"runtime"
+)
+
+// GetDefaultReplayDir returns the default replay directory
+func GetDefaultReplayDir() string {
+	for _, strategy := range findReplayDirStrategies {
+		dir, ok, err := strategy()
+		if !ok || err != nil {
+			continue
+		}
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		return dir
+	}
+	return ""
+}
+
+type findReplayDirStrategy func() (string, bool, error)
+
+var (
+	findReplayDirStrategies = []findReplayDirStrategy{
+		strategyMacUser(),
+		strategyWindowsUser(),
+		strategyWindowsUserOld(),
+	}
+)
+
+func strategyMacUser() func() (string, bool, error) {
+	return func() (string, bool, error) {
+		if runtime.GOOS == "windows" {
+			return "", false, nil
+		}
+		user, err := user.Current()
+		if err != nil {
+			return "", false, err
+		}
+		return fmt.Sprintf("%s/Library/Application Support/Blizzard/StarCraft/Maps/Replays/AutoSave", user.HomeDir), true, nil
+	}
+}
+
+func strategyWindowsUser() func() (string, bool, error) {
+	return func() (string, bool, error) {
+		if runtime.GOOS != "windows" {
+			return "", false, nil
+		}
+		user, err := user.Current()
+		if err != nil {
+			return "", false, err
+		}
+		return fmt.Sprintf(`%s\Documents\Starcraft\Maps\Replays`, user.HomeDir), true, nil
+	}
+}
+
+func strategyWindowsUserOld() func() (string, bool, error) {
+	return func() (string, bool, error) {
+		if runtime.GOOS != "windows" {
+			return "", false, nil
+		}
+		return `C:\Program Files (x86)\StarCraft\Maps\Replays`, true, nil
+	}
+}

--- a/internal/fileops/files.go
+++ b/internal/fileops/files.go
@@ -106,8 +106,3 @@ func calculateChecksum(filePath string) (string, error) {
 
 	return fmt.Sprintf("%x", hash.Sum(nil)), nil
 }
-
-// GetDefaultReplayDir returns the default replay directory
-func GetDefaultReplayDir() string {
-	return "/Users/marianol/Library/Application Support/Blizzard/StarCraft/Maps/Replays/AutoSave"
-}


### PR DESCRIPTION
fixes https://github.com/marianogappa/screpdb/issues/32.

Implements different strategies to calculate the default replays folder:
- Uses `user.Current` to get the current user's homedir path.
- Tries the typical Windows replay path location.
- Tries the typical MacOS replay path location.
- Tries a hardcoded old Windows replay location.

Works on Mac, Windows TBD:
<img width="1253" height="298" alt="Screenshot 2026-01-17 at 20 02 35" src="https://github.com/user-attachments/assets/7e9d20a1-150e-419c-ab7a-2e87e46e0577" />


