### PR TITLE
Refactor player report into tabs with lazy loading

### DIFF
--- a/internal/dashboard/db/sqlc/queries/game_detail.sql
+++ b/internal/dashboard/db/sqlc/queries/game_detail.sql
@@ -79,8 +79,8 @@ SELECT
   CAST(COALESCE(MIN(p.name), '') AS TEXT) AS player_name,
   COUNT(*) AS games_played,
   CAST(COALESCE(SUM(CASE WHEN p.is_winner = 1 THEN 1 ELSE 0 END), 0) AS INTEGER) AS wins,
-  CAST(COALESCE(AVG(p.apm), 0) AS FLOAT) AS avg_apm,
-  CAST(COALESCE(AVG(p.eapm), 0) AS FLOAT) AS avg_eapm
+  CAST(COALESCE(AVG(CASE WHEN p.apm > 0 THEN p.apm END), 0) AS FLOAT) AS avg_apm,
+  CAST(COALESCE(AVG(CASE WHEN p.eapm > 0 THEN p.eapm END), 0) AS FLOAT) AS avg_eapm
 FROM players p
 WHERE lower(trim(p.name)) = ? AND p.is_observer = 0 AND lower(trim(coalesce(p.type, ''))) = 'human';
 

--- a/internal/dashboard/db/sqlcgen/game_detail.sql.go
+++ b/internal/dashboard/db/sqlcgen/game_detail.sql.go
@@ -14,8 +14,8 @@ SELECT
   CAST(COALESCE(MIN(p.name), '') AS TEXT) AS player_name,
   COUNT(*) AS games_played,
   CAST(COALESCE(SUM(CASE WHEN p.is_winner = 1 THEN 1 ELSE 0 END), 0) AS INTEGER) AS wins,
