### PR TITLE
fix: harden release artifact upload checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,11 @@ jobs:
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          files: |
+            dist/screpdb-windows-amd64.exe
+            dist/screpdb-dashboard-windows-amd64.exe
+            dist/screpdb-linux-amd64
+            dist/screpdb-linux-arm64
+            dist/screpdb-darwin-amd64
+            dist/screpdb-darwin-arm64
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Use an explicit artifact list and fail when any expected binary is missing.\nThis also creates a releasable commit so release-please can cut a patch release.

Made-with: Cursor