### PR TITLE
fix: show cliff drop pill on replay summary featuring strip

### DIFF
--- a/internal/dashboard/endpoint_custom_markers_definitions.go
+++ b/internal/dashboard/endpoint_custom_markers_definitions.go
@@ -73,6 +73,7 @@ var staticFeaturingOrder = []string{
 	// late-game custom-evaluator markers
 	"threw_nukes",
 	"made_recalls",
+	"cliff_drop",
 	"mech_transition",
 	// transition markers (KindMarker)
 	"one_one_one",


### PR DESCRIPTION
Adds cliff_drop to staticFeaturingOrder so the per-replay feature pill renders alongside the other late-game custom-evaluator markers (threw_nukes, made_recalls). Without it, cliff drops only appeared on the per-player pill row, never on the replay-level summary.