-  CAST(COALESCE(AVG(p.apm), 0) AS FLOAT) AS avg_apm,
-  CAST(COALESCE(AVG(p.eapm), 0) AS FLOAT) AS avg_eapm
+  CAST(COALESCE(AVG(CASE WHEN p.apm > 0 THEN p.apm END), 0) AS FLOAT) AS avg_apm,
+  CAST(COALESCE(AVG(CASE WHEN p.eapm > 0 THEN p.eapm END), 0) AS FLOAT) AS avg_eapm
 FROM players p
 WHERE lower(trim(p.name)) = ? AND p.is_observer = 0 AND lower(trim(coalesce(p.type, ''))) = 'human'
 `

--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -227,6 +227,9 @@ func (d *Dashboard) buildWorkflowPlayerRecentGames(playerKey string) ([]workflow
 		}
 		result = append(result, g)
 	}
+	if err := d.populateWorkflowGameListPlayers(result); err != nil {
+		return nil, fmt.Errorf("failed to populate players for %s: %w", playerName, err)
+	}
 	if err := d.populateWorkflowRecentGamesCurrentPlayer(playerKey, result); err != nil {
 		return nil, fmt.Errorf("failed to populate recent game context for %s: %w", playerName, err)
 	}

--- a/internal/dashboard/endpoint_main_player_insights.go
+++ b/internal/dashboard/endpoint_main_player_insights.go
@@ -201,6 +201,20 @@ func (d *Dashboard) populateAdvancedPlayerOverview(playerKey string, result *wor
 	}
 	result.FingerprintMetrics = []workflowComparativeMetric{}
 
+	raceRows, err := d.dbStore.ListRaceSections(d.ctx, playerKey)
+	if err != nil {
+		return fmt.Errorf("failed to load race breakdown: %w", err)
+	}
+	breakdown := make([]workflowPlayerRaceBreakdown, 0, len(raceRows))
+	for _, row := range raceRows {
+		breakdown = append(breakdown, workflowPlayerRaceBreakdown{
+			Race:      row.Race,
+			GameCount: row.GameCount,
+			Wins:      row.Wins,
+		})
+	}
+	result.RaceBreakdown = breakdown
+
 	return nil
 }
 
@@ -994,7 +1008,7 @@ func (d *Dashboard) buildPlayerChatSummary(playerKey string) (workflowPlayerChat
 	summary.GamesWithChat = int64(len(gamesWithChat))
 	summary.DistinctTerms = int64(len(termCounts))
 	summary.TopTerms = summarizeChatCounts(termCounts, 10)
-	summary.ExampleMessages = summarizeChatExamples(rawMessages, 5)
+	summary.ExampleMessages = summarizeChatExamples(rawMessages, 15)
 
 	return summary, nil
 }

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -44,6 +44,8 @@ import {
   mainRouteHref,
   mainRouteSnapshotEqual,
   MAIN_GAME_TABS,
+  MAIN_PLAYER_TABS,
+  MAIN_PLAYER_SKILL_PROXY_SUBTABS,
 } from './lib/mainRoute';
 import './styles.css';
 
@@ -135,6 +137,17 @@ const isMainGameSkillProxyTab = (tab) => MAIN_GAME_SKILL_PROXY_TABS.includes(tab
 const SKILL_PROXY_CADENCE_INFO_TEXT = 'ℹ️ How smoothly you keep adding army from the mid game on—not just how much, but how evenly you queue it. Formula: units/min ÷ (1 + gap CV).';
 
 const SKILL_PROXY_VIEWPORT_INFO_TEXT = 'ℹ️ How many times a player switches between places on average per minute.';
+
+const SKILL_PROXY_DELAY_INFO_TEXT = 'Average seconds from a production building becoming ready until the first matching unit command. Lower is better.';
+
+// Per-insight short descriptions for the player Skill proxies > Summary cards.
+// APM omitted intentionally (number is self-explanatory in that view).
+const PLAYER_INSIGHT_DESCRIPTION_OVERRIDES = {
+  apm: '',
+  'first-unit-delay': SKILL_PROXY_DELAY_INFO_TEXT,
+  'unit-production-cadence': 'How smoothly you keep adding army from the mid game on—not just how much, but how evenly you queue it. Formula: units/min ÷ (1 + gap CV).',
+  'viewport-switch-rate': 'How many times a player switches between places on average per minute.',
+};
 
 const DROP_ACTOR_EVENT_TYPES = ['drop', 'reaver_drop', 'dt_drop'];
 
@@ -1197,6 +1210,8 @@ function App() {
   const [mainPlayersSortBy, setMainPlayersSortBy] = useState('games');
   const [mainPlayersSortDir, setMainPlayersSortDir] = useState('desc');
   const [mainPlayersTab, setMainPlayersTab] = useState(() => initialMainRoute.playersTab);
+  const [mainPlayerTab, setMainPlayerTab] = useState(() => initialMainRoute.playerTab);
+  const [mainPlayerSubtab, setMainPlayerSubtab] = useState(() => initialMainRoute.playerSubtab || '');
   const [mainPlayersFilterOptions, setMainPlayersFilterOptions] = useState({
     races: [],
     last_played: [],
@@ -1654,7 +1669,7 @@ function App() {
     }
   };
 
-  const openMainPlayer = async (playerKey) => {
+  const openMainPlayer = async (playerKey, options = {}) => {
     const normalizedPlayerKey = String(playerKey || '').trim().toLowerCase();
     try {
       setMainPlayerLoading(true);
@@ -1688,15 +1703,21 @@ function App() {
       setSelectedPlayerKey(normalizedPlayerKey);
       setMainAnswer(null);
       setMainQuestion('');
+      const wantTab = options.initialPlayerTab;
+      const nextTab = wantTab && MAIN_PLAYER_TABS.includes(String(wantTab).trim().toLowerCase())
+        ? String(wantTab).trim().toLowerCase()
+        : 'summary';
+      setMainPlayerTab(nextTab);
+      const wantSubtab = String(options.initialPlayerSubtab || '').trim().toLowerCase();
+      if (nextTab === 'skill-proxies') {
+        setMainPlayerSubtab(MAIN_PLAYER_SKILL_PROXY_SUBTABS.includes(wantSubtab) ? wantSubtab : 'summary');
+      } else if (nextTab === 'summary') {
+        // Race subtab is dynamic; persist if provided, else resolved at render from race_breakdown.
+        setMainPlayerSubtab(wantSubtab);
+      } else {
+        setMainPlayerSubtab('');
+      }
       navigateMainView('player');
-      loadMainPlayerRecentGames(normalizedPlayerKey);
-      loadMainPlayerChatSummary(normalizedPlayerKey);
-      loadMainPlayerMetrics(normalizedPlayerKey);
-      loadMainPlayerOutliers(normalizedPlayerKey);
-      loadMainPlayerApmInsight(normalizedPlayerKey);
-      loadMainPlayerDelayInsight(normalizedPlayerKey);
-      loadMainPlayerCadenceInsight(normalizedPlayerKey);
-      loadMainPlayerViewportInsight(normalizedPlayerKey);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -1964,7 +1985,10 @@ function App() {
     if (initialMainRoute.view === 'game' && initialMainRoute.replayId != null) {
       void openMainGame(initialMainRoute.replayId, { initialGameTab: initialMainRoute.gameTab });
     } else if (initialMainRoute.view === 'player' && initialMainRoute.playerKey) {
-      void openMainPlayer(initialMainRoute.playerKey);
+      void openMainPlayer(initialMainRoute.playerKey, {
+        initialPlayerTab: initialMainRoute.playerTab,
+        initialPlayerSubtab: initialMainRoute.playerSubtab,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time hydration from initial URL.
   }, []);
@@ -1977,6 +2001,8 @@ function App() {
       selectedPlayerKey,
       mainGameTab,
       mainPlayersTab,
+      mainPlayerTab,
+      mainPlayerSubtab,
       currentDashboardUrl,
     });
     if (typeof window !== 'undefined' && mainRouteSnapshotEqual(window.location.search, next && next.length ? `?${next}` : '')) {
@@ -1984,7 +2010,7 @@ function App() {
     }
     if (typeof window === 'undefined') return;
     window.history.pushState({ __spa: 1 }, '', mainRouteHref(next));
-  }, [activeView, selectedReplayId, selectedPlayerKey, mainGameTab, mainPlayersTab, currentDashboardUrl]);
+  }, [activeView, selectedReplayId, selectedPlayerKey, mainGameTab, mainPlayersTab, mainPlayerTab, mainPlayerSubtab, currentDashboardUrl]);
 
   useEffect(() => {
     const onPopState = () => {
@@ -1995,6 +2021,8 @@ function App() {
       setSelectedPlayerKey(r.playerKey || '');
       setMainGameTab(r.gameTab);
       setMainPlayersTab(r.playersTab);
+      setMainPlayerTab(r.playerTab);
+      setMainPlayerSubtab(r.playerSubtab || '');
       setCurrentDashboardUrl(r.view === 'dashboards' && r.dash ? r.dash : 'default');
       const finish = () => {
         suppressUrlSyncRef.current = false;
@@ -2007,7 +2035,10 @@ function App() {
           finish();
         }
       } else if (r.view === 'player' && r.playerKey) {
-        const p = openMainPlayerRef.current?.(r.playerKey);
+        const p = openMainPlayerRef.current?.(r.playerKey, {
+          initialPlayerTab: r.playerTab,
+          initialPlayerSubtab: r.playerSubtab,
+        });
         if (p && typeof p.finally === 'function') {
           p.finally(finish);
         } else {
@@ -2029,6 +2060,61 @@ function App() {
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
+
+  useEffect(() => {
+    if (activeView !== 'player' || !selectedPlayerKey) return;
+    if (mainPlayerTab !== 'summary') return;
+    if (!mainPlayerMetrics && !mainPlayerMetricsLoading && !mainPlayerMetricsError) {
+      loadMainPlayerMetrics(selectedPlayerKey);
+    }
+  }, [activeView, selectedPlayerKey, mainPlayerTab, mainPlayerMetrics, mainPlayerMetricsLoading, mainPlayerMetricsError]);
+
+  useEffect(() => {
+    if (activeView !== 'player' || !selectedPlayerKey) return;
+    if (mainPlayerTab !== 'skill-proxies' || mainPlayerSubtab !== 'summary') return;
+    if (!mainPlayerApmInsight && !mainPlayerApmInsightLoading && !mainPlayerApmInsightError) {
+      loadMainPlayerApmInsight(selectedPlayerKey);
+    }
+    if (!mainPlayerDelayInsight && !mainPlayerDelayInsightLoading && !mainPlayerDelayInsightError) {
+      loadMainPlayerDelayInsight(selectedPlayerKey);
+    }
+    if (!mainPlayerCadenceInsight && !mainPlayerCadenceInsightLoading && !mainPlayerCadenceInsightError) {
+      loadMainPlayerCadenceInsight(selectedPlayerKey);
+    }
+    if (!mainPlayerViewportInsight && !mainPlayerViewportInsightLoading && !mainPlayerViewportInsightError) {
+      loadMainPlayerViewportInsight(selectedPlayerKey);
+    }
+  }, [
+    activeView, selectedPlayerKey, mainPlayerTab, mainPlayerSubtab,
+    mainPlayerApmInsight, mainPlayerApmInsightLoading, mainPlayerApmInsightError,
+    mainPlayerDelayInsight, mainPlayerDelayInsightLoading, mainPlayerDelayInsightError,
+    mainPlayerCadenceInsight, mainPlayerCadenceInsightLoading, mainPlayerCadenceInsightError,
+    mainPlayerViewportInsight, mainPlayerViewportInsightLoading, mainPlayerViewportInsightError,
+  ]);
+
+  useEffect(() => {
+    if (activeView !== 'player' || !selectedPlayerKey) return;
+    if (mainPlayerTab !== 'skill-proxies' || mainPlayerSubtab !== 'usage-signals') return;
+    if (!mainPlayerOutliers && !mainPlayerOutliersLoading && !mainPlayerOutliersError) {
+      loadMainPlayerOutliers(selectedPlayerKey);
+    }
+  }, [activeView, selectedPlayerKey, mainPlayerTab, mainPlayerSubtab, mainPlayerOutliers, mainPlayerOutliersLoading, mainPlayerOutliersError]);
+
+  useEffect(() => {
+    if (activeView !== 'player' || !selectedPlayerKey) return;
+    if (mainPlayerTab !== 'recent-games') return;
+    if (!mainPlayerRecentGames.length && !mainPlayerRecentGamesLoading && !mainPlayerRecentGamesError) {
+      loadMainPlayerRecentGames(selectedPlayerKey);
+    }
+  }, [activeView, selectedPlayerKey, mainPlayerTab, mainPlayerRecentGames, mainPlayerRecentGamesLoading, mainPlayerRecentGamesError]);
+
+  useEffect(() => {
+    if (activeView !== 'player' || !selectedPlayerKey) return;
+    if (mainPlayerTab !== 'chat-summary') return;
+    if (!mainPlayerChatSummary && !mainPlayerChatSummaryLoading && !mainPlayerChatSummaryError) {
+      loadMainPlayerChatSummary(selectedPlayerKey);
+    }
+  }, [activeView, selectedPlayerKey, mainPlayerTab, mainPlayerChatSummary, mainPlayerChatSummaryLoading, mainPlayerChatSummaryError]);
 
   useEffect(() => {
     loadMainGames({ page: mainGamesPage, filters: mainGamesFilters });
@@ -2596,6 +2682,23 @@ function App() {
     return <span style={{ color, fontWeight: 600 }}>{name}</span>;
   };
 
+  const renderPlayerLinkLabel = (name, playerKey) => {
+    const color = playerAccentColor(playerKey || name);
+    const style = color ? { color, fontWeight: 600 } : undefined;
+    if (!playerKey) return <span style={style}>{name}</span>;
+    return (
+      <button
+        type="button"
+        className="workflow-player-name-link"
+        title="Analyze player"
+        style={style}
+        onClick={(e) => { e.stopPropagation(); openMainPlayer(playerKey); }}
+      >
+        {name}
+      </button>
+    );
+  };
+
   const renderPlayersMatchup = (label) => {
     const sides = String(label || '').split(' vs ');
     return sides.map((side, sideIndex) => {
@@ -2636,7 +2739,7 @@ function App() {
             <span key={`${player.player_id}-${idx}`}>
               {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
               {renderWorkerIcon(player.race)}
-              {renderPlayerLabel(player.name, player.player_key)}
+              {renderPlayerLinkLabel(player.name, player.player_key)}
               {idx < players.length - 1 ? ', ' : ''}
             </span>
           ))}
@@ -2658,7 +2761,7 @@ function App() {
                 >
                   {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
                   {renderWorkerIcon(player.race)}
-                  {renderPlayerLabel(player.name, player.player_key)}
+                  {renderPlayerLinkLabel(player.name, player.player_key)}
                 </span>
               ))}
             </span>
@@ -3046,8 +3149,8 @@ function App() {
   }, [selectedMainGameEvent, mainGamePlayers, mainEventMapBounds]);
 
   const mainPlayerInsights = [
-    mainPlayerViewportInsight,
     mainPlayerApmInsight,
+    mainPlayerViewportInsight,
     mainPlayerDelayInsight,
     mainPlayerCadenceInsight,
   ].filter(Boolean);
@@ -4987,8 +5090,30 @@ function App() {
           </div>
         )}
 
-        {activeView === 'player' && (
-          <div className="workflow-panel">
+        {activeView === 'player' && (() => {
+          const raceBreakdownRaw = Array.isArray(mainPlayer?.race_breakdown) ? mainPlayer.race_breakdown : [];
+          const playerRaceTabs = raceBreakdownRaw
+            .filter((r) => r && r.race && (Number(r.game_count) || 0) > 0)
+            .slice()
+            .sort((a, b) => (Number(b.game_count) || 0) - (Number(a.game_count) || 0));
+          const raceTabKeys = playerRaceTabs.map((r) => String(r.race).toLowerCase());
+          const requestedRace = String(mainPlayerSubtab || '').toLowerCase();
+          const effectiveRaceSubtab = raceTabKeys.includes(requestedRace)
+            ? requestedRace
+            : (raceTabKeys[0] || '');
+          const sectionByRace = new Map(
+            (mainPlayerMetrics?.race_behaviour_sections || []).map((s) => [String(s.race).toLowerCase(), s]),
+          );
+          const activeRaceSection = effectiveRaceSubtab ? sectionByRace.get(effectiveRaceSubtab) : null;
+          const activeRaceBreakdown = effectiveRaceSubtab
+            ? playerRaceTabs.find((r) => String(r.race).toLowerCase() === effectiveRaceSubtab)
+            : null;
+          const isSkillProxiesTab = mainPlayerTab === 'skill-proxies';
+          const skillProxySubtab = isSkillProxiesTab
+            ? (MAIN_PLAYER_SKILL_PROXY_SUBTABS.includes(mainPlayerSubtab) ? mainPlayerSubtab : 'summary')
+            : 'summary';
+          return (
+          <div className="workflow-panel workflow-panel--player">
             {mainPlayerLoading ? (
               <div className="loading">Loading player report...</div>
             ) : mainPlayer ? (
@@ -5008,220 +5133,335 @@ function App() {
                   <span><strong>APM</strong> {mainPlayer.average_apm?.toFixed(1)}</span>
                   <span><strong>EAPM</strong> {mainPlayer.average_eapm?.toFixed(1)}</span>
                 </div>
-                <div className="workflow-cards">
-                  <div className="workflow-card workflow-card-race-behaviours">
-                    {mainPlayerMetricsLoading ? <div className="chart-empty">Loading metrics...</div> : null}
-                    {!mainPlayerMetricsLoading && mainPlayerMetricsError ? <div className="chart-empty">{mainPlayerMetricsError}</div> : null}
-                    {!mainPlayerMetricsLoading && !mainPlayerMetricsError && (mainPlayerMetrics?.race_behaviour_sections || []).length === 0 ? (
-                      <div className="chart-empty">No race behaviour sections available.</div>
-                    ) : null}
-                    {!mainPlayerMetricsLoading && !mainPlayerMetricsError && (mainPlayerMetrics?.race_behaviour_sections || []).map((section) => (
-                      <div key={section.race} className="workflow-race-behaviour-section">
-                        <div className="workflow-card-subtitle">
-                          {getRaceIcon(section.race) ? <img src={getRaceIcon(section.race)} alt={section.race} className="unit-icon-inline workflow-race-title-icon" /> : null}
-                          <span>{section.race}</span>
-                        </div>
-                        <div className="workflow-subtle-note">
-                          {`${section.game_count} games (${((Number(section.game_rate) || 0) * 100).toFixed(1)}%), ${section.wins} wins, ${((Number(section.win_rate) || 0) * 100).toFixed(1)}% win rate`}
-                        </div>
-                        {(section.common_behaviours || []).length === 0 ? <div className="chart-empty">No common behaviours at 20%+ for this race.</div> : null}
-                        {(section.common_behaviours || []).map((item, idx) => (
-                          <div key={`${section.race}-${item.name}`} className="workflow-pattern-row">
-                            <span>{renderPatternPill({ pattern_name: item.name, value: 'true' }, `player-common-${section.race}-${idx}`, undefined, markerRegistry)}</span>
-                            <span>{`${((Number(item.game_rate) || 0) * 100).toFixed(1)}% (${item.replay_count}/${section.game_count})`}</span>
-                          </div>
-                        ))}
-                      </div>
-                    ))}
+                <div className="workflow-game-tab-stack">
+                  <div className="workflow-production-tabs workflow-game-main-tabs" role="tablist" aria-label="Player report sections">
+                    <button type="button" role="tab" aria-selected={mainPlayerTab === 'summary'}
+                      className={`workflow-production-tab ${mainPlayerTab === 'summary' ? 'workflow-production-tab-active' : ''}`}
+                      onClick={() => { setMainPlayerTab('summary'); setMainPlayerSubtab(''); }}>
+                      Summary
+                    </button>
+                    <button type="button" role="tab" aria-selected={isSkillProxiesTab}
+                      className={`workflow-production-tab ${isSkillProxiesTab ? 'workflow-production-tab-active' : ''}`}
+                      onClick={() => {
+                        if (isSkillProxiesTab) return;
+                        setMainPlayerTab('skill-proxies');
+                        setMainPlayerSubtab('summary');
+                      }}>
+                      Skill proxies
+                    </button>
+                    <button type="button" role="tab" aria-selected={mainPlayerTab === 'recent-games'}
+                      className={`workflow-production-tab ${mainPlayerTab === 'recent-games' ? 'workflow-production-tab-active' : ''}`}
+                      onClick={() => { setMainPlayerTab('recent-games'); setMainPlayerSubtab(''); }}>
+                      Recent games
+                    </button>
+                    <button type="button" role="tab" aria-selected={mainPlayerTab === 'chat-summary'}
+                      className={`workflow-production-tab ${mainPlayerTab === 'chat-summary' ? 'workflow-production-tab-active' : ''}`}
+                      onClick={() => { setMainPlayerTab('chat-summary'); setMainPlayerSubtab(''); }}>
+                      Chat summary
+                    </button>
                   </div>
-                  <div className="workflow-card workflow-card-fingerprints">
-                    <div className="workflow-card-title"><span>Population comparison</span></div>
-                    {mainPlayerInsightLoading ? <div className="chart-empty">Loading population comparisons...</div> : null}
-                    {!mainPlayerInsightLoading && mainPlayerInsightErrors.length > 0 ? (
-                      <div className="chart-empty">{mainPlayerInsightErrors[0]}</div>
-                    ) : null}
-                    {!mainPlayerInsightLoading && mainPlayerInsightErrors.length === 0 ? (
-                      <div className="workflow-insight-grid">
-                        {mainPlayerInsights.map((insight) => {
-                          const percentile = Number(insight.performance_percentile || 0);
-                          const accent = insightScoreColor(percentile);
+
+                  {mainPlayerTab === 'summary' && playerRaceTabs.length > 0 ? (
+                    <div className="workflow-skill-proxy-subnav">
+                      <div className="workflow-production-tabs workflow-skill-proxy-tabs" role="tablist" aria-label="Race breakdown">
+                        {playerRaceTabs.map((r) => {
+                          const key = String(r.race).toLowerCase();
+                          const active = key === effectiveRaceSubtab;
                           return (
                             <button
                               type="button"
-                              key={insight.insight_type}
-                              className="workflow-insight-card workflow-insight-card-link"
-                              style={insight.eligible ? { borderColor: `${accent}55`, boxShadow: `inset 0 0 0 1px ${accent}22` } : undefined}
-                              onClick={() => openMainPlayersSubview(playerInsightDestinationTab(insight.insight_type))}
+                              role="tab"
+                              key={key}
+                              aria-selected={active}
+                              className={`workflow-production-tab ${active ? 'workflow-production-tab-active' : ''}`}
+                              onClick={() => setMainPlayerSubtab(key)}
                             >
-                              <div className="workflow-insight-card-header">
-                                <span>{insight.title}</span>
-                              </div>
-                              {insight.eligible ? (
-                                <>
-                                  <div className="workflow-insight-score-row">
-                                    <span className="workflow-insight-score" style={{ color: accent }}>{insightSummaryLabel(percentile)}</span>
-                                    <span className="workflow-insight-grade" style={{ backgroundColor: `${accent}22`, color: accent }}>{insightScoreLabel(percentile)}</span>
-                                  </div>
-                                  <div className="workflow-insight-value">{insight.player_value_label}</div>
-                                  <div className="workflow-subtle-note">{`${insight.population_size} eligible players in population.`}</div>
-                                </>
-                              ) : (
-                                <>
-                                  <div className="workflow-insight-unavailable">Not enough data yet</div>
-                                  <div className="workflow-subtle-note">{insight.ineligible_reason || 'This comparison is not available yet.'}</div>
-                                </>
-                              )}
-                              <div className="workflow-insight-footer">
-                                <span className="workflow-insight-link-hint">Open player population view</span>
-                                <span className="workflow-insight-info-icon" aria-hidden="true">ⓘ</span>
-                              </div>
-                              <div className="workflow-insight-details">
-                                <div className="workflow-subtle-note">{insight.description}</div>
-                                <div className="workflow-insight-detail-list">
-                                  {(insight.details || []).map((detail) => (
-                                    <div key={`${insight.insight_type}-${detail.label}`} className="workflow-insight-detail-row">
-                                      <span>{detail.label}</span>
-                                      <span>{detail.value}</span>
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
+                              {getRaceIcon(r.race) ? (
+                                <img src={getRaceIcon(r.race)} alt={r.race} className="unit-icon-inline workflow-race-tab-icon" />
+                              ) : null}
+                              <span>{r.race}</span>
+                              <span className="workflow-subtle-note">{` (${r.game_count})`}</span>
                             </button>
                           );
                         })}
                       </div>
-                    ) : null}
-                    <div className="workflow-card-subtitle"><span>Usage signals</span></div>
-                    {mainPlayerUsagePills.length === 0 ? (
-                      <div className="workflow-subtle-note">No low-usage flags were triggered for hotkeys or queued orders.</div>
-                    ) : (
-                      <div className="workflow-pattern-pills">
-                        {mainPlayerUsagePills.map((pill) => (
-                          <span key={pill.key} className={pill.className} title={pill.title}>{pill.label}</span>
-                        ))}
-                      </div>
-                    )}
-                    <div className="workflow-card-subtitle">
-                      <span>Distinctive outliers</span>
-                      <HelpTooltip text={PLAYER_OUTLIER_HELP} label="Outlier calculation explanation" />
                     </div>
-                    <div className="workflow-subtle-note">Same-race, human-only baselines. Items are shown in one list and prefixed by command family.</div>
-                    {mainPlayerOutliersLoading ? <div className="chart-empty">Loading outliers...</div> : null}
-                    {!mainPlayerOutliersLoading && mainPlayerOutliersError ? <div className="chart-empty">{mainPlayerOutliersError}</div> : null}
-                    {!mainPlayerOutliersLoading && !mainPlayerOutliersError && mainPlayerOutlierItems.length === 0 ? (
-                      <div className="chart-empty">No outliers crossed current thresholds.</div>
-                    ) : null}
-                    {!mainPlayerOutliersLoading && !mainPlayerOutliersError && mainPlayerOutlierItems.map((item) => (
-                      <div key={`${item.category}-${item.race}-${item.name}`} className="workflow-pattern-row">
-                        <span>{`${item.category}: ${item.pretty_name}`}</span>
-                        <span className="workflow-outlier-expl">
-                          <span className="workflow-outlier-rate">{`${((Number(item.player_rate) || 0) * 100).toFixed(0)}%`}</span>
-                          <span>you</span>
-                          <span>vs</span>
-                          <span className="workflow-outlier-rate-muted">{`${((Number(item.baseline_rate) || 0) * 100).toFixed(0)}%`}</span>
-                          <span>baseline</span>
-                          {(item.qualified_by || []).map((qualifier) => (
-                            <span key={`${item.name}-${qualifier}`} className={outlierQualifierClassName(qualifier)}>{qualifier}</span>
-                          ))}
-                        </span>
+                  ) : null}
+
+                  {isSkillProxiesTab ? (
+                    <div className="workflow-skill-proxy-subnav">
+                      <div className="workflow-production-tabs workflow-skill-proxy-tabs" role="tablist" aria-label="Skill proxy subsections">
+                        <button type="button" role="tab" aria-selected={skillProxySubtab === 'summary'}
+                          className={`workflow-production-tab ${skillProxySubtab === 'summary' ? 'workflow-production-tab-active' : ''}`}
+                          onClick={() => setMainPlayerSubtab('summary')}>
+                          Summary
+                        </button>
+                        <button type="button" role="tab" aria-selected={skillProxySubtab === 'usage-signals'}
+                          className={`workflow-production-tab ${skillProxySubtab === 'usage-signals' ? 'workflow-production-tab-active' : ''}`}
+                          onClick={() => setMainPlayerSubtab('usage-signals')}>
+                          Usage signals & distinctive outliers
+                        </button>
                       </div>
-                    ))}
-                  </div>
-                  <div className="workflow-card workflow-card-recent-games">
-                    <div className="workflow-card-title"><span>Recent games</span></div>
-                    {mainPlayerRecentGamesLoading ? <div className="chart-empty">Loading recent games...</div> : null}
-                    {!mainPlayerRecentGamesLoading && mainPlayerRecentGamesError ? <div className="chart-empty">{mainPlayerRecentGamesError}</div> : null}
-                    {!mainPlayerRecentGamesLoading && !mainPlayerRecentGamesError && mainPlayerRecentGames.length === 0 ? (
-                      <div className="chart-empty">No recent games found for this player.</div>
-                    ) : null}
-                    {!mainPlayerRecentGamesLoading && !mainPlayerRecentGamesError && mainPlayerRecentGames.slice(0, 6).map((g) => (
-                      <button key={g.replay_id} className="workflow-recent-game-card" onClick={() => openMainGame(g.replay_id)}>
-                        <div className="workflow-recent-game-header">
-                          <span>{formatRelativeReplayDate(g.replay_date)}</span>
-                          <span>{g.map_name}</span>
-                          {g.current_player?.race ? (
-                            <span className="workflow-recent-game-race">
-                              {getRaceIcon(g.current_player.race) ? (
-                                <img
-                                  src={getRaceIcon(g.current_player.race)}
-                                  alt={g.current_player.race}
-                                  className="unit-icon-inline workflow-recent-game-race-icon"
-                                />
-                              ) : null}
-                              <span>{g.current_player.race}</span>
-                            </span>
-                          ) : (
-                            <span className="workflow-empty-inline">-</span>
-                          )}
-                          <span>{formatDuration(g.duration_seconds)}</span>
-                        </div>
-                        <div className="workflow-subtle-note">{renderPlayersMatchup(g.players_label || '')}</div>
-                        <div className="workflow-recent-game-meta">
-                          {g.current_player?.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
-                        </div>
-                        {filterSummaryPillPatterns(g.current_player?.detected_patterns).length > 0 ? (
-                          <div className="workflow-pattern-pills workflow-pattern-pills-compact">
-                            {filterSummaryPillPatterns(g.current_player?.detected_patterns).map((pattern, idx) => renderPatternPill(pattern, `recent-${g.replay_id}-${idx}`, undefined, markerRegistry))}
-                          </div>
-                        ) : null}
-                      </button>
-                    ))}
-                  </div>
-                  <div className="workflow-card workflow-card-chat-summary">
-                    <div className="workflow-card-title"><span>Chat Summary</span></div>
-                    {mainPlayerChatSummaryLoading ? <div className="chart-empty">Loading chat summary...</div> : null}
-                    {!mainPlayerChatSummaryLoading && mainPlayerChatSummaryError ? <div className="chart-empty">{mainPlayerChatSummaryError}</div> : null}
-                    {!mainPlayerChatSummaryLoading && !mainPlayerChatSummaryError && (Number(mainPlayerChatSummary?.total_messages) || 0) === 0 ? (
-                      <div className="chart-empty">No chat messages found for this player in ingested games.</div>
-                    ) : (
-                      !mainPlayerChatSummaryLoading && !mainPlayerChatSummaryError && mainPlayerChatSummary ? (
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="workflow-cards">
+                  {mainPlayerTab === 'summary' && (
+                    <div className="workflow-card workflow-card-race-behaviours">
+                      {playerRaceTabs.length === 0 ? (
+                        <div className="chart-empty">No race data yet for this player.</div>
+                      ) : (
                         <>
-                          <div className="workflow-subtle-note">
-                            {`${mainPlayerChatSummary?.total_messages || 0} messages across ${mainPlayerChatSummary?.games_with_chat || 0} games, ${mainPlayerChatSummary?.distinct_terms || 0} distinct terms after cleanup.`}
-                          </div>
-                          <div className="workflow-card-subtitle"><span>Top terms</span></div>
-                          {(mainPlayerChatSummary?.top_terms || []).length === 0 ? (
-                            <div className="chart-empty">Not enough messages to infer common terms.</div>
-                          ) : (
-                            <div className="workflow-pattern-pills">
-                              {(mainPlayerChatSummary?.top_terms || []).map((item) => (
-                                <span key={`player-chat-term-${item.term}`} className="workflow-pattern-pill">
-                                  <span>{item.term}</span>
-                                  <span>{`x${item.count}`}</span>
-                                </span>
+                          {mainPlayerMetricsLoading ? <div className="chart-empty">Loading metrics...</div> : null}
+                          {!mainPlayerMetricsLoading && mainPlayerMetricsError ? <div className="chart-empty">{mainPlayerMetricsError}</div> : null}
+                          {!mainPlayerMetricsLoading && !mainPlayerMetricsError && activeRaceSection ? (
+                            <div key={activeRaceSection.race} className="workflow-race-behaviour-section">
+                              <div className="workflow-subtle-note">
+                                {`${activeRaceSection.game_count} games (${((Number(activeRaceSection.game_rate) || 0) * 100).toFixed(1)}%), ${activeRaceSection.wins} wins, ${((Number(activeRaceSection.win_rate) || 0) * 100).toFixed(1)}% win rate`}
+                              </div>
+                              {(activeRaceSection.common_behaviours || []).length === 0 ? <div className="chart-empty">No common behaviours at 20%+ for this race.</div> : null}
+                              {(activeRaceSection.common_behaviours || []).map((item, idx) => (
+                                <div key={`${activeRaceSection.race}-${item.name}`} className="workflow-pattern-row">
+                                  <span>{renderPatternPill({ pattern_name: item.name, value: 'true' }, `player-common-${activeRaceSection.race}-${idx}`, undefined, markerRegistry)}</span>
+                                  <span>{`${((Number(item.game_rate) || 0) * 100).toFixed(1)}% (${item.replay_count}/${activeRaceSection.game_count})`}</span>
+                                </div>
                               ))}
                             </div>
-                          )}
-                          <div className="workflow-card-subtitle"><span>Last 5 messages</span></div>
-                          {(mainPlayerChatSummary?.example_messages || []).map((msg, idx) => (
-                            <div key={`player-chat-example-${idx}`} className="workflow-event-row">
-                              <span>{msg}</span>
+                          ) : null}
+                          {!mainPlayerMetricsLoading && !mainPlayerMetricsError && !activeRaceSection && activeRaceBreakdown ? (
+                            <div className="workflow-race-behaviour-section">
+                              <div className="workflow-subtle-note">
+                                {`${activeRaceBreakdown.game_count} games, ${activeRaceBreakdown.wins} wins`}
+                              </div>
+                              <div className="chart-empty">No behaviour breakdown available for this race.</div>
                             </div>
-                          ))}
+                          ) : null}
                         </>
-                      ) : null
-                    )}
-                  </div>
+                      )}
+                    </div>
+                  )}
+
+                  {isSkillProxiesTab && skillProxySubtab === 'summary' && (
+                    <div className="workflow-card workflow-card-fingerprints">
+                      <div className="workflow-card-title"><span>Population comparison</span></div>
+                      {mainPlayerInsightLoading ? <div className="chart-empty">Loading population comparisons...</div> : null}
+                      {!mainPlayerInsightLoading && mainPlayerInsightErrors.length > 0 ? (
+                        <div className="chart-empty">{mainPlayerInsightErrors[0]}</div>
+                      ) : null}
+                      {!mainPlayerInsightLoading && mainPlayerInsightErrors.length === 0 ? (
+                        <div className="workflow-insight-grid">
+                          {mainPlayerInsights.map((insight) => {
+                            const percentile = Number(insight.performance_percentile || 0);
+                            const accent = insightScoreColor(percentile);
+                            const overrideDesc = PLAYER_INSIGHT_DESCRIPTION_OVERRIDES[insight.insight_type];
+                            const description = overrideDesc !== undefined ? overrideDesc : insight.description;
+                            const popTab = playerInsightDestinationTab(insight.insight_type);
+                            return (
+                              <div
+                                key={insight.insight_type}
+                                className="workflow-insight-card workflow-insight-card-static"
+                                style={insight.eligible ? { borderColor: `${accent}55`, boxShadow: `inset 0 0 0 1px ${accent}22` } : undefined}
+                              >
+                                <div className="workflow-insight-card-header">
+                                  <span>{insight.title}</span>
+                                </div>
+                                {insight.eligible ? (
+                                  <>
+                                    <div className="workflow-insight-score-row">
+                                      <span className="workflow-insight-score" style={{ color: accent }}>{insightSummaryLabel(percentile)}</span>
+                                    </div>
+                                    <div className="workflow-insight-value">{insight.player_value_label}</div>
+                                    <div className="workflow-subtle-note">{`${insight.population_size} eligible players in population.`}</div>
+                                  </>
+                                ) : (
+                                  <>
+                                    <div className="workflow-insight-unavailable">Not enough data yet</div>
+                                    <div className="workflow-subtle-note">{insight.ineligible_reason || 'This comparison is not available yet.'}</div>
+                                  </>
+                                )}
+                                {description ? (
+                                  <div className="workflow-subtle-note workflow-insight-description">{description}</div>
+                                ) : null}
+                                {popTab ? (
+                                  <div className="workflow-insight-card-footer">
+                                    <button
+                                      type="button"
+                                      className="workflow-link-btn"
+                                      onClick={() => openMainPlayersSubview(popTab)}
+                                    >
+                                      See all players comparison →
+                                    </button>
+                                  </div>
+                                ) : null}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : null}
+                    </div>
+                  )}
+
+                  {isSkillProxiesTab && skillProxySubtab === 'usage-signals' && (
+                    <div className="workflow-card workflow-card-fingerprints">
+                      <div className="workflow-card-title"><span>Usage signals</span></div>
+                      {mainPlayerUsagePills.length === 0 ? (
+                        <div className="workflow-subtle-note">No low-usage flags were triggered for hotkeys or queued orders.</div>
+                      ) : (
+                        <div className="workflow-pattern-pills">
+                          {mainPlayerUsagePills.map((pill) => (
+                            <span key={pill.key} className={pill.className} title={pill.title}>{pill.label}</span>
+                          ))}
+                        </div>
+                      )}
+                      <div className="workflow-card-subtitle">
+                        <span>Distinctive outliers</span>
+                        <HelpTooltip text={PLAYER_OUTLIER_HELP} label="Outlier calculation explanation" />
+                      </div>
+                      <div className="workflow-subtle-note">Same-race, human-only baselines. Items are shown in one list and prefixed by command family.</div>
+                      {mainPlayerOutliersLoading ? <div className="chart-empty">Loading outliers...</div> : null}
+                      {!mainPlayerOutliersLoading && mainPlayerOutliersError ? <div className="chart-empty">{mainPlayerOutliersError}</div> : null}
+                      {!mainPlayerOutliersLoading && !mainPlayerOutliersError && mainPlayerOutlierItems.length === 0 ? (
+                        <div className="chart-empty">No outliers crossed current thresholds.</div>
+                      ) : null}
+                      {!mainPlayerOutliersLoading && !mainPlayerOutliersError && mainPlayerOutlierItems.map((item) => (
+                        <div key={`${item.category}-${item.race}-${item.name}`} className="workflow-pattern-row">
+                          <span>{`${item.category}: ${item.pretty_name}`}</span>
+                          <span className="workflow-outlier-expl">
+                            <span className="workflow-outlier-rate">{`${((Number(item.player_rate) || 0) * 100).toFixed(0)}%`}</span>
+                            <span>you</span>
+                            <span>vs</span>
+                            <span className="workflow-outlier-rate-muted">{`${((Number(item.baseline_rate) || 0) * 100).toFixed(0)}%`}</span>
+                            <span>baseline</span>
+                            {(item.qualified_by || []).map((qualifier) => (
+                              <span key={`${item.name}-${qualifier}`} className={outlierQualifierClassName(qualifier)}>{qualifier}</span>
+                            ))}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  {mainPlayerTab === 'recent-games' && (
+                    <div className="workflow-card workflow-card-recent-games">
+                      <div className="workflow-card-title"><span>Recent games</span></div>
+                      {mainPlayerRecentGamesLoading ? <div className="chart-empty">Loading recent games...</div> : null}
+                      {!mainPlayerRecentGamesLoading && mainPlayerRecentGamesError ? <div className="chart-empty">{mainPlayerRecentGamesError}</div> : null}
+                      {!mainPlayerRecentGamesLoading && !mainPlayerRecentGamesError && mainPlayerRecentGames.length === 0 ? (
+                        <div className="chart-empty">No recent games found for this player.</div>
+                      ) : null}
+                      {!mainPlayerRecentGamesLoading && !mainPlayerRecentGamesError && mainPlayerRecentGames.slice(0, 6).map((g) => {
+                        const isWinner = !!g.current_player?.is_winner;
+                        const hasResult = g.current_player !== undefined && g.current_player !== null;
+                        const resultClass = hasResult ? (isWinner ? 'workflow-recent-game-card--win' : 'workflow-recent-game-card--loss') : '';
+                        const playersList = Array.isArray(g.players) ? g.players : [];
+                        const is1v1 = playersList.length === 2;
+                        let matchupNode = null;
+                        if (is1v1) {
+                          const myKey = String(g.current_player?.player_key || '').toLowerCase();
+                          const me = playersList.find((p) => String(p.player_key || '').toLowerCase() === myKey) || playersList[0];
+                          const opp = playersList.find((p) => p !== me) || playersList[1];
+                          const myIcon = getWorkerIconForRace(me?.race);
+                          const oppIcon = getWorkerIconForRace(opp?.race);
+                          matchupNode = (
+                            <span className="workflow-recent-game-matchup">
+                              {myIcon ? <img src={myIcon} alt={me?.race || ''} title={me?.race || ''} className="workflow-recent-game-worker-icon" /> : <span>{me?.race || '-'}</span>}
+                              <span className="workflow-recent-game-vs">vs</span>
+                              {oppIcon ? <img src={oppIcon} alt={opp?.race || ''} title={opp?.race || ''} className="workflow-recent-game-worker-icon" /> : <span>{opp?.race || '-'}</span>}
+                            </span>
+                          );
+                        } else if (g.current_player?.race) {
+                          const icon = getWorkerIconForRace(g.current_player.race);
+                          matchupNode = (
+                            <span className="workflow-recent-game-matchup">
+                              {icon ? <img src={icon} alt={g.current_player.race} title={g.current_player.race} className="workflow-recent-game-worker-icon" /> : null}
+                              <span>{g.current_player.race}</span>
+                            </span>
+                          );
+                        }
+                        return (
+                          <button key={g.replay_id} className={`workflow-recent-game-card ${resultClass}`} onClick={() => openMainGame(g.replay_id)}>
+                            <div className="workflow-recent-game-header workflow-recent-game-header--left">
+                              {isWinner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+                              <span>{formatRelativeReplayDate(g.replay_date)}</span>
+                              <span>{formatDuration(g.duration_seconds)}</span>
+                              <span>{g.map_name}</span>
+                              {matchupNode}
+                            </div>
+                            <div className="workflow-subtle-note">{renderPlayersMatchup(g.players_label || '')}</div>
+                            {filterSummaryPillPatterns(g.current_player?.detected_patterns).length > 0 ? (
+                              <div className="workflow-pattern-pills workflow-pattern-pills-compact">
+                                {filterSummaryPillPatterns(g.current_player?.detected_patterns).map((pattern, idx) => renderPatternPill(pattern, `recent-${g.replay_id}-${idx}`, undefined, markerRegistry))}
+                              </div>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {mainPlayerTab === 'chat-summary' && (
+                    <div className="workflow-card workflow-card-chat-summary">
+                      <div className="workflow-card-title"><span>Chat Summary</span></div>
+                      {mainPlayerChatSummaryLoading ? <div className="chart-empty">Loading chat summary...</div> : null}
+                      {!mainPlayerChatSummaryLoading && mainPlayerChatSummaryError ? <div className="chart-empty">{mainPlayerChatSummaryError}</div> : null}
+                      {!mainPlayerChatSummaryLoading && !mainPlayerChatSummaryError && (Number(mainPlayerChatSummary?.total_messages) || 0) === 0 ? (
+                        <div className="chart-empty">No chat messages found for this player in ingested games.</div>
+                      ) : (
+                        !mainPlayerChatSummaryLoading && !mainPlayerChatSummaryError && mainPlayerChatSummary ? (
+                          <>
+                            <div className="workflow-subtle-note">
+                              {`${mainPlayerChatSummary?.total_messages || 0} messages across ${mainPlayerChatSummary?.games_with_chat || 0} games, ${mainPlayerChatSummary?.distinct_terms || 0} distinct terms after cleanup.`}
+                            </div>
+                            <div className="workflow-card-subtitle"><span>Top terms</span></div>
+                            {(mainPlayerChatSummary?.top_terms || []).length === 0 ? (
+                              <div className="chart-empty">Not enough messages to infer common terms.</div>
+                            ) : (
+                              <div className="workflow-pattern-pills">
+                                {(mainPlayerChatSummary?.top_terms || []).map((item) => (
+                                  <span key={`player-chat-term-${item.term}`} className="workflow-pattern-pill">
+                                    <span>{item.term}</span>
+                                    <span>{`x${item.count}`}</span>
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                            <div className="workflow-card-subtitle"><span>Last 15 messages</span></div>
+                            {(mainPlayerChatSummary?.example_messages || []).map((msg, idx) => (
+                              <div key={`player-chat-example-${idx}`} className="workflow-event-row">
+                                <span>{msg}</span>
+                              </div>
+                            ))}
+                          </>
+                        ) : null
+                      )}
+                    </div>
+                  )}
                 </div>
               </>
             ) : (
               <div className="chart-empty">Select a player from a game report.</div>
             )}
-            <form onSubmit={handleMainAsk} className="workflow-ask-form">
-              <input
-                className="widget-creation-input"
-                value={mainQuestion}
-                onChange={(e) => setMainQuestion(e.target.value)}
-                placeholder={openaiEnabled ? 'Ask AI about this player...' : 'Enable AI to ask questions'}
-                disabled={!openaiEnabled || mainAskLoading}
-              />
-              <button className="btn-create-ai" type="submit" disabled={!openaiEnabled || mainAskLoading || !mainQuestion.trim()}>
-                {mainAskLoading ? 'Asking...' : 'Ask AI'}
-              </button>
-            </form>
-            {renderMainAiResult()}
+            {mainPlayer && mainPlayerTab === 'summary' ? (
+              <>
+                <form onSubmit={handleMainAsk} className="workflow-ask-form">
+                  <input
+                    className="widget-creation-input"
+                    value={mainQuestion}
+                    onChange={(e) => setMainQuestion(e.target.value)}
+                    placeholder={openaiEnabled ? 'Ask AI about this player...' : 'Enable AI to ask questions'}
+                    disabled={!openaiEnabled || mainAskLoading}
+                  />
+                  <button className="btn-create-ai" type="submit" disabled={!openaiEnabled || mainAskLoading || !mainQuestion.trim()}>
+                    {mainAskLoading ? 'Asking...' : 'Ask AI'}
+                  </button>
+                </form>
+                {renderMainAiResult()}
+              </>
+            ) : null}
           </div>
-        )}
+          );
+        })()}
 
         {activeView === 'dashboards' && customDashboardsEnabled && (
           <>

--- a/internal/dashboard/frontend/src/components/IngestModal.jsx
+++ b/internal/dashboard/frontend/src/components/IngestModal.jsx
@@ -75,7 +75,7 @@ function IngestModal({
             </label>
           </div>
 
-          <form onSubmit={onSubmit} className="ingest-plain-block">
+          <form onSubmit={onSubmit} className="ingest-plain-block ingest-manual-block">
             <div className="ingest-title">Manual ingest</div>
             <div className="ingest-manual-stack">
               <div className="ingest-manual-row">

--- a/internal/dashboard/frontend/src/lib/mainRoute.js
+++ b/internal/dashboard/frontend/src/lib/mainRoute.js
@@ -21,6 +21,15 @@ export const MAIN_PLAYERS_TABS = [
   'viewport-multitasking',
 ];
 
+export const MAIN_PLAYER_TABS = [
+  'summary',
+  'skill-proxies',
+  'recent-games',
+  'chat-summary',
+];
+
+export const MAIN_PLAYER_SKILL_PROXY_SUBTABS = ['summary', 'usage-signals'];
+
 const normalizeSearch = (search) => {
   if (!search || search === '?') return '';
   return String(search).startsWith('?') ? search.slice(1) : search;
@@ -50,6 +59,8 @@ const pickEnum = (value, allowed, fallback) => {
  *   playerKey: string,
  *   gameTab: string,
  *   playersTab: string,
+ *   playerTab: string,
+ *   playerSubtab: string,
  *   dash: string|null,
  * }}
  */
@@ -61,12 +72,20 @@ export function parseMainRouteSearch(search) {
   const playerRaw = params.get('player');
   const gameTabRaw = params.get('gameTab');
   const playersTabRaw = params.get('playersTab');
+  const playerTabRaw = params.get('playerTab');
+  const playerSubtabRaw = params.get('playerSubtab');
   const dashRaw = params.get('dash');
 
   let replayId = view === 'game' ? parseReplayIdParam(replayRaw) : null;
   let playerKey = view === 'player' ? normalizePlayerKeyParam(playerRaw) : '';
   let gameTab = pickEnum(gameTabRaw, MAIN_GAME_TABS, 'summary');
   let playersTab = pickEnum(playersTabRaw, MAIN_PLAYERS_TABS, 'summary');
+  let playerTab = pickEnum(playerTabRaw, MAIN_PLAYER_TABS, 'summary');
+  // playerSubtab is contextual: only validated for skill-proxies; race subtabs are dynamic.
+  let playerSubtab = String(playerSubtabRaw || '').trim().toLowerCase();
+  if (playerTab === 'skill-proxies') {
+    playerSubtab = MAIN_PLAYER_SKILL_PROXY_SUBTABS.includes(playerSubtab) ? playerSubtab : 'summary';
+  }
   let dash = dashRaw != null && String(dashRaw).trim() !== '' ? String(dashRaw).trim() : null;
 
   if (view === 'game' && replayId == null) {
@@ -88,6 +107,8 @@ export function parseMainRouteSearch(search) {
     playerKey,
     gameTab,
     playersTab,
+    playerTab,
+    playerSubtab,
     dash: view === 'dashboards' ? dash || 'default' : null,
   };
 }
@@ -99,6 +120,8 @@ export function parseMainRouteSearch(search) {
  *   selectedPlayerKey: string,
  *   mainGameTab: string,
  *   mainPlayersTab: string,
+ *   mainPlayerTab: string,
+ *   mainPlayerSubtab: string,
  *   currentDashboardUrl: string,
  * }} s
  * @returns {string} query string without leading `?` (empty = default games home)
@@ -123,6 +146,20 @@ export function buildMainRouteSearch(s) {
 
   if (view === 'player' && s.selectedPlayerKey) {
     params.set('player', s.selectedPlayerKey);
+    const tab = pickEnum(s.mainPlayerTab, MAIN_PLAYER_TABS, 'summary');
+    if (tab !== 'summary') {
+      params.set('playerTab', tab);
+    }
+    const sub = String(s.mainPlayerSubtab || '').trim().toLowerCase();
+    if (tab === 'skill-proxies') {
+      const validated = MAIN_PLAYER_SKILL_PROXY_SUBTABS.includes(sub) ? sub : 'summary';
+      if (validated !== 'summary') {
+        params.set('playerSubtab', validated);
+      }
+    } else if (tab === 'summary' && sub) {
+      // Race subtab — opaque; persist only when set.
+      params.set('playerSubtab', sub);
+    }
   }
 
   if (view === 'players') {
@@ -173,5 +210,7 @@ export function mainRouteSnapshotEqual(searchA, searchB) {
     && ra.playerKey === rb.playerKey
     && ra.gameTab === rb.gameTab
     && ra.playersTab === rb.playersTab
+    && ra.playerTab === rb.playerTab
+    && ra.playerSubtab === rb.playerSubtab
     && dashA === dashB;
 }

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -1363,6 +1363,12 @@ body {
   gap: 10px;
 }
 
+.ingest-manual-block {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+
 .ingest-plain-heading {
   display: flex;
   justify-content: space-between;
@@ -1880,6 +1886,21 @@ body {
   align-self: flex-start;
   text-align: left;
   max-width: 100%;
+}
+
+/* Player report: single-column full-width cards (one visible per tab). */
+.workflow-panel--player .workflow-cards {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.workflow-panel--player .workflow-meta {
+  margin-bottom: 14px;
+}
+
+.workflow-panel--player .workflow-ask-form {
+  margin-top: 18px;
 }
 
 .workflow-meta--game-header {
@@ -2424,6 +2445,12 @@ body {
   height: 60px;
 }
 
+.workflow-race-tab-icon {
+  width: 18px;
+  height: 18px;
+  margin-right: 6px;
+}
+
 .chart-card {
   min-height: 360px;
 }
@@ -2715,6 +2742,22 @@ body {
   gap: 6px;
 }
 
+/* Static card (player Skill proxies > Summary): no hover/click affordance. */
+.workflow-insight-card-static {
+  cursor: default;
+}
+
+.workflow-insight-description {
+  margin-top: 6px;
+}
+
+.workflow-insight-card-footer {
+  margin-top: auto;
+  padding-top: 8px;
+  display: flex;
+  justify-content: flex-start;
+}
+
 .workflow-insight-detail-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -2792,6 +2835,49 @@ body {
   align-items: center;
   gap: 6px;
   color: rgba(255, 255, 255, 0.86);
+}
+
+.workflow-recent-game-header--left {
+  justify-content: flex-start;
+  gap: 14px;
+}
+
+.workflow-recent-game-matchup {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workflow-recent-game-vs {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.workflow-recent-game-worker-icon {
+  width: 30px;
+  height: 30px;
+  object-fit: contain;
+  vertical-align: middle;
+}
+
+.workflow-recent-game-card--win {
+  background: rgba(40, 160, 80, 0.12);
+  border-color: rgba(80, 200, 120, 0.32);
+}
+
+.workflow-recent-game-card--win:hover {
+  background: rgba(40, 160, 80, 0.20);
+  border-color: rgba(120, 220, 150, 0.5);
+}
+
+.workflow-recent-game-card--loss {
+  background: rgba(200, 60, 60, 0.10);
+  border-color: rgba(220, 100, 100, 0.32);
+}
+
+.workflow-recent-game-card--loss:hover {
+  background: rgba(200, 60, 60, 0.18);
+  border-color: rgba(240, 130, 130, 0.5);
 }
 
 .workflow-outlier-expl {


### PR DESCRIPTION
## Summary

Mirror the game report layout in the player page. Tab-based instead of a single long-scroll panel, content loads only on tab activation. A handful of adjacent UX/correctness issues addressed at the same time.

### Tab structure

- **Summary** — dynamic per-race subtabs sorted by game count, primary race default. Ask AI lives here.
- **Skill proxies** — Summary subtab (4 insight cards) + Usage signals & distinctive outliers subtab.
- **Recent games**
- **Chat summary**

State deep-linkable via `playerTab` + `playerSubtab` URL params; popstate restores them.

### Lazy loading

Each tab fetches only on first activation:
- `/metrics` → Summary
- 4 insight endpoints (APM, viewport, delay, cadence) → Skill proxies > Summary
- `/outliers` → Usage signals
- `/insights/recent-games` → Recent games
- `/chat-summary` → Chat summary

Eager fan-out removed from `openMainPlayer`.

### Skill proxies > Summary card cleanup

- Keep "Better than X% of population" comparison
- Drop "Elite / Solid / Needs work" pill
- Drop hover-expand details + info icon; description always visible
- Replace whole-card click with explicit "See all players comparison →" link at bottom
- APM card first; per-insight description overrides (shorter blurbs from per-game skill proxies; no description for APM)

### APM/EAPM discrepancy fix

`GetPlayerOverviewSummary` used `AVG(p.apm)` (including 0-APM rows) while population aggregate excluded them. Subtitle and APM insight card now show the same number. Switched overview to `AVG(CASE WHEN p.apm > 0 THEN p.apm END)`. Same fix for EAPM.

### Recent games overhaul

- Backend also calls `populateWorkflowGameListPlayers` so players array available
- 1v1s render `worker_icon vs worker_icon` (drone/probe/scv) at half previous icon size
- Win rows slight green tint, losses slight red tint, undefined neutral
- Header left-aligned; crown leads the row on a win (no separate meta row)

### Other

- **Chat summary**: server cap 5 → 15 example messages; label updated
- **Game report title**: player names become buttons that open the player page (new `renderPlayerLinkLabel` helper; existing `renderPlayerLabel` unchanged for plain-text contexts)
- **Player Summary > race subtab**: redundant race icon/title row dropped — active subtab button already shows it
- **Ingest modal**: minimal border around the Manual ingest block for visual grouping

## Test plan

- [x] Cold-load player → only `/detail` fires (verified via Network panel)
- [x] Each tab fetches on first activation; subsequent switches don't re-fetch
- [x] Race subtabs render from sync `/detail`; switch without refetching
- [x] APM in subtitle matches APM in Skill proxies > Summary card (346.4 == 346.4)
- [x] Skill proxies > Summary shows "Better than X%" / "Best in sample" without grade pill
- [x] "See all players comparison →" navigates to the right population tab
- [x] Recent games: 1v1 shows worker matchup, win is green, crown leads winning row
- [x] Chat summary shows up to 15 messages
- [x] Deep link `?view=player&player=X&playerTab=skill-proxies&playerSubtab=usage-signals` lands on the right state after reload
- [x] Browser Back works across tabs
- [x] Game report title player names open the player page on click
- [x] Ingest modal Manual ingest block has visible border

🤖 Generated with [Claude Code](https://claude.com/claude-code)