### PR TITLE
feat: Implement dashboard replay filtering.

### DIFF
--- a/internal/dashboard/endpoint_create_dashboard.go
+++ b/internal/dashboard/endpoint_create_dashboard.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -14,41 +15,61 @@ func (d *Dashboard) handlerCreateDashboard(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	type CreateDashboardRequest struct {
-		URL         string  `json:"url"`
-		Name        string  `json:"name"`
-		Description *string `json:"description"`
+		URL              string  `json:"url"`
+		Name             string  `json:"name"`
+		Description      *string `json:"description"`
+		ReplaysFilterSQL *string `json:"replays_filter_sql"`
 	}
 	var req CreateDashboardRequest
 	if err := json.Unmarshal(bs, &req); err != nil {
+		log.Printf("dashboard create: invalid json err=%v", err)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("invalid json: " + err.Error()))
 		return
 	}
 
 	if req.URL == "" {
+		log.Printf("dashboard create: missing url")
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("url cannot be empty"))
 		return
 	}
 
 	if req.Name == "" {
+		log.Printf("dashboard create: missing name url=%s", req.URL)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("name cannot be empty"))
 		return
 	}
 
-	dash, err := d.createDashboard(d.ctx, req.URL, req.Name, req.Description)
+	var replaysFilterSQL *string
+	if req.ReplaysFilterSQL != nil {
+		normalized, err := d.validateReplayFilterSQL(req.ReplaysFilterSQL)
+		if err != nil {
+			log.Printf("dashboard create: invalid replays_filter_sql url=%s err=%v", req.URL, err)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("invalid replays_filter_sql: " + err.Error()))
+			return
+		}
+		if normalized != "" {
+			replaysFilterSQL = &normalized
+		}
+	}
+
+	dash, err := d.createDashboard(d.ctx, req.URL, req.Name, req.Description, replaysFilterSQL)
 	if err != nil {
+		log.Printf("dashboard create: failed url=%s err=%v", req.URL, err)
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("error creating dashboard: " + err.Error()))
 		return
 	}
 
 	type DashboardResponse struct {
-		URL         string  `json:"url"`
-		Name        string  `json:"name"`
-		Description *string `json:"description"`
-		CreatedAt   *string `json:"created_at"`
+		URL              string  `json:"url"`
+		Name             string  `json:"name"`
+		Description      *string `json:"description"`
+		ReplaysFilterSQL *string `json:"replays_filter_sql"`
+		CreatedAt        *string `json:"created_at"`
 	}
 	var dashDesc *string
 	if dash.Description != nil {
@@ -60,10 +81,11 @@ func (d *Dashboard) handlerCreateDashboard(w http.ResponseWriter, r *http.Reques
 		dashCreatedAt = &ts
 	}
 	response := DashboardResponse{
-		URL:         dash.URL,
-		Name:        dash.Name,
-		Description: dashDesc,
-		CreatedAt:   dashCreatedAt,
+		URL:              dash.URL,
+		Name:             dash.Name,
+		Description:      dashDesc,
+		ReplaysFilterSQL: dash.ReplaysFilterSQL,
+		CreatedAt:        dashCreatedAt,
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/internal/dashboard/endpoint_list_dashboards.go
+++ b/internal/dashboard/endpoint_list_dashboards.go
@@ -14,10 +14,11 @@ func (d *Dashboard) handlerListDashboards(w http.ResponseWriter, _ *http.Request
 	}
 
 	type DashboardResponse struct {
-		URL         string  `json:"url"`
-		Name        string  `json:"name"`
-		Description *string `json:"description"`
-		CreatedAt   *string `json:"created_at"`
+		URL              string  `json:"url"`
+		Name             string  `json:"name"`
+		Description      *string `json:"description"`
+		ReplaysFilterSQL *string `json:"replays_filter_sql"`
+		CreatedAt        *string `json:"created_at"`
 	}
 	response := make([]DashboardResponse, len(dashboards))
 	for i, dash := range dashboards {
@@ -31,10 +32,11 @@ func (d *Dashboard) handlerListDashboards(w http.ResponseWriter, _ *http.Request
 			createdAt = &ts
 		}
 		response[i] = DashboardResponse{
-			URL:         dash.URL,
-			Name:        dash.Name,
-			Description: desc,
-			CreatedAt:   createdAt,
+			URL:              dash.URL,
+			Name:             dash.Name,
+			Description:      desc,
+			ReplaysFilterSQL: dash.ReplaysFilterSQL,
+			CreatedAt:        createdAt,
 		}
 	}
 
@@ -42,4 +44,3 @@ func (d *Dashboard) handlerListDashboards(w http.ResponseWriter, _ *http.Request
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(response)
 }
-

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -454,6 +454,7 @@ function App() {
       {editingWidget && (
         <EditWidgetFullscreen
           widget={editingWidget}
+          dashboardUrl={currentDashboardUrl}
           onClose={() => {
             setEditingWidget(null);
             loadDashboard(currentDashboardUrl);

--- a/internal/dashboard/frontend/src/api.js
+++ b/internal/dashboard/frontend/src/api.js
@@ -36,7 +36,7 @@ export const api = {
 
   updateDashboard: async (url, data) => {
     const response = await fetch(`${API_BASE}/dashboard/${url}`, {
-      method: 'POST',
+      method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     });
@@ -93,13 +93,14 @@ export const api = {
     }
   },
 
-  executeQuery: async (query, variableValues = null) => {
+  executeQuery: async (query, variableValues = null, dashboardUrl = null) => {
     const response = await fetch(`${API_BASE}/query`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query,
-        variable_values: variableValues || {}
+        variable_values: variableValues || {},
+        dashboard_url: dashboardUrl || '',
       }),
     });
     if (!response.ok) {
@@ -109,11 +110,11 @@ export const api = {
     return response.json();
   },
 
-  getQueryVariables: async (query) => {
+  getQueryVariables: async (query, dashboardUrl = null) => {
     const response = await fetch(`${API_BASE}/query/variables`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify({ query, dashboard_url: dashboardUrl || '' }),
     });
     if (!response.ok) {
       const text = await response.text();

--- a/internal/dashboard/frontend/src/components/DashboardManager.jsx
+++ b/internal/dashboard/frontend/src/components/DashboardManager.jsx
@@ -1,10 +1,16 @@
 import React, { useState } from 'react';
 import { api } from '../api';
+import ReplayFilterEditor, { BUILTIN_FILTERS } from './ReplayFilterEditor';
 
 function DashboardManager({ dashboards, currentUrl, onClose, onRefresh, onSwitch }) {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingUrl, setEditingUrl] = useState(null);
-  const [formData, setFormData] = useState({ name: '', url: '', description: '' });
+  const [formData, setFormData] = useState({
+    name: '',
+    url: '',
+    description: '',
+    replaysFilterSQL: BUILTIN_FILTERS[0].sql,
+  });
   const [error, setError] = useState(null);
 
   const handleCreate = async (e) => {
@@ -15,9 +21,10 @@ function DashboardManager({ dashboards, currentUrl, onClose, onRefresh, onSwitch
         name: formData.name,
         url: formData.url,
         description: formData.description || null,
+        replays_filter_sql: formData.replaysFilterSQL,
       });
       setShowCreateForm(false);
-      setFormData({ name: '', url: '', description: '' });
+      setFormData({ name: '', url: '', description: '', replaysFilterSQL: BUILTIN_FILTERS[0].sql });
       onRefresh();
     } catch (err) {
       setError(err.message);
@@ -60,12 +67,13 @@ function DashboardManager({ dashboards, currentUrl, onClose, onRefresh, onSwitch
       name: dashboard.name,
       url: dashboard.url,
       description: dashboard.description?.valid ? dashboard.description.string : '',
+      replaysFilterSQL: dashboard.replays_filter_sql || '',
     });
   };
 
   const cancelEdit = () => {
     setEditingUrl(null);
-    setFormData({ name: '', url: '', description: '' });
+    setFormData({ name: '', url: '', description: '', replaysFilterSQL: BUILTIN_FILTERS[0].sql });
   };
 
   const saveEdit = async (e) => {
@@ -175,13 +183,18 @@ function DashboardManager({ dashboards, currentUrl, onClose, onRefresh, onSwitch
                 className="form-input"
               />
             </div>
+
+            <ReplayFilterEditor
+              value={formData.replaysFilterSQL}
+              onChange={(value) => setFormData({ ...formData, replaysFilterSQL: value })}
+            />
             <div className="form-actions">
               <button type="submit" className="btn-save">Create</button>
               <button
                 type="button"
                 onClick={() => {
                   setShowCreateForm(false);
-                  setFormData({ name: '', url: '', description: '' });
+                  setFormData({ name: '', url: '', description: '', replaysFilterSQL: BUILTIN_FILTERS[0].sql });
                 }}
                 className="btn-cancel"
               >
@@ -203,4 +216,3 @@ function DashboardManager({ dashboards, currentUrl, onClose, onRefresh, onSwitch
 }
 
 export default DashboardManager;
-

--- a/internal/dashboard/frontend/src/components/EditDashboardModal.jsx
+++ b/internal/dashboard/frontend/src/components/EditDashboardModal.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
+import ReplayFilterEditor from './ReplayFilterEditor';
 
 function EditDashboardModal({ dashboard, onClose, onSave }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [replaysFilterSQL, setReplaysFilterSQL] = useState('');
 
   useEffect(() => {
     if (dashboard) {
       setName(dashboard.name || '');
       setDescription(dashboard.description?.valid ? dashboard.description.string || '' : '');
+      setReplaysFilterSQL(dashboard.replays_filter_sql || '');
     }
   }, [dashboard]);
 
@@ -16,6 +19,7 @@ function EditDashboardModal({ dashboard, onClose, onSave }) {
     onSave({
       name,
       description: description || null,
+      replays_filter_sql: replaysFilterSQL,
     });
   };
 
@@ -49,6 +53,8 @@ function EditDashboardModal({ dashboard, onClose, onSave }) {
             />
           </div>
 
+          <ReplayFilterEditor value={replaysFilterSQL} onChange={setReplaysFilterSQL} />
+
           <div className="form-actions">
             <button type="button" onClick={onClose} className="btn-cancel">
               Cancel
@@ -64,4 +70,3 @@ function EditDashboardModal({ dashboard, onClose, onSave }) {
 }
 
 export default EditDashboardModal;
-

--- a/internal/dashboard/frontend/src/components/EditWidgetFullscreen.jsx
+++ b/internal/dashboard/frontend/src/components/EditWidgetFullscreen.jsx
@@ -21,7 +21,7 @@ const WIDGET_TYPES = [
   { value: 'heatmap', label: 'Heatmap' },
 ];
 
-function EditWidgetFullscreen({ widget, onClose, onSave }) {
+function EditWidgetFullscreen({ widget, onClose, onSave, dashboardUrl }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [query, setQuery] = useState('');
@@ -61,7 +61,7 @@ function EditWidgetFullscreen({ widget, onClose, onSave }) {
       }
 
       try {
-        const response = await api.getQueryVariables(query);
+        const response = await api.getQueryVariables(query, dashboardUrl);
         const vars = response.variables || {};
         setVariables(vars);
         
@@ -83,7 +83,7 @@ function EditWidgetFullscreen({ widget, onClose, onSave }) {
 
     const timeoutId = setTimeout(fetchVariables, 300);
     return () => clearTimeout(timeoutId);
-  }, [query]);
+  }, [query, dashboardUrl]);
 
   const executeQuery = useCallback(async (sqlQuery, varValues = null) => {
     if (!sqlQuery.trim()) {
@@ -96,7 +96,7 @@ function EditWidgetFullscreen({ widget, onClose, onSave }) {
     setIsExecuting(true);
     setPreviewError(null);
     try {
-      const response = await api.executeQuery(sqlQuery, varValues || variableValues);
+      const response = await api.executeQuery(sqlQuery, varValues || variableValues, dashboardUrl);
       setPreviewData(response.results || []);
       setPreviewColumns(response.columns || []);
       setLastExecutedQuery(sqlQuery);
@@ -107,7 +107,7 @@ function EditWidgetFullscreen({ widget, onClose, onSave }) {
     } finally {
       setIsExecuting(false);
     }
-  }, [variableValues]);
+  }, [variableValues, dashboardUrl]);
 
   // Debounced query execution
   useEffect(() => {
@@ -565,4 +565,3 @@ function EditWidgetFullscreen({ widget, onClose, onSave }) {
 }
 
 export default EditWidgetFullscreen;
-

--- a/internal/dashboard/frontend/src/components/ReplayFilterEditor.jsx
+++ b/internal/dashboard/frontend/src/components/ReplayFilterEditor.jsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const BUILTIN_FILTERS = [
+  {
+    id: 'only_1v1_humans',
+    label: 'Only 1v1 with Human players',
+    sql: `SELECT *
+FROM replays r
+WHERE EXISTS (
+  SELECT 1
+  FROM players p
+  WHERE p.replay_id = r.id
+    AND p.type = 'Human'
+  GROUP BY p.replay_id
+  HAVING COUNT(*) = 2
+)`,
+  },
+  {
+    id: 'only_8_humans_melee_hunters',
+    label: 'Only 8 Human players, Melee, map contains "hunters"',
+    sql: `SELECT *
+FROM replays r
+WHERE r.game_type = 'Melee'
+  AND LOWER(r.map_name) LIKE '%hunters%'
+  AND r.id IN (
+    SELECT p.replay_id
+    FROM players p
+    WHERE p.type = 'Human'
+    GROUP BY p.replay_id
+    HAVING COUNT(*) = 8
+  )`,
+  },
+  {
+    id: 'only_longer_than_3_minutes',
+    label: 'Only longer than 3 minutes',
+    sql: `SELECT *
+FROM replays
+WHERE duration_seconds > 180`,
+  },
+];
+
+const FILTER_OPTIONS = [
+  { id: 'none', label: 'No filter (all replays)' },
+  ...BUILTIN_FILTERS.map((filter) => ({ id: filter.id, label: filter.label })),
+  { id: 'custom', label: 'Custom SQL' },
+];
+
+const normalizeSQL = (value) => {
+  if (!value) return '';
+  let trimmed = value.trim();
+  while (trimmed.endsWith(';')) {
+    trimmed = trimmed.slice(0, -1).trim();
+  }
+  return trimmed.replace(/\s+/g, ' ').trim();
+};
+
+const findBuiltinMatch = (value) => {
+  const normalized = normalizeSQL(value);
+  if (!normalized) return null;
+  return BUILTIN_FILTERS.find((filter) => normalizeSQL(filter.sql) === normalized) || null;
+};
+
+function ReplayFilterEditor({ value, onChange }) {
+  const builtinMatch = useMemo(() => findBuiltinMatch(value), [value]);
+  const [mode, setMode] = useState(builtinMatch ? builtinMatch.id : value ? 'custom' : 'none');
+  const [customSQL, setCustomSQL] = useState(value || '');
+
+  useEffect(() => {
+    if (!value || normalizeSQL(value) === '') {
+      setMode('none');
+      setCustomSQL('');
+      return;
+    }
+    const match = findBuiltinMatch(value);
+    if (match) {
+      setMode(match.id);
+      setCustomSQL('');
+      return;
+    }
+    setMode('custom');
+    setCustomSQL(value);
+  }, [value]);
+
+  const handleModeChange = (e) => {
+    const next = e.target.value;
+    setMode(next);
+    if (next === 'none') {
+      onChange('');
+      return;
+    }
+    if (next === 'custom') {
+      onChange(customSQL);
+      return;
+    }
+    const selected = BUILTIN_FILTERS.find((filter) => filter.id === next);
+    if (selected) {
+      onChange(selected.sql);
+    }
+  };
+
+  const handleCustomChange = (e) => {
+    const next = e.target.value;
+    setCustomSQL(next);
+    onChange(next);
+  };
+
+  const computedSQL = mode === 'custom'
+    ? customSQL
+    : (BUILTIN_FILTERS.find((filter) => filter.id === mode)?.sql || '');
+
+  return (
+    <>
+      <div className="form-group">
+        <label>Replay Filter</label>
+        <select className="form-input" value={mode} onChange={handleModeChange}>
+          {FILTER_OPTIONS.map((opt) => (
+            <option key={opt.id} value={opt.id}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        <div className="form-hint">
+          Use a query like <code>SELECT * FROM replays WHERE ...</code> to scope all widgets in this dashboard.
+        </div>
+      </div>
+
+      {mode === 'custom' ? (
+        <div className="form-group">
+          <label>Custom SQL</label>
+          <textarea
+            className="form-textarea"
+            rows={8}
+            value={customSQL}
+            onChange={handleCustomChange}
+            placeholder="SELECT * FROM replays WHERE ..."
+          />
+        </div>
+      ) : mode === 'none' ? null : (
+        <div className="form-group">
+          <label>Computed SQL</label>
+          <textarea className="form-textarea" rows={8} value={computedSQL} readOnly />
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ReplayFilterEditor;
+export { BUILTIN_FILTERS };

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -697,6 +697,18 @@ body {
   margin-top: 20px;
 }
 
+.form-hint {
+  margin-top: 6px;
+  font-size: 12px;
+  color: rgba(224, 224, 224, 0.7);
+}
+
+.form-hint code {
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  color: rgba(224, 224, 224, 0.9);
+}
+
 .btn-save,
 .btn-cancel {
   padding: 10px 20px;

--- a/internal/dashboard/migrate.go
+++ b/internal/dashboard/migrate.go
@@ -1,9 +1,57 @@
 package dashboard
 
 import (
+	"database/sql"
+	"fmt"
+
 	"github.com/marianogappa/screpdb/internal/migrations"
 )
 
 func runMigrations(sqlitePath string) error {
-	return migrations.RunMigrations(sqlitePath)
+	if err := migrations.RunMigrations(sqlitePath); err != nil {
+		return err
+	}
+	return ensureDashboardReplayFilterColumn(sqlitePath)
+}
+
+func ensureDashboardReplayFilterColumn(sqlitePath string) error {
+	db, err := sql.Open("sqlite", sqliteDSN(sqlitePath))
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`PRAGMA table_info(dashboards);`)
+	if err != nil {
+		return fmt.Errorf("failed to query dashboards table info: %w", err)
+	}
+	defer rows.Close()
+
+	var found bool
+	for rows.Next() {
+		var cid int
+		var name string
+		var colType string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &defaultValue, &pk); err != nil {
+			return fmt.Errorf("failed to scan table info: %w", err)
+		}
+		if name == "replays_filter_sql" {
+			found = true
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to read table info: %w", err)
+	}
+	if found {
+		return nil
+	}
+
+	if _, err := db.Exec(`ALTER TABLE dashboards ADD COLUMN replays_filter_sql TEXT;`); err != nil {
+		return fmt.Errorf("failed to add dashboards.replays_filter_sql: %w", err)
+	}
+	return nil
 }

--- a/internal/dashboard/replay_filter.go
+++ b/internal/dashboard/replay_filter.go
@@ -1,0 +1,35 @@
+package dashboard
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func (d *Dashboard) validateReplayFilterSQL(replaysFilterSQL *string) (string, error) {
+	if replaysFilterSQL == nil {
+		return "", nil
+	}
+	normalized := normalizeSQL(*replaysFilterSQL)
+	if normalized == "" {
+		return "", nil
+	}
+	if !isSelectQuery(normalized) {
+		return "", fmt.Errorf("replays_filter_sql must be a SELECT query")
+	}
+	qualified := qualifyReplayFilterSQL(normalized)
+	if hasUnqualifiedReplays(qualified) {
+		return "", fmt.Errorf("replays_filter_sql must reference main.replays when used in a view")
+	}
+	err := d.withFilteredConnection(nil, func(db *sql.DB) error {
+		row := db.QueryRowContext(d.ctx, fmt.Sprintf("SELECT 1 FROM (%s) LIMIT 1", qualified))
+		var tmp int
+		if err := row.Scan(&tmp); err != nil && err != sql.ErrNoRows {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return qualified, nil
+}

--- a/internal/migrations/dashboard/000001_initial.up.sql
+++ b/internal/migrations/dashboard/000001_initial.up.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS dashboards (
 	url TEXT PRIMARY KEY,
 	name TEXT NOT NULL,
 	description TEXT,
+	replays_filter_sql TEXT,
 	created_at TEXT DEFAULT CURRENT_TIMESTAMP,
 	CONSTRAINT url_safe_check CHECK (url <> '' AND url NOT GLOB '*[^A-Za-z0-9_-]*')
 );


### PR DESCRIPTION
fixes https://github.com/marianogappa/screpdb/issues/57

Here's an example dashboard of 50 replays ingested from which only 48 are BGH 2v2v2v2. The dashboard contains a gauge that counts the total replays (i.e. `SELECT COUNT(*) FROM replays`), and it only finds 48 👍 
<img width="662" height="534" alt="Screenshot 2026-02-13 at 18 25 30" src="https://github.com/user-attachments/assets/da108a49-9808-4679-8e4c-3381ecb562d3" />
