### PR TITLE
feat: UI polish, mid-map attack fallback, viewport-rate + phase fixes

### DIFF
--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -187,6 +187,21 @@ func (d *Dashboard) populateDetectedPatternsForGameDetail(detail *workflowGameDe
 		pattern := buildWorkflowPatternValue(row.PatternName, row.Value, row.DetectedSecond, row.Payload)
 		if player, ok := playerByID[playerID]; ok {
 			player.DetectedPatterns = append(player.DetectedPatterns, pattern)
+			// Surface the mech transition marker on the Game Events
+			// timeline at the second it was committed (4th-Factory
+			// completion). The marker itself stays a per-player pill;
+			// this just adds a narrative anchor to the events list.
+			if pattern.EventType == "mech_transition" && pattern.DetectedSecond > 0 {
+				detail.GameEvents = append(detail.GameEvents, workflowGameEvent{
+					Type:   "mech_transition",
+					Second: int64(pattern.DetectedSecond),
+					Actor: &workflowGameEventPlayer{
+						PlayerID: player.PlayerID,
+						Name:     player.Name,
+						Color:    player.Color,
+					},
+				})
+			}
 		}
 	}
 	return nil
@@ -2114,174 +2129,35 @@ func (d *Dashboard) populateFirstUnitEfficiencyForGameDetail(detail *workflowGam
 	return nil
 }
 
-// populatePhaseMarkersForGameDetail computes Early/Mid game-end seconds used
-// by the frontend to split the Game Events list into three sections.
+// populatePhaseMarkersForGameDetail copies the persisted Early/Mid
+// game-end seconds onto the response so the frontend can split the Game
+// Events list into three sections. The boundaries come from the
+// mid_game_starts / late_game_starts markers persisted at ingest by
+// detectors.PhaseBoundaryDetector (which runs phases.Compute over the
+// enriched stream). Reading the persisted markers here keeps this
+// surface in lockstep with attacker-composition (which also reads them
+// via GetPhaseBoundariesForReplay) and avoids the action-type drift
+// that broke a request-time recomputation against raw rows.
 //
-// Early-game ends at the EARLIEST of, across all players:
-//   - first Mutalisk completion
-//   - first Lurker completion
-//   - first Wraith completion
-//   - first Siege Tank completion AND Tank Siege Mode tech researched (max of the two)
-//   - first Dragoon completion AND Singularity Charge upgrade researched (max of the two)
+// Algorithm (lives in internal/patterns/phases — see PhaseBoundaryDetector):
 //
-// Mid-game ends at the EARLIEST mid-game candidate that is also >= the early-game
-// end second:
-//   - first Defiler/Arbiter/Carrier/Battlecruiser/Ultralisk completion
-//   - any Terran ground/armor weapons +2 (Infantry Weapons, Vehicle Weapons,
-//     Infantry Armor, Vehicle Plating reaching level 2)
+//   - earlyEnd: earliest first-occurrence across all players of
+//     Mutalisk / Lurker / Wraith / max(Siege Tank, Tank Siege Mode) /
+//     max(Dragoon, Singularity Charge) / Reaver / Dark Templar.
+//   - midEnd:   earliest of Defiler / Arbiter / Carrier / Battlecruiser /
+//     Ultralisk / any Terran ground or armor +2.
 //
-// Returns 0 in either field when no matching event is found — frontend
-// collapses empty sections.
+// Either field stays 0 when the corresponding marker isn't present
+// (game ended before that signal); the frontend collapses empty
+// sections.
 func (d *Dashboard) populatePhaseMarkersForGameDetail(detail *workflowGameDetail) error {
-	rows, err := d.dbStore.ListFirstUnitCommandRows(d.ctx, detail.ReplayID)
+	boundaries, err := d.dbStore.GetPhaseBoundariesForReplay(d.ctx, detail.ReplayID)
 	if err != nil {
-		return fmt.Errorf("failed to load phase-marker commands: %w", err)
+		return fmt.Errorf("failed to load phase-boundary markers: %w", err)
 	}
-
-	// First completion second per normalized unit key (across all players).
-	firstUnit := map[string]int64{}
-	rememberFirst := func(key string, second int64) {
-		if existing, ok := firstUnit[key]; !ok || second < existing {
-			firstUnit[key] = second
-		}
-	}
-	for _, row := range rows {
-		if row.ActionType != "Train" && row.ActionType != "Morph" {
-			continue
-		}
-		commandUnits := parseCommandUnitNames(row.UnitType, row.UnitTypes)
-		for _, name := range commandUnits {
-			for _, alias := range unitNameAliases(name) {
-				rememberFirst(alias, row.Second)
-			}
-		}
-	}
-
-	// Tank Siege Mode tech (single-occurrence).
-	siegeModeSec := int64(-1)
-	techRows, err := d.dbStore.ListTechTimingRows(d.ctx, detail.ReplayID)
-	if err != nil {
-		return fmt.Errorf("failed to load phase-marker tech rows: %w", err)
-	}
-	for _, row := range techRows {
-		if !strings.EqualFold(strings.TrimSpace(row.Label), "Tank Siege Mode") {
-			continue
-		}
-		if siegeModeSec < 0 || row.Second < siegeModeSec {
-			siegeModeSec = row.Second
-		}
-	}
-
-	// Singularity Charge upgrade + Terran +2 ground/armor.
-	upgradeRows, err := d.dbStore.ListUpgradeTimingRows(d.ctx, detail.ReplayID)
-	if err != nil {
-		return fmt.Errorf("failed to load phase-marker upgrade rows: %w", err)
-	}
-	terran2Names := map[string]bool{
-		"terran infantry weapons": true,
-		"terran vehicle weapons":  true,
-		"terran infantry armor":   true,
-		"terran vehicle plating":  true,
-	}
-	dragoonRangeSec := int64(-1)
-	terranPlus2Sec := int64(-1)
-	// upgradeRows aren't pre-sorted by second, and per-player level == nth occurrence;
-	// gather per-(player,label) sorted seconds, then use the 2nd entry for +2.
-	type pl struct {
-		player int64
-		label  string
-	}
-	upgradeOccurrences := map[pl][]int64{}
-	for _, row := range upgradeRows {
-		labelLower := strings.ToLower(strings.TrimSpace(row.Label))
-		if strings.Contains(labelLower, "singularity charge") {
-			if dragoonRangeSec < 0 || row.Second < dragoonRangeSec {
-				dragoonRangeSec = row.Second
-			}
-		}
-		if terran2Names[labelLower] {
-			key := pl{player: row.PlayerID, label: labelLower}
-			upgradeOccurrences[key] = append(upgradeOccurrences[key], row.Second)
-		}
-	}
-	for _, secs := range upgradeOccurrences {
-		sort.Slice(secs, func(i, j int) bool { return secs[i] < secs[j] })
-		if len(secs) < 2 {
-			continue
-		}
-		// secs[1] = level 2 finish second.
-		if terranPlus2Sec < 0 || secs[1] < terranPlus2Sec {
-			terranPlus2Sec = secs[1]
-		}
-	}
-
-	// Build candidate lists.
-	earliest := func(seconds ...int64) int64 {
-		best := int64(-1)
-		for _, s := range seconds {
-			if s < 0 {
-				continue
-			}
-			if best < 0 || s < best {
-				best = s
-			}
-		}
-		return best
-	}
-	maxOf := func(a, b int64) int64 {
-		if a < 0 || b < 0 {
-			return -1
-		}
-		if a > b {
-			return a
-		}
-		return b
-	}
-
-	mutaSec := lookupFirstUnit(firstUnit, "mutalisk")
-	lurkerSec := lookupFirstUnit(firstUnit, "lurker")
-	wraithSec := lookupFirstUnit(firstUnit, "wraith")
-	siegeTankSec := lookupFirstUnit(firstUnit, "siegetank", "siegetanktankmode", "siegetanksiegemode")
-	dragoonSec := lookupFirstUnit(firstUnit, "dragoon")
-
-	siegeArmedSec := maxOf(siegeTankSec, siegeModeSec)
-	dragoonArmedSec := maxOf(dragoonSec, dragoonRangeSec)
-
-	earlyEnd := earliest(mutaSec, lurkerSec, wraithSec, siegeArmedSec, dragoonArmedSec)
-
-	defilerSec := lookupFirstUnit(firstUnit, "defiler")
-	arbiterSec := lookupFirstUnit(firstUnit, "arbiter")
-	carrierSec := lookupFirstUnit(firstUnit, "carrier")
-	bcSec := lookupFirstUnit(firstUnit, "battlecruiser")
-	ultraSec := lookupFirstUnit(firstUnit, "ultralisk")
-
-	midCandidate := earliest(defilerSec, arbiterSec, carrierSec, bcSec, ultraSec, terranPlus2Sec)
-	midEnd := midCandidate
-	if midEnd >= 0 && earlyEnd >= 0 && midEnd < earlyEnd {
-		midEnd = earlyEnd
-	}
-
-	if earlyEnd > 0 {
-		detail.EarlyGameEndsAtSecond = earlyEnd
-	}
-	if midEnd > 0 {
-		detail.MidGameEndsAtSecond = midEnd
-	}
+	detail.EarlyGameEndsAtSecond = boundaries.EarlyEndsAtSecond
+	detail.MidGameEndsAtSecond = boundaries.MidEndsAtSecond
 	return nil
-}
-
-// lookupFirstUnit returns the earliest second across the given normalized unit
-// keys, or -1 when none is present.
-func lookupFirstUnit(firstUnit map[string]int64, keys ...string) int64 {
-	best := int64(-1)
-	for _, key := range keys {
-		if sec, ok := firstUnit[key]; ok {
-			if best < 0 || sec < best {
-				best = sec
-			}
-		}
-	}
-	return best
 }
 
 // zergBOEventSchema describes the per-BO event list shown in the Build

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -255,14 +255,13 @@ var workflowFeaturingFilters = []struct {
 	IconLabel string
 	Emoji     string
 }{
-	{Key: "team_stacking", Label: "Team stacking", Group: "marker", Emoji: "😈"},
 	{Key: "carriers", Label: "Carrier", Group: "marker", IconKey: "carrier"},
 	{Key: "battlecruisers", Label: "Battlecruiser", Group: "marker", IconKey: "battlecruiser"},
 	{Key: "ten_plus_scouts", Label: "10+ Scouts", Group: "marker", IconKey: "scout", IconLabel: "10+"},
 	{Key: "mech", Label: "Mech", Group: "marker", IconKeys: []string{"siegetank", "goliath"}, IconLabel: "Mech"},
 	{Key: "sk_terran", Label: "SK Terran", Group: "marker", IconKeys: []string{"marine", "medic"}, IconLabel: "SK Terran"},
 	{Key: "one_one_one", Label: "1-1-1", Group: "marker"},
-	{Key: "mech_transition", Label: "Mech Transition", Group: "marker", IconKeys: []string{"siegetank", "goliath"}},
+	{Key: "mech_transition", Label: "Mech Transition", Group: "marker", IconKeys: []string{"siegetank", "goliath"}, IconLabel: "Mech transition"},
 	{Key: "mutalisk_timing", Label: "Mutalisk timing", Group: "marker", IconKey: "mutalisk", IconLabel: "timing"},
 	{Key: "turret_timing", Label: "Turret timing", Group: "marker", IconKey: "missileturret", IconLabel: "Timing"},
 	{Key: "cliff_drop", Label: "Cliff drop", Group: "marker", IconKey: "dropship", IconLabel: "Cliff drop"},
@@ -275,6 +274,7 @@ var workflowFeaturingFilters = []struct {
 	{Key: "mind_control", Label: "Mind Control", Group: "marker", IconKey: "darkarchon", IconLabel: "Mind Control"},
 	{Key: "nukes", Label: "Nukes", Group: "marker", IconKey: "ghost", IconLabel: "Nuke"},
 	{Key: "recalls", Label: "Recalls", Group: "marker", IconKey: "arbiter", IconLabel: "Recall"},
+	{Key: "team_stacking", Label: "Team stacking", Group: "marker", Emoji: "😈"},
 	// Build order pills — keys & labels kept in sync with internal/markers.
 	// Suppressed in render for Money maps (game-list + replay-summary
 	// featuring strips); BO tab and per-player summary pills still show.
@@ -293,7 +293,7 @@ var workflowFeaturingFilters = []struct {
 	{Key: "bo_gate_expand", Label: "Gate Expand", Group: "bo"},
 	{Key: "bo_forge_expa", Label: "Forge Expand", Group: "bo"},
 	{Key: "bo_1_rax_1_fac", Label: "1 Rax 1 Fac", Group: "bo"},
-	{Key: "bo_rax_cc", Label: "Rax-CC", Group: "bo"},
+	{Key: "bo_rax_cc", Label: "1 Rax FE", Group: "bo"},
 	{Key: "bo_cc_first", Label: "CC First", Group: "bo"},
 	{Key: "bo_bbs", Label: "BBS", Group: "bo"},
 }

--- a/internal/dashboard/endpoint_players_insight_viewport.go
+++ b/internal/dashboard/endpoint_players_insight_viewport.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -11,6 +12,12 @@ import (
 )
 
 const workflowViewportMultitaskingMinGames int64 = 4
+
+// viewportMultitaskingFeatureKey is the marker registry FeatureKey for the
+// viewport-multitasking marker. Stored in replay_events.event_type — the
+// queries below filter against that. PatternNameViewportMultitasking is the
+// human-readable pattern label, kept separately for the response payload.
+const viewportMultitaskingFeatureKey = "viewport_multitasking"
 
 type workflowPlayerViewportMultitaskingPoint struct {
 	PlayerKey                 string  `json:"player_key"`
@@ -123,7 +130,7 @@ func (d *Dashboard) buildWorkflowPlayerViewportAsyncInsight(playerKey string) (w
 }
 
 func (d *Dashboard) loadWorkflowViewportMultitaskingAggregates() ([]workflowViewportMultitaskingAggregate, error) {
-	rows, err := d.dbStore.ListViewportAggregateRows(d.ctx, models.PatternNameViewportMultitasking)
+	rows, err := d.dbStore.ListViewportAggregateRows(d.ctx, viewportMultitaskingFeatureKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load viewport multitasking patterns: %w", err)
 	}
@@ -222,7 +229,20 @@ func stddevFloatSlice(values []float64, mean float64) float64 {
 }
 
 func parseViewportSwitchRate(raw string) (float64, bool) {
-	value, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, false
+	}
+	// Markers store viewport switches-per-minute as JSON
+	// {"switches_per_minute": <float>} in replay_events.payload.
+	var payload struct {
+		SwitchesPerMinute float64 `json:"switches_per_minute"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &payload); err == nil {
+		return payload.SwitchesPerMinute, true
+	}
+	// Fallback: legacy rows persisted the rate as a plain float string.
+	value, err := strconv.ParseFloat(trimmed, 64)
 	if err != nil {
 		return 0, false
 	}
@@ -251,7 +271,7 @@ func (d *Dashboard) populateViewportMultitaskingForGameDetail(detail *workflowGa
 		return nil
 	}
 
-	rows, err := d.dbStore.ListViewportGameRows(d.ctx, detail.ReplayID, models.PatternNameViewportMultitasking)
+	rows, err := d.dbStore.ListViewportGameRows(d.ctx, detail.ReplayID, viewportMultitaskingFeatureKey)
 	if err != nil {
 		return fmt.Errorf("failed to load game viewport multitasking patterns: %w", err)
 	}

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -342,6 +342,7 @@ const gameEventDescription = (event, registry) => {
   }
   if (eventType === 'became_terran') return actor ? `${actor} became Terran` : 'Became Terran';
   if (eventType === 'became_zerg') return actor ? `${actor} became Zerg` : 'Became Zerg';
+  if (eventType === 'mech_transition') return actor ? `${actor} transitions to Mech` : 'Mech transition';
   return prettyPatternName(event?.type || 'event');
 };
 
@@ -445,6 +446,7 @@ const renderGameEventDescription = (event, registry) => {
   }
   if (eventType === 'became_terran') return actorName ? <>{actorSpan} became Terran</> : 'Became Terran';
   if (eventType === 'became_zerg') return actorName ? <>{actorSpan} became Zerg</> : 'Became Zerg';
+  if (eventType === 'mech_transition') return actorName ? <>{actorSpan} transitions to Mech</> : 'Mech transition';
   return prettyPatternName(event?.type || 'event');
 };
 
@@ -1099,9 +1101,22 @@ const shouldHidePatternFromSummaryPills = (pattern, trustGameEventsForDrops) => 
   return false;
 };
 
-const filterSummaryPillPatterns = (patterns, trustGameEventsForDrops = false) => (
-  (patterns || []).filter((pattern) => !shouldHidePatternFromSummaryPills(pattern, trustGameEventsForDrops))
-);
+const filterSummaryPillPatterns = (patterns, trustGameEventsForDrops = false) => {
+  const filtered = (patterns || []).filter((pattern) => !shouldHidePatternFromSummaryPills(pattern, trustGameEventsForDrops));
+  // Stable-sort by detected_second so pills read chronologically (BO first,
+  // then mid-game markers like SK Terran / Mech Transition). Patterns
+  // without a detected_second (e.g. unit-composition rollups) sort to the
+  // end. Hotkey markers carry an end-of-replay second already, so they
+  // naturally land after timed markers.
+  const indexed = filtered.map((pattern, idx) => ({ pattern, idx }));
+  indexed.sort((a, b) => {
+    const ta = Number.isFinite(a.pattern?.detected_second) ? a.pattern.detected_second : Number.POSITIVE_INFINITY;
+    const tb = Number.isFinite(b.pattern?.detected_second) ? b.pattern.detected_second : Number.POSITIVE_INFINITY;
+    if (ta !== tb) return ta - tb;
+    return a.idx - b.idx;
+  });
+  return indexed.map((entry) => entry.pattern);
+};
 
 // renderPatternPill resolves a detected_patterns[] entry through the backend
 // marker registry and builds a pill from the registered SummaryPlayer metadata.
@@ -2914,11 +2929,14 @@ function App() {
     return <img src={url} alt={race || ''} title={race || ''} className="workflow-race-icon" />;
   };
 
-  const renderMainGameListPlayers = (game) => {
+  const renderMainGameListPlayers = (game, linkPlayerNames = true) => {
     const players = Array.isArray(game?.players) ? game.players : [];
     if (players.length === 0) {
       return renderPlayersMatchup(game?.players_label || '');
     }
+    const renderName = (player) => (linkPlayerNames
+      ? renderPlayerLinkLabel(player.name, player.player_key)
+      : renderPlayerLabel(player.name, player.player_key));
     const stackingMarker = game?.team_stacking ? (
       <span
         className="workflow-team-stacking-marker"
@@ -2938,7 +2956,7 @@ function App() {
             <span key={`${player.player_id}-${idx}`}>
               {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
               {renderWorkerIcon(player.race)}
-              {renderPlayerLinkLabel(player.name, player.player_key)}
+              {renderName(player)}
               {idx < players.length - 1 ? ', ' : ''}
             </span>
           ))}
@@ -2962,7 +2980,7 @@ function App() {
                 >
                   {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
                   {renderWorkerIcon(player.race)}
-                  {renderPlayerLinkLabel(player.name, player.player_key)}
+                  {renderName(player)}
                 </span>
               ))}
             </span>
@@ -3947,7 +3965,7 @@ function App() {
                     {mainGames.map((game) => (
                       <tr key={game.replay_id} className={selectedReplayId === game.replay_id ? 'workflow-selected-row' : ''} onClick={() => openMainGame(game.replay_id)}>
                         <td>{formatRelativeReplayDate(game.replay_date)}</td>
-                        <td>{renderMainGameListPlayers(game)}</td>
+                        <td>{renderMainGameListPlayers(game, false)}</td>
                         <td>{formatMapNameWithKind(game.map_name, game.map_kind)}</td>
                         <td>{formatDuration(game.duration_seconds)}</td>
                         <td>

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -2084,6 +2084,12 @@ body {
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 2px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.workflow-games-filter-row::-webkit-scrollbar {
+  display: none;
 }
 
 .workflow-games-filter-row>* {
@@ -2096,6 +2102,12 @@ body {
   overflow-y: hidden;
   max-width: none;
   min-height: 30px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.workflow-games-filter-pills::-webkit-scrollbar {
+  display: none;
 }
 
 .workflow-summary-filter-input,
@@ -2608,6 +2620,15 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+}
+
+/* When a player line overflows, keep the pill container on the same row as
+   name+actions (filling remaining width) so pills wrap inside the container
+   and the second row starts at the first pill's column rather than under the
+   player name. */
+.workflow-player-line > .workflow-pattern-pills {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .workflow-pattern-pill {
@@ -3944,12 +3965,21 @@ body {
   gap: 0.2em;
   padding: 0.08em 0.45em 0.1em;
   border-radius: 999px;
-  font-size: 0.92em;
-  line-height: 1.25;
+  font-size: 1.01em;
+  line-height: 1.8;
   border: 1px solid rgba(255, 255, 255, 0.1);
   max-width: 100%;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
+}
+
+.workflow-team-player-pill .workflow-race-icon {
+  width: 25px;
+  height: 25px;
+}
+
+.workflow-team-player-pill .workflow-crown {
+  font-size: 1.0em;
 }
 
 .workflow-inline-warning {

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -9,7 +9,7 @@ import (
 
 // AlgorithmVersion is the current version of the pattern detection algorithm
 // Increment this when the algorithm changes to trigger re-detection
-const AlgorithmVersion = 20
+const AlgorithmVersion = 21
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -637,8 +637,8 @@ func allMarkers() []Marker {
 			// Factory. The 2nd Rax — when present — typically arrives
 			// AFTER the CC (e.g. D-B-D-C-B), which is why a separate
 			// "2-Rax CC" BO would over-fragment the data.
-			Name:        "Rax-CC",
-			PatternName: "Build Order: Rax-CC",
+			Name:        "1 Rax FE",
+			PatternName: "Build Order: 1 Rax FE",
 			FeatureKey:  "bo_rax_cc",
 			Race:        RaceTerran,
 			Matchup:     []string{"TvT", "PvT", "TvZ"},
@@ -659,8 +659,8 @@ func allMarkers() []Marker {
 				{Key: "Command Center", Match: MatchBuild(subjCommandCenter), TargetSecond: 180, Tolerance: Sym(18)},
 				{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 195, Tolerance: Sym(18)},
 			},
-			SummaryPlayer: &Pill{Label: "Rax-CC", IconKey: "commandcenter"},
-			GamesList:     &Pill{Label: "Rax-CC", IconKey: "commandcenter"},
+			SummaryPlayer: &Pill{Label: "1 Rax FE", IconKey: "commandcenter"},
+			GamesList:     &Pill{Label: "1 Rax FE", IconKey: "commandcenter"},
 		},
 		{
 			// BBS: confirmed in the dataset (e.g. SST_JumJaJungJi opens
@@ -768,8 +768,8 @@ func allMarkers() []Marker {
 				FirstProduceExists(subjMedic),
 			),
 			RuleDeadline:  480,
-			SummaryPlayer: &Pill{IconKey: "medic", Style: PillStyleStrong, Title: "SK Terran"},
-			GamesList:     &Pill{IconKey: "medic", Style: PillStyleStrong, Title: "SK Terran"},
+			SummaryPlayer: &Pill{Label: "SK Terran", IconKey: "marine", Style: PillStyleStrong, Title: "SK Terran"},
+			GamesList:     &Pill{Label: "SK Terran", IconKey: "marine", Style: PillStyleStrong, Title: "SK Terran"},
 		},
 		{
 			// Mech transition (TvZ only): bio start (Medic produced ≤330s)
@@ -785,7 +785,7 @@ func allMarkers() []Marker {
 			Matchup:       []string{"TvZ"},
 			Custom:        func() CustomEvaluator { return &mechTransitionEvaluator{} },
 			RuleDeadline:  endOfReplaySentinel,
-			SummaryPlayer: &Pill{Label: "Mech transition at min {minute}", IconKey: "siegetank"},
+			SummaryPlayer: &Pill{Label: "Mech Transition", IconKey: "siegetank"},
 			GamesList:     &Pill{Label: "Mech transition", IconKey: "siegetank"},
 		},
 		{

--- a/internal/patterns/markers/definitions_test.go
+++ b/internal/patterns/markers/definitions_test.go
@@ -407,33 +407,33 @@ func TestBO_CCFirst(t *testing.T) {
 }
 
 func TestBO_RaxCC(t *testing.T) {
-	bo := findBO(t, "Rax-CC")
+	bo := findBO(t, "1 Rax FE")
 	// Positive: Depot, Rax, CC, Refinery (CC before gas + Factory).
 	pos := factsBuilder().
 		B(subjSupplyDepot, 60).B(subjBarracks, 88).
 		B(subjCommandCenter, 180).B(subjRefinery, 195).list()
 	if !bo.Matches(pos) {
-		t.Fatalf("Rax-CC should match Rax → CC → Refinery sequence")
+		t.Fatalf("1 Rax FE should match Rax → CC → Refinery sequence")
 	}
 	// Negative: Refinery before CC.
 	neg := factsBuilder().
 		B(subjSupplyDepot, 60).B(subjBarracks, 88).
 		B(subjRefinery, 115).B(subjCommandCenter, 180).list()
 	if bo.Matches(neg) {
-		t.Fatalf("Rax-CC should fail when Refinery precedes CC")
+		t.Fatalf("1 Rax FE should fail when Refinery precedes CC")
 	}
 	// Negative: 2 Rax before CC.
 	neg2 := factsBuilder().
 		B(subjSupplyDepot, 60).B(subjBarracks, 88).B(subjBarracks, 130).
 		B(subjCommandCenter, 180).list()
 	if bo.Matches(neg2) {
-		t.Fatalf("Rax-CC should fail with 2 Barracks before CC")
+		t.Fatalf("1 Rax FE should fail with 2 Barracks before CC")
 	}
 	// Negative: CC before Barracks (CC First).
 	neg3 := factsBuilder().
 		B(subjSupplyDepot, 60).B(subjCommandCenter, 145).B(subjBarracks, 165).list()
 	if bo.Matches(neg3) {
-		t.Fatalf("Rax-CC should fail when CC precedes Barracks")
+		t.Fatalf("1 Rax FE should fail when CC precedes Barracks")
 	}
 }
 

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -28,7 +28,7 @@
       },
       {
         "replay_player_id": 1,
-        "pattern_name": "Build Order: Rax-CC",
+        "pattern_name": "Build Order: 1 Rax FE",
         "value": "{\"expert_actuals\":[{\"second\":55,\"found\":true},{\"second\":85,\"found\":true},{\"second\":161,\"found\":true},{\"second\":174,\"found\":true}]}"
       },
       {
@@ -87,7 +87,7 @@
       },
       {
         "replay_player_id": 1,
-        "pattern_name": "Build Order: Rax-CC",
+        "pattern_name": "Build Order: 1 Rax FE",
         "value": "{\"expert_actuals\":[{\"second\":58,\"found\":true},{\"second\":87,\"found\":true},{\"second\":171,\"found\":true},{\"second\":174,\"found\":true}]}"
       },
       {

--- a/internal/patterns/worldstate/events_compose.go
+++ b/internal/patterns/worldstate/events_compose.go
@@ -257,6 +257,13 @@ func (e *Engine) emitAttackCandidates(candidates []CandidateAttack) {
 	reaverDropEmitted := map[byte]bool{}
 	scoutEmitted := map[byte]bool{}
 
+	// Mid-map attack fallback: hold the earliest neutral-defender attack
+	// candidate so we can promote it post-loop when the replay would
+	// otherwise have zero attack events. Picks up 1v1 mid-map fights where
+	// pressure opens on an unowned polygon and emitAttackIfImportant would
+	// reject every candidate as defender=neutral.
+	var earliestNeutralAttack *CandidateAttack
+
 	for _, c := range candidates {
 		if e.sameTeam(c.Attacker, c.Defender) {
 			continue
@@ -273,10 +280,48 @@ func (e *Engine) emitAttackCandidates(candidates []CandidateAttack) {
 		case "drop":
 			e.emitDropCandidate(c, cmdByFrame[c.Frame], reaverDropEmitted, firstTankSecByPlayer)
 		case "attack":
+			if c.Defender == neutralPID {
+				if earliestNeutralAttack == nil || c.Second < earliestNeutralAttack.Second {
+					cc := c
+					earliestNeutralAttack = &cc
+				}
+				continue
+			}
 			e.emitAttackIfImportant(c, cmdByFrame[c.Frame], spellsByAttacker,
 				attackedAlready, knownUnitsByAttacker, knownSpellsByAttacker)
 		}
 	}
+
+	if len(attackedAlready) == 0 && earliestNeutralAttack != nil {
+		if opp, ok := e.singleOpponentHuman(earliestNeutralAttack.Attacker); ok {
+			c := *earliestNeutralAttack
+			c.Defender = opp
+			e.emitAttackIfImportant(c, cmdByFrame[c.Frame], spellsByAttacker,
+				attackedAlready, knownUnitsByAttacker, knownSpellsByAttacker)
+		}
+	}
+}
+
+// singleOpponentHuman returns the single opposing human player when there's
+// exactly one — i.e. 1v1 melee. Used by the mid-map attack fallback to
+// attribute defender for a neutral-polygon attack candidate.
+func (e *Engine) singleOpponentHuman(attacker byte) (byte, bool) {
+	var opp byte = neutralPID
+	count := 0
+	for _, pid := range e.humanPlayerIDs {
+		if pid == attacker {
+			continue
+		}
+		if e.sameTeam(pid, attacker) {
+			continue
+		}
+		opp = pid
+		count++
+	}
+	if count == 1 {
+		return opp, true
+	}
+	return neutralPID, false
 }
 
 func (e *Engine) emitScoutCandidate(c CandidateAttack, cmd *models.Command) {


### PR DESCRIPTION
## Summary

UI polish, two narrative-event additions, and two bug fixes that surfaced via game inspection on real replays. AlgorithmVersion bumped 20 → 21 because one fix writes new rows into `replay_events` (re-ingest needed to pick it up on existing replays).

### UI / pills
- Game-list player pills enlarged: race icon 14→25px, line-height 1.8, name +10%, crown 1.0em
- Player names inside game-list pills are plain colored text (no longer link buttons that hijack row clicks)
- When a player line overflows, pills wrap inside the pill container so the second row aligns with the first pill (not under the player name)
- Filter row hides the horizontal scrollbar when chips overflow
- Mech Transition filter chip gets text ("Mech transition") alongside its two icons
- Mech Transition summary pill: drops "{minute}", just "Mech Transition"
- SK Terran pill (summary + games-list): marine icon + "SK Terran" label in both surfaces
- Per-player summary pills sort by `detected_second` (BO → mid-game markers → hotkeys / unit comps)
- Team Stacking moved to the end of the marker filter list
- Build order **Rax-CC → 1 Rax FE** (Name, PatternName, all pill labels, filter chip; `FeatureKey` left as `bo_rax_cc` so DB rows + golden don't move)

### Game events / narrative
- **Mid-map attack fallback**: in 1v1s where pressure opens on an unowned polygon and the replay would otherwise emit zero attack events, promote the earliest neutral-defender candidate with defender = the single opposing human. Catches mid-map decider fights that the importance filter currently rejects (`defender=neutral`)
- **Mech transition** now surfaces in the Game Events list at the exact second the marker committed: "{player} transitions to Mech"

### Bug fixes
- **Viewport switch rate showed nothing** after the markers-into-replay_events migration (#99). Two regressions stacked:
  - `endpoint_players_insight_viewport` queried by `PatternName` ("Viewport Multitasking") but the SQL filters `event_type`, which stores marker `FeatureKey` ("viewport_multitasking") → 0 rows
  - `parseViewportSwitchRate` did `strconv.ParseFloat` on the payload, but the evaluator stores `{"switches_per_minute":<float>}` as JSON → all rows discarded
  - Fix: pass FeatureKey to the queries; JSON-unmarshal the payload, fall back to plain-float for legacy rows
- **Phase boundaries wrong on the per-game events list**: `populatePhaseMarkersForGameDetail` was recomputing at request time with an action-type filter (`"Train"` / `"Morph"`) that skipped `"Unit Morph"` rows — i.e. every Zerg larva morph (mutas, lurkers, defilers, ultras). For TvZ this fell back to Siege Tank+Mode + Terran +2, pushing MID GAME 9+ minutes late. Replaced with a read of the persisted `mid_game_starts` / `late_game_starts` markers via the existing `GetPhaseBoundariesForReplay` (already used by attacker-composition). Old recompute + `lookupFirstUnit` helper deleted.

### Re-ingest

`AlgorithmVersion` bumped 20 → 21. Required by the mid-map attack fallback (writes a new `replay_events` row in some 1v1 replays). Existing replays will be re-detected on next pass.

## Test plan
- [x] `go test ./internal/patterns/...` — green
- [x] Backend `go build ./...` — clean
- [ ] Visual: rebuild frontend (`make ui-build`) and confirm:
  - [ ] Player pills in game list are visibly bigger, pills row 2 aligns with pill column 1
  - [ ] No scrollbar on filter row when chips overflow horizontally
  - [ ] Team Stacking chip is at the end of marker filters
  - [ ] Mech Transition filter chip shows "Mech transition" text alongside its icons
  - [ ] SK Terran pill on replay summary + per-player rows: marine icon + "SK Terran"
  - [ ] Build order chip and pills say "1 Rax FE"
  - [ ] Per-player summary pills are time-ordered (BO first, hotkeys / unit comps last)
- [ ] Re-ingest the database (`AlgorithmVersion` bump triggers it). Then on a 1v1 with a mid-map decider (e.g. KnockOut MM-73196E7C-…rep), confirm there is now an "X attacks Y at …" entry in the events list around 9:51
- [ ] On replay 76 (TvZ KnockOut, MM-EA08D1F4-…rep): MID GAME header appears between 5:11 (first muta) and the next event; LATE GAME header appears between 11:49 (first defiler) and 12:50
- [ ] Viewport switch rate populates again on the players insight tab and per-replay viewport widget
- [ ] Mech transition Terran replay shows a "{player} transitions to Mech" row in the Game Events list

🤖 Generated with [Claude Code](https://claude.com/claude-code)