### PR TITLE
feat: alliances tab — clique-based detection + Sankey timeline

### DIFF
--- a/internal/dashboard/endpoint_main_game_alliance_context.go
+++ b/internal/dashboard/endpoint_main_game_alliance_context.go
@@ -1,0 +1,170 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// populatePlayerDepartureForGameDetail backfills per-player LeftSecond /
+// LeaveReason from the already-populated GameEvents (leave_game and
+// player_stopped_playing) plus the raw commands.leave_reason for an exact
+// reason string. This is shipped on detail.Players so the Alliances tab can
+// truncate player lines at the moment a player stopped playing.
+func (d *Dashboard) populatePlayerDepartureForGameDetail(detail *workflowGameDetail) error {
+	if len(detail.Players) == 0 {
+		return nil
+	}
+
+	// Index player rows by ID for fast lookup / write-back.
+	playerByID := map[int64]*workflowGamePlayer{}
+	for i := range detail.Players {
+		p := &detail.Players[i]
+		playerByID[p.PlayerID] = p
+	}
+
+	// Pull the earliest leave_game / player_stopped_playing second from the
+	// already-populated GameEvents slice. This avoids a second round-trip and
+	// guarantees consistency with what the Events list shows.
+	type departure struct {
+		Second int64
+		Reason string
+	}
+	deparByPID := map[int64]departure{}
+	for _, ev := range detail.GameEvents {
+		if ev.Actor == nil {
+			continue
+		}
+		pid := ev.Actor.PlayerID
+		switch ev.Type {
+		case "leave_game":
+			cur, ok := deparByPID[pid]
+			if !ok || ev.Second < cur.Second {
+				deparByPID[pid] = departure{Second: ev.Second, Reason: "Left"}
+			}
+		case "player_stopped_playing":
+			cur, ok := deparByPID[pid]
+			if !ok || ev.Second < cur.Second {
+				deparByPID[pid] = departure{Second: ev.Second, Reason: "Stopped"}
+			}
+		}
+	}
+
+	// Replace the generic "Left" with the screp leave-reason enum (Quit,
+	// Defeat, Dropped, Finished, Draw, Victory, UNKNOWN). The data lives on
+	// commands.leave_reason — we only fetch when there's at least one
+	// leave_game event to enrich.
+	hasLeaveGame := false
+	for _, dep := range deparByPID {
+		if dep.Reason == "Left" {
+			hasLeaveGame = true
+			break
+		}
+	}
+	if hasLeaveGame {
+		rows, err := d.dbStore.ReplayQueryContext(d.ctx,
+			`SELECT c.player_id, COALESCE(c.leave_reason, '')
+			 FROM commands c
+			 WHERE c.replay_id = ?
+			   AND c.action_type = 'Leave Game'
+			   AND c.leave_reason IS NOT NULL
+			 UNION ALL
+			 SELECT c.player_id, COALESCE(c.leave_reason, '')
+			 FROM commands_low_value c
+			 WHERE c.replay_id = ?
+			   AND c.action_type = 'Leave Game'
+			   AND c.leave_reason IS NOT NULL`,
+			detail.ReplayID, detail.ReplayID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to query leave reasons: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var pid int64
+			var reason string
+			if err := rows.Scan(&pid, &reason); err != nil {
+				return fmt.Errorf("failed to scan leave reason: %w", err)
+			}
+			reason = strings.TrimSpace(reason)
+			if reason == "" {
+				continue
+			}
+			if dep, ok := deparByPID[pid]; ok && dep.Reason == "Left" {
+				dep.Reason = reason
+				deparByPID[pid] = dep
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to iterate leave reasons: %w", err)
+		}
+	}
+
+	for pid, dep := range deparByPID {
+		player, ok := playerByID[pid]
+		if !ok {
+			continue
+		}
+		s := dep.Second
+		player.LeftSecond = &s
+		player.LeaveReason = dep.Reason
+	}
+	return nil
+}
+
+// populateAllianceTabChatForGameDetail attaches the per-replay chat stream to
+// the Alliances tab response. Only runs for Melee games with more than two
+// active players (the same gate the alliance timeline uses, so the field is
+// present together with the topology timeline that needs it).
+func (d *Dashboard) populateAllianceTabChatForGameDetail(detail *workflowGameDetail) error {
+	if detail.GameType != "Melee" {
+		return nil
+	}
+	if len(detail.AllianceTimeline) == 0 {
+		// AllianceTimeline is the source of truth for "does the alliance tab
+		// even render": it stays empty when the alliance populator's
+		// ≤2-active-player gate trips. Mirror that condition here so we don't
+		// ship chat for games that aren't surfacing the tab.
+		return nil
+	}
+
+	rows, err := d.dbStore.ReplayQueryContext(d.ctx,
+		`SELECT c.seconds_from_game_start, c.player_id, COALESCE(c.chat_message, '')
+		 FROM commands c
+		 WHERE c.replay_id = ?
+		   AND c.chat_message IS NOT NULL
+		   AND trim(c.chat_message) <> ''
+		 UNION ALL
+		 SELECT c.seconds_from_game_start, c.player_id, COALESCE(c.chat_message, '')
+		 FROM commands_low_value c
+		 WHERE c.replay_id = ?
+		   AND c.chat_message IS NOT NULL
+		   AND trim(c.chat_message) <> ''
+		 ORDER BY 1 ASC, 2 ASC`,
+		detail.ReplayID, detail.ReplayID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to query alliance-tab chat: %w", err)
+	}
+	defer rows.Close()
+	out := []workflowAllianceChat{}
+	for rows.Next() {
+		var second int64
+		var pid int64
+		var message string
+		if err := rows.Scan(&second, &pid, &message); err != nil {
+			return fmt.Errorf("failed to scan chat row: %w", err)
+		}
+		out = append(out, workflowAllianceChat{
+			Second:   second,
+			PlayerID: pid,
+			Message:  message,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate chat rows: %w", err)
+	}
+	if len(out) > 0 {
+		detail.AllianceTabChat = out
+	}
+	return nil
+}

--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -118,6 +118,12 @@ func (d *Dashboard) buildWorkflowGameDetail(replayID int64) (workflowGameDetail,
 	if err := d.populateAllianceTimelineForGameDetail(&detail); err != nil {
 		return detail, err
 	}
+	if err := d.populatePlayerDepartureForGameDetail(&detail); err != nil {
+		return detail, err
+	}
+	if err := d.populateAllianceTabChatForGameDetail(&detail); err != nil {
+		return detail, err
+	}
 
 	return detail, nil
 }

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -325,6 +325,14 @@ type workflowGamePlayer struct {
 	APM              int64                  `json:"apm"`
 	EAPM             int64                  `json:"eapm"`
 	DetectedPatterns []workflowPatternValue `json:"detected_patterns"`
+	// LeftSecond is the earliest second the player became inactive — either an
+	// explicit Leave Game command or the inactivity-derived
+	// player_stopped_playing event. Nil when the player played to the end.
+	LeftSecond *int64 `json:"left_second,omitempty"`
+	// LeaveReason mirrors the LeaveGameCmd reason ("Quit", "Defeat", "Dropped",
+	// "Finished", "Draw", "Victory", "UNKNOWN") when LeftSecond is set by a
+	// leave_game event, or "Stopped" when set by player_stopped_playing.
+	LeaveReason string `json:"leave_reason,omitempty"`
 }
 
 // workflowPatternValue is the per-pattern entry shipped to the frontend inside
@@ -369,6 +377,10 @@ type workflowGameDetail struct {
 	MutaliskTimingSummary *workflowMutaliskTimingSummary `json:"mutalisk_timing_summary,omitempty"`
 	AllianceTimeline     []workflowAllianceSnapshot               `json:"alliance_timeline,omitempty"`
 	AllianceStackingThresholdSeconds int64                        `json:"alliance_stacking_threshold_seconds,omitempty"`
+	// AllianceTabChat is the full per-replay chat stream surfaced exclusively
+	// for the Alliances tab's context panel. Each entry is one chat command
+	// keyed to the player who sent it. Empty for non-melee or ≤2-player games.
+	AllianceTabChat []workflowAllianceChat `json:"alliance_tab_chat,omitempty"`
 
 	// EarlyGameEndsAtSecond / MidGameEndsAtSecond split the game-events list
 	// into Early/Mid/Late sections. Computed from unit-completion + research
@@ -393,6 +405,15 @@ type workflowAllianceSnapshot struct {
 	Sec      int64     `json:"sec"`
 	Teams    [][]int64 `json:"teams"`
 	Stacking bool      `json:"stacking"`
+}
+
+// workflowAllianceChat is one chat message attached to the Alliances tab.
+// Player_id matches the players[].player_id (DB row id). Message is the raw
+// text the player sent; the frontend handles any escaping for display.
+type workflowAllianceChat struct {
+	Second   int64  `json:"second"`
+	PlayerID int64  `json:"player_id"`
+	Message  string `json:"message"`
 }
 
 // workflowMarkerPlayer carries per-player Build Orders tab data:

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -5482,9 +5482,14 @@ function App() {
                     <AllianceTimeline
                       players={Array.isArray(mainGame?.players) ? mainGame.players : []}
                       timeline={Array.isArray(mainGame?.alliance_timeline) ? mainGame.alliance_timeline : []}
+                      chat={Array.isArray(mainGame?.alliance_tab_chat) ? mainGame.alliance_tab_chat : []}
+                      gameEvents={Array.isArray(mainGame?.game_events) ? mainGame.game_events : []}
                       durationSeconds={mainGame?.duration_seconds || 0}
+                      earlyEndsAt={mainGame?.early_game_ends_at_second || 0}
+                      midEndsAt={mainGame?.mid_game_ends_at_second || 0}
                       stackingThresholdSeconds={mainGame?.alliance_stacking_threshold_seconds || 300}
                       getRaceIcon={getWorkerIconForRace}
+                      getPlayerColor={(p) => playerColorToCss(p?.color)}
                     />
                   </div>
                 )}

--- a/internal/dashboard/frontend/src/components/charts/AllianceTimeline.jsx
+++ b/internal/dashboard/frontend/src/components/charts/AllianceTimeline.jsx
@@ -1,69 +1,170 @@
 import React, { useMemo, useRef, useState, useEffect } from 'react';
 
-// AllianceTimeline renders the alliance-topology timeline for a multi-player
-// melee game. Layout (per the picked visualization):
-//   ┌─────────────────────────────────────────┐
-//   │   GRAPH of current topology             │  top, ~60% height
-//   │   nodes = players, colored by team      │
-//   │   edges = mutual alliances              │
-//   ├─────────────────────────────────────────┤
-//   │   PHASE BANDS  | red where stacking     │  middle: scrub strip
-//   │   ●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ►       │  scrubber thumb on time axis
-//   │   0:00                       18:42       │
-//   └─────────────────────────────────────────┘
+// AllianceTimeline renders alliance topology as a Sankey-style flow.
+// Time runs top-to-bottom on a non-linear axis (rows = significant events
+// only). Each player owns a vertical lane that terminates when they leave or
+// stop playing. Team membership at each row is shown as a translucent pill
+// hugging the contiguous columns of allied players. A right-hand context
+// panel — chat, alliance diffs, departures, military events near departures
+// — anchors each event to its time row.
 //
 // Inputs:
-//   players: [{ player_id, name, race, team }] — used for node labels/icons.
-//   timeline: [{ sec, teams: [[player_id, ...], ...], stacking }] — ordered.
+//   players: [{ player_id, name, race, team, color, left_second, leave_reason }]
+//   timeline: [{ sec, teams: [[player_id, ...], ...], stacking }]
+//   chat: [{ second, player_id, message }]
+//   gameEvents: [{ type, second, actor, target, ... }] — the full game-event
+//                stream; we filter for attack/drop/recall/nuke near departures.
 //   durationSeconds: number
-//   stackingThresholdSeconds: number — bands longer than this earn 😈.
+//   earlyEndsAt / midEndsAt: number (phase-boundary seconds)
+//   stackingThresholdSeconds: number — bands ≥ this earn the stacked badge.
 //   getRaceIcon: race -> url (or null)
 
-const NODE_RADIUS = 22;
-const NODE_LABEL_GAP = 6;
-const NODE_LABEL_HEIGHT = 16;
-const TEAM_GAP = 60;
-const PLAYER_GAP = 12;
-const GRAPH_TOP_PADDING = 18;
-const GRAPH_BOTTOM_PADDING = 10;
-const STRIP_HEIGHT = 32;
-const STRIP_TOP_PADDING = 28;
-const TIME_AXIS_HEIGHT = 22;
-
+// Fallback palette used only when a player has no recognizable BW colour name.
 const TEAM_COLORS = ['#60A5FA', '#F472B6', '#34D399', '#FBBF24', '#A78BFA', '#22D3EE', '#FB7185', '#4ADE80'];
+
+// playerHexColor returns a player's in-game BW colour via the resolver passed
+// in by the host (App.jsx wraps the engine's screp-colors map). Falls back to
+// the palette above when the resolver is missing or doesn't know the name —
+// e.g. for synthetic player ids or pre-bootstrapped renders.
+const playerHexColor = (player, getPlayerColor) => {
+  if (!player) return TEAM_COLORS[0];
+  if (typeof getPlayerColor === 'function') {
+    const resolved = getPlayerColor(player);
+    if (resolved && /^#?[0-9a-fA-F]{3,8}$/.test(String(resolved).trim())) {
+      const v = String(resolved).trim();
+      return v.startsWith('#') ? v : `#${v}`;
+    }
+  }
+  return TEAM_COLORS[Math.abs(Number(player.player_id) || 0) % TEAM_COLORS.length];
+};
+const ROW_MIN_HEIGHT = 110;
+const EVENT_ROW_HEIGHT = 30; // Each event entry's vertical footprint in the side panel.
+const EVENT_ROW_TOP_OFFSET = 18; // Top padding inside a row group before the first event.
+// How many rows of stable column position can pass before the player's name
+// is re-rendered above their node so the reader stays oriented in long games.
+const NAME_REFRESH_INTERVAL = 4;
+const TOP_PAD = 60;
+const BOTTOM_PAD = 32;
+const COL_MIN_WIDTH = 80;
+const NODE_R = 18;
+const LEFT_LABEL_W = 78;
+const RIGHT_PANEL_MIN_W = 320;
+const RIGHT_PANEL_PAD_LEFT = 16;
+
+// Events within this many seconds of a departure are surfaced as context.
+const NEAR_DEPARTURE_WINDOW_SEC = 60;
+// Two events closer than this in seconds collapse onto one row.
+const ROW_MERGE_SEC = 1;
+// Generic events ≥ this gap from the prior row introduce a new row even
+// without an alliance change — so the right-hand event panel has a row to
+// dock against. Set conservatively so we don't add too many rows.
+const STANDALONE_EVENT_MIN_GAP_SEC = 0;
 
 const formatMMSS = (sec) => {
   const v = Math.max(0, Math.floor(Number(sec) || 0));
   return `${Math.floor(v / 60)}:${String(v % 60).padStart(2, '0')}`;
 };
 
-// Map a team's min-pid to a stable color. Same team-membership across
-// snapshots keeps the same color; merged/split teams pick up new colors,
-// which is the right behavior — those *are* different teams.
-const colorForTeam = (team) => {
-  if (!team || !team.length) return TEAM_COLORS[0];
-  return TEAM_COLORS[Math.abs(Number(team[0]) || 0) % TEAM_COLORS.length];
+// Team-level colour: use the BW colour of the team's lowest-pid member when
+// available. This keeps a player's colour (and the lines/arcs touching them)
+// in sync with the in-game replay colour they had.
+const teamColor = (pids, playerByID, getPlayerColor) => {
+  if (!pids || pids.length === 0) return TEAM_COLORS[0];
+  const p = playerByID ? playerByID[pids[0]] : null;
+  return playerHexColor(p || { player_id: pids[0] }, getPlayerColor);
 };
 
-// Format like "2v2v2 + 1 solo" — useful labels for the strip.
+// "4v2v1" style label — used inside team pills with ≥2 teams visible.
 const teamShape = (teams) => {
-  const sizes = teams.map((t) => t.length);
-  const nonSolo = sizes.filter((s) => s >= 2).sort((a, b) => b - a);
-  const solo = sizes.filter((s) => s === 1).length;
-  const left = nonSolo.length > 0 ? nonSolo.join('v') : '';
-  const right = solo > 0 ? `${solo} solo` : '';
-  if (left && right) return `${left} + ${right}`;
-  if (left) return left;
-  if (right) return right;
-  return '—';
+  const sizes = teams.map((t) => t.length).filter((n) => n >= 1);
+  if (sizes.length < 2) return '';
+  return sizes.sort((a, b) => b - a).join('v');
+};
+
+const isStacked = (teams) => {
+  const sizes = teams.map((t) => t.length).filter((n) => n >= 2);
+  if (sizes.length < 2) return false;
+  return new Set(sizes).size > 1;
+};
+
+// Phase tag for a row second based on early/mid boundary markers.
+const phaseTagFor = (sec, earlyEndsAt, midEndsAt) => {
+  const s = Number(sec) || 0;
+  if (s <= 0) return 'START';
+  if (earlyEndsAt > 0 && s < earlyEndsAt) return 'EARLY';
+  if (midEndsAt > 0 && s < midEndsAt) return 'MID';
+  if (midEndsAt > 0) return 'LATE';
+  if (earlyEndsAt > 0) return 'MID';
+  return '';
+};
+
+// Diff teams[t-1] vs teams[t] and return human-readable change pills.
+// rowSec is the second of the *new* row — we use it (with playerByID's
+// left_second) to suppress "× break" events that are merely the side-effect
+// of a player departing. The player's line already terminates visually; a
+// separate break pill would just be noise.
+const diffTopology = (prevTeams, nextTeams, playerByID, rowSec, getPlayerColor) => {
+  const prevPairs = new Set();
+  const nextPairs = new Set();
+  const addPairs = (teams, target) => {
+    for (const t of teams) {
+      for (let i = 0; i < t.length; i += 1) {
+        for (let j = i + 1; j < t.length; j += 1) {
+          const a = t[i];
+          const b = t[j];
+          const key = a < b ? `${a}|${b}` : `${b}|${a}`;
+          target.add(key);
+        }
+      }
+    }
+  };
+  addPairs(prevTeams || [], prevPairs);
+  addPairs(nextTeams || [], nextPairs);
+  const added = [];
+  const removed = [];
+  for (const k of nextPairs) if (!prevPairs.has(k)) added.push(k);
+  for (const k of prevPairs) if (!nextPairs.has(k)) removed.push(k);
+  const nameOf = (pid) => (playerByID[pid]?.name || `#${pid}`);
+  const colorOf = (pid) => {
+    const p = playerByID[pid];
+    if (!p) return null;
+    return playerHexColor(p, getPlayerColor);
+  };
+  const departedBy = (pid) => {
+    const p = playerByID[pid];
+    if (!p || p.left_second == null) return false;
+    return Number(p.left_second) <= rowSec;
+  };
+  const out = [];
+  for (const k of added) {
+    const [a, b] = k.split('|').map(Number);
+    out.push({ kind: 'ally', a: nameOf(a), b: nameOf(b), colorA: colorOf(a), colorB: colorOf(b) });
+  }
+  for (const k of removed) {
+    const [a, b] = k.split('|').map(Number);
+    // Skip pair-removals where either member has departed by this row — the
+    // terminating line already explains the lost alliance.
+    if (departedBy(a) || departedBy(b)) continue;
+    out.push({ kind: 'break', a: nameOf(a), b: nameOf(b), colorA: colorOf(a), colorB: colorOf(b) });
+  }
+  const wasStacked = isStacked(prevTeams || []);
+  const nowStacked = isStacked(nextTeams || []);
+  if (!wasStacked && nowStacked) out.push({ kind: 'stack' });
+  if (wasStacked && !nowStacked) out.push({ kind: 'unstack' });
+  return out;
 };
 
 const AllianceTimeline = ({
   players = [],
   timeline = [],
+  chat = [],
+  gameEvents = [],
   durationSeconds = 0,
+  earlyEndsAt = 0,
+  midEndsAt = 0,
   stackingThresholdSeconds = 300,
   getRaceIcon,
+  getPlayerColor,
 }) => {
   const playerByID = useMemo(() => {
     const m = {};
@@ -73,326 +174,780 @@ const AllianceTimeline = ({
     return m;
   }, [players]);
 
-  // Phases: each timeline entry plus its end second.
-  const phases = useMemo(() => {
-    const safe = Array.isArray(timeline) ? timeline : [];
-    return safe.map((snap, idx) => {
-      const start = Math.max(0, Number(snap.sec) || 0);
-      const end = idx + 1 < safe.length
-        ? Math.max(start, Number(safe[idx + 1].sec) || start)
-        : Math.max(start, Number(durationSeconds) || start);
-      return {
-        sec: start,
-        endSec: end,
-        durationSec: end - start,
-        teams: Array.isArray(snap.teams) ? snap.teams : [],
-        stacking: !!snap.stacking,
-      };
-    });
-  }, [timeline, durationSeconds]);
+  // Active (non-observer) players in API order. Backend already filters
+  // is_observer=0, but be defensive.
+  const activePlayers = useMemo(
+    () => players.filter((p) => p && p.player_id != null),
+    [players],
+  );
 
-  // Default scrubber position: phase with longest duration. Tie-break to the
-  // phase with mutual alliances (stacking or otherwise).
-  const defaultIdx = useMemo(() => {
-    if (phases.length === 0) return 0;
-    let best = 0;
-    let bestDur = -1;
-    for (let i = 0; i < phases.length; i += 1) {
-      const ph = phases[i];
-      const hasMutual = ph.teams.some((t) => t.length >= 2);
-      if (
-        ph.durationSec > bestDur
-        || (ph.durationSec === bestDur && hasMutual && !phases[best].teams.some((t) => t.length >= 2))
-      ) {
-        best = i;
-        bestDur = ph.durationSec;
+  // ── Phase rows ─────────────────────────────────────────────────────────
+  // A row = a distinct time point. Each snapshot in the alliance timeline
+  // emits a row; each player departure (left_second) emits a row if it
+  // doesn't already coincide with an alliance event. We always anchor a
+  // final row at duration_seconds so terminating lines have somewhere to
+  // run to.
+  const rows = useMemo(() => {
+    const snaps = (Array.isArray(timeline) ? timeline : []).map((s) => ({
+      sec: Math.max(0, Number(s.sec) || 0),
+      teams: Array.isArray(s.teams) ? s.teams.map((t) => t.slice()) : [],
+      stackingSrc: !!s.stacking,
+    }));
+    if (snaps.length === 0) return [];
+
+    const secs = new Set();
+    snaps.forEach((s) => secs.add(s.sec));
+    for (const p of activePlayers) {
+      if (p.left_second != null) {
+        secs.add(Math.max(0, Number(p.left_second) || 0));
       }
     }
-    return best;
-  }, [phases]);
+    if (durationSeconds > 0) secs.add(Math.max(0, Number(durationSeconds) || 0));
 
-  const [phaseIdx, setPhaseIdx] = useState(defaultIdx);
-  useEffect(() => { setPhaseIdx(defaultIdx); }, [defaultIdx]);
+    // Merge near-duplicates so we don't get two rows for events 1 second apart
+    // (e.g. snapshot at sec=64 + departure at sec=64).
+    const sortedSecs = Array.from(secs).sort((a, b) => a - b);
+    const mergedSecs = [];
+    for (const s of sortedSecs) {
+      if (mergedSecs.length === 0 || s - mergedSecs[mergedSecs.length - 1] > ROW_MERGE_SEC) {
+        mergedSecs.push(s);
+      }
+    }
 
-  const stripRef = useRef(null);
-  const [stripWidth, setStripWidth] = useState(800);
+    const snapAtOrBefore = (sec) => {
+      let best = snaps[0];
+      for (const s of snaps) {
+        if (s.sec <= sec) best = s;
+      }
+      return best;
+    };
+
+    return mergedSecs.map((sec) => {
+      const snap = snapAtOrBefore(sec);
+      const teams = snap.teams
+        .map((t) => t.filter((pid) => {
+          const p = playerByID[pid];
+          if (!p) return false;
+          if (p.left_second != null && Number(p.left_second) < sec) return false;
+          return true;
+        }))
+        .filter((t) => t.length > 0);
+      const departures = activePlayers
+        .filter((p) => p.left_second != null && Math.abs(Number(p.left_second) - sec) <= ROW_MERGE_SEC)
+        .map((p) => p.player_id);
+      return { sec, teams, stacking: isStacked(teams), departures };
+    });
+  }, [timeline, activePlayers, playerByID, durationSeconds]);
+
+  // ── Column ordering per row ────────────────────────────────────────────
+  // Per-row layout: place the first (largest, lowest-min) clique, then
+  // repeatedly pick the unplaced clique that shares the most members with
+  // what's already laid down. That's the natural chain order for non-
+  // transitive alliances (D-C-Y-f stays D-C-Y-f rather than being shuffled
+  // into D-C-f-Y). Departed players keep their last-known column index so
+  // their terminating "x" lands where the lane was.
+  const computeRowOrder = (row, prev) => {
+    const remaining = row.teams.map((_, i) => i);
+    const placed = new Set();
+    const newOrderActive = [];
+    const placeMembers = (team) => {
+      const toPlace = team.filter((pid) => !placed.has(pid));
+      const retained = toPlace
+        .filter((pid) => prev.includes(pid))
+        .sort((a, b) => prev.indexOf(a) - prev.indexOf(b));
+      const newcomers = toPlace
+        .filter((pid) => !prev.includes(pid))
+        .sort((a, b) => a - b);
+      for (const pid of [...retained, ...newcomers]) {
+        newOrderActive.push(pid);
+        placed.add(pid);
+      }
+    };
+    while (remaining.length > 0) {
+      let bestIdx = 0;
+      let bestKey = null;
+      for (let i = 0; i < remaining.length; i += 1) {
+        const ti = remaining[i];
+        const team = row.teams[ti];
+        const overlap = team.reduce((acc, pid) => acc + (placed.has(pid) ? 1 : 0), 0);
+        const size = team.length;
+        const idxs = team.map((pid) => prev.indexOf(pid)).filter((v) => v >= 0);
+        const centroid = idxs.length === 0
+          ? Number.MAX_SAFE_INTEGER
+          : idxs.reduce((a, v) => a + v, 0) / idxs.length;
+        // Priority: extend the existing layout (overlap), then preserve the
+        // prev-row position of the team's centroid (-centroid), THEN prefer
+        // larger cliques as a tiebreaker. Putting -centroid before size
+        // stops a newly-formed bigger clique from hijacking column 0 just
+        // because it has more members than the pair currently anchored
+        // there — concretely, the {D,C,Y} triangle at 11:28 stays in its
+        // home columns instead of swapping with chobo+FA.
+        const key = [overlap, -centroid, size, -ti];
+        if (
+          bestKey === null
+          || key[0] > bestKey[0]
+          || (key[0] === bestKey[0] && key[1] > bestKey[1])
+          || (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] > bestKey[2])
+          || (key[0] === bestKey[0] && key[1] === bestKey[1] && key[2] === bestKey[2] && key[3] > bestKey[3])
+        ) {
+          bestKey = key;
+          bestIdx = i;
+        }
+      }
+      const ti = remaining[bestIdx];
+      remaining.splice(bestIdx, 1);
+      placeMembers(row.teams[ti]);
+    }
+
+    const newOrder = newOrderActive.slice();
+    for (const pid of row.departures) {
+      if (newOrder.includes(pid)) continue;
+      const prevIdx = prev.indexOf(pid);
+      if (prevIdx < 0) {
+        newOrder.push(pid);
+        continue;
+      }
+      const target = Math.min(prevIdx, newOrder.length);
+      newOrder.splice(target, 0, pid);
+    }
+    return newOrder;
+  };
+
+  // simulate(initialOrder) walks every row applying computeRowOrder, returns
+  // both the resulting column arrays AND a quality score (lower = better).
+  // The score charges 2 points for each player whose column index shifts
+  // between consecutive rows (visual line crossing) and 1 point per column
+  // of arc length (pair-allied players placed far apart). With both terms
+  // we get layouts that are *stable* (chobo + FA never swap) AND have
+  // adjacent arcs (chain D-C-Y-f naturally lined up).
+  const simulateOrder = (initialOrder) => {
+    const cols = [];
+    let movement = 0;
+    let arcLen = 0;
+    let prev = initialOrder.slice();
+    for (let ri = 0; ri < rows.length; ri += 1) {
+      const row = rows[ri];
+      const newOrder = computeRowOrder(row, prev);
+      cols.push(newOrder);
+      for (let i = 0; i < newOrder.length; i += 1) {
+        const prevIdx = prev.indexOf(newOrder[i]);
+        if (prevIdx >= 0) movement += Math.abs(i - prevIdx);
+      }
+      for (const team of row.teams) {
+        if (team.length === 2) {
+          const c1 = newOrder.indexOf(team[0]);
+          const c2 = newOrder.indexOf(team[1]);
+          if (c1 >= 0 && c2 >= 0) arcLen += Math.abs(c1 - c2) - 1;
+        }
+      }
+      prev = newOrder.filter((pid) => !row.departures.includes(pid));
+    }
+    return { cols, score: movement * 2 + arcLen };
+  };
+
+  // Compute the BEST initial column order to minimise total movement and
+  // arc length. Players who never appear in a size-≥2 clique anywhere in
+  // the timeline ("permanent solos" — e.g. someone whose ally requests are
+  // never reciprocated, like RememberMyName in replay 500) get pinned to
+  // the end of the lineup: their position has no impact on movement or
+  // arc-length scoring, so multiple permutations tie. Without this pin the
+  // first tied perm encountered in iteration wins, which can drop a solo
+  // randomly into the middle of an otherwise stable lineup.
+  const { columns, initialOrder } = useMemo(() => {
+    if (rows.length === 0) return { columns: [], initialOrder: [] };
+    const pidList = activePlayers.map((p) => p.player_id);
+    const isPermaSolo = (pid) => {
+      for (const row of rows) {
+        for (const team of row.teams) {
+          if (team.length >= 2 && team.includes(pid)) return false;
+        }
+      }
+      return true;
+    };
+    const permaSolos = pidList.filter(isPermaSolo);
+    const nonSolos = pidList.filter((pid) => !permaSolos.includes(pid));
+    if (nonSolos.length > 8) {
+      const fallback = [...nonSolos, ...permaSolos];
+      const r = simulateOrder(fallback);
+      return { columns: r.cols, initialOrder: fallback };
+    }
+    const permute = (arr) => {
+      if (arr.length <= 1) return [arr];
+      const out = [];
+      for (let i = 0; i < arr.length; i += 1) {
+        const rest = arr.slice(0, i).concat(arr.slice(i + 1));
+        for (const p of permute(rest)) out.push([arr[i], ...p]);
+      }
+      return out;
+    };
+    let bestOrder = [...nonSolos, ...permaSolos];
+    let bestCols = null;
+    let bestScore = Infinity;
+    for (const perm of permute(nonSolos)) {
+      const candidate = [...perm, ...permaSolos];
+      const { cols, score } = simulateOrder(candidate);
+      if (score < bestScore) {
+        bestScore = score;
+        bestOrder = candidate;
+        bestCols = cols;
+      }
+    }
+    return { columns: bestCols || [], initialOrder: bestOrder };
+    // computeRowOrder + simulateOrder are stable closures over `rows` which
+    // is itself a useMemo — only those identities matter for dep tracking.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows, activePlayers]);
+
+  // ── Layout dimensions ──────────────────────────────────────────────────
+  const wrapRef = useRef(null);
+  const [wrapWidth, setWrapWidth] = useState(960);
   useEffect(() => {
-    const el = stripRef.current;
+    const el = wrapRef.current;
     if (!el) return undefined;
     const ro = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const w = Math.floor(entry.contentRect.width);
-        if (w > 0) setStripWidth(w);
+        if (w > 0) setWrapWidth(w);
       }
     });
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
 
-  if (phases.length === 0) {
+  // ── Context panel rows (computed before layout so row heights can flex) ─
+  // For each row index, gather the events that "belong" to it. Kept above
+  // the early-return guard so hook order stays stable across renders.
+  const eventsByRowIdx = useMemo(() => {
+    const out = rows.map(() => []);
+    if (rows.length === 0) return out;
+    const rowSecOf = (sec) => {
+      // Pick the row whose sec is closest to the event — so an attack at
+      // 17:21 buckets to the 17:44 row (near the departure it correlates
+      // with), not the 4:55 row (last alliance change before it).
+      let chosen = 0;
+      let bestDist = Infinity;
+      for (let i = 0; i < rows.length; i += 1) {
+        const d = Math.abs(rows[i].sec - sec);
+        if (d < bestDist) {
+          bestDist = d;
+          chosen = i;
+        }
+      }
+      return chosen;
+    };
+
+    for (let ri = 0; ri < rows.length; ri += 1) {
+      const prev = ri === 0 ? [] : rows[ri - 1].teams;
+      const diffs = diffTopology(prev, rows[ri].teams, playerByID, rows[ri].sec);
+      for (const d of diffs) {
+        out[ri].push({ sec: rows[ri].sec, kind: d.kind, data: d, sort: 0 });
+      }
+    }
+
+    for (let ri = 0; ri < rows.length; ri += 1) {
+      for (const pid of rows[ri].departures) {
+        const p = playerByID[pid];
+        if (!p) continue;
+        // "Stopped" (inactivity-derived) gets its own visual treatment from
+        // an explicit quit — the player didn't formally leave, they just
+        // stopped issuing meaningful commands.
+        const reason = p.leave_reason || 'Left';
+        const kind = reason === 'Stopped' ? 'stopped' : 'depart';
+        out[ri].push({
+          sec: rows[ri].sec,
+          kind,
+          data: { pid, name: p.name, reason },
+          sort: 1,
+        });
+      }
+    }
+
+    for (const c of chat || []) {
+      const ri = rowSecOf(Number(c.second) || 0);
+      const p = playerByID[c.player_id];
+      out[ri].push({
+        sec: Number(c.second) || 0,
+        kind: 'chat',
+        data: {
+          name: p?.name || `#${c.player_id}`,
+          message: c.message,
+          color: p ? playerHexColor(p, getPlayerColor) : '#cbd5e1',
+        },
+        sort: 2,
+      });
+    }
+
+    const departureSet = new Set();
+    for (let ri = 0; ri < rows.length; ri += 1) {
+      for (const pid of rows[ri].departures) departureSet.add(pid);
+    }
+    if (departureSet.size > 0) {
+      for (const ev of gameEvents || []) {
+        const type = String(ev.type || '');
+        if (type !== 'attack' && type !== 'drop' && type !== 'reaver_drop'
+          && type !== 'dt_drop' && type !== 'cliff_drop'
+          && type !== 'recall' && type !== 'nuke') continue;
+        const actorPid = ev.actor?.player_id;
+        const targetPid = ev.target?.player_id;
+        const evSec = Number(ev.second) || 0;
+        let nearby = false;
+        let relevant = false;
+        for (const pid of departureSet) {
+          const p = playerByID[pid];
+          if (!p || p.left_second == null) continue;
+          const leftSec = Number(p.left_second) || 0;
+          if (Math.abs(evSec - leftSec) > NEAR_DEPARTURE_WINDOW_SEC) continue;
+          nearby = true;
+          if (actorPid === pid || targetPid === pid) { relevant = true; break; }
+        }
+        if (!nearby || !relevant) continue;
+        const ri = rowSecOf(evSec);
+        const actor = playerByID[actorPid];
+        const target = playerByID[targetPid];
+        out[ri].push({
+          sec: evSec,
+          kind: type,
+          data: {
+            actor: actor?.name || ev.actor?.name || '',
+            target: target?.name || ev.target?.name || '',
+            actorColor: actor ? playerHexColor(actor, getPlayerColor) : null,
+            targetColor: target ? playerHexColor(target, getPlayerColor) : null,
+          },
+          sort: 3,
+        });
+      }
+    }
+
+    for (const list of out) {
+      list.sort((a, b) => {
+        if (a.sec !== b.sec) return a.sec - b.sec;
+        return a.sort - b.sort;
+      });
+    }
+    return out;
+  }, [rows, chat, gameEvents, playerByID]);
+
+  if (rows.length === 0 || activePlayers.length === 0) {
     return (
       <div className="workflow-card">
-        <div className="chart-empty">No alliance commands recorded for this game.</div>
+        <div className="chart-empty">No alliance information available for this game.</div>
       </div>
     );
   }
 
-  const currentPhase = phases[Math.min(phaseIdx, phases.length - 1)];
-  const totalDur = Math.max(durationSeconds, phases[phases.length - 1].endSec) || 1;
+  // Per-row Y coordinates — each row gets enough space to fit its events
+  // without overflowing into the next row. Both SVG and the right panel
+  // index into rowYs[] for vertical positioning.
+  const rowYs = [];
+  let cursorY = TOP_PAD;
+  for (let ri = 0; ri < rows.length; ri += 1) {
+    rowYs.push(cursorY);
+    const eventCount = (eventsByRowIdx[ri] || []).length;
+    const eventsHeight = eventCount > 0
+      ? EVENT_ROW_TOP_OFFSET + eventCount * EVENT_ROW_HEIGHT + 6
+      : 0;
+    const spacing = Math.max(ROW_MIN_HEIGHT, eventsHeight);
+    cursorY += spacing;
+  }
+  const rowY = (i) => rowYs[i];
+  const svgHeight = (rowYs[rows.length - 1] || TOP_PAD) + BOTTOM_PAD;
 
-  // ── Graph layout (current snapshot) ─────────────────────────────────────
-  // Lay out teams left-to-right; players within each team are stacked
-  // vertically. Solo teams collapse to a "Free agents" column on the right.
-  const teamsForGraph = currentPhase.teams.slice().sort((a, b) => {
-    // Non-solo teams first (largest first), then solos.
-    if ((a.length >= 2) !== (b.length >= 2)) return a.length >= 2 ? -1 : 1;
-    if (a.length !== b.length) return b.length - a.length;
-    return Number(a[0] || 0) - Number(b[0] || 0);
-  });
+  const numCols = activePlayers.length;
+  // Right panel takes a fixed minimum; SVG takes the remainder. If the
+  // viewport is narrow the SVG stretches horizontally with min-width per col.
+  const rightPanelWidth = Math.max(RIGHT_PANEL_MIN_W, Math.min(420, Math.floor(wrapWidth * 0.36)));
+  const svgWidthBudget = Math.max(360, wrapWidth - rightPanelWidth - RIGHT_PANEL_PAD_LEFT);
+  const colsSpace = svgWidthBudget - LEFT_LABEL_W - 24;
+  const colW = Math.max(COL_MIN_WIDTH, Math.floor(colsSpace / numCols));
+  const svgWidth = LEFT_LABEL_W + colW * numCols + 24;
+  const colX = (i) => LEFT_LABEL_W + colW * i + colW / 2;
 
-  const nodeBlockHeight = (NODE_RADIUS * 2) + NODE_LABEL_GAP + NODE_LABEL_HEIGHT;
-  const tallestTeam = Math.max(1, ...teamsForGraph.map((t) => t.length));
-  const graphHeight = GRAPH_TOP_PADDING
-    + (tallestTeam * nodeBlockHeight)
-    + ((tallestTeam - 1) * PLAYER_GAP)
-    + GRAPH_BOTTOM_PADDING;
-  const teamWidth = NODE_RADIUS * 2 + 60;
-  const graphWidth = Math.max(
-    240,
-    teamsForGraph.length * teamWidth + (Math.max(0, teamsForGraph.length - 1) * TEAM_GAP) + 32,
-  );
-
-  const teamColumns = teamsForGraph.map((team, teamIdx) => {
-    const cx = 16 + (teamIdx * (teamWidth + TEAM_GAP)) + (teamWidth / 2);
-    const nodes = team.map((pid, i) => {
-      const cy = GRAPH_TOP_PADDING + NODE_RADIUS + i * (nodeBlockHeight + PLAYER_GAP);
-      const player = playerByID[pid] || { name: `#${pid}`, race: '' };
-      return { pid, cx, cy, player };
-    });
-    return { team, color: colorForTeam(team), nodes };
-  });
-
-  const edges = [];
-  teamColumns.forEach((col) => {
-    if (col.nodes.length < 2) return;
-    for (let i = 0; i < col.nodes.length - 1; i += 1) {
-      const a = col.nodes[i];
-      const b = col.nodes[i + 1];
-      edges.push({ from: a, to: b, color: col.color });
-    }
-  });
-
-  // ── Strip layout ────────────────────────────────────────────────────────
-  const stripScale = (sec) => (Math.max(0, Math.min(totalDur, sec)) / totalDur) * stripWidth;
-
-  const handleStripClick = (event) => {
-    const rect = stripRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const x = event.clientX - rect.left;
-    const sec = (x / Math.max(1, rect.width)) * totalDur;
-    let nearest = 0;
-    let nearestDelta = Infinity;
-    for (let i = 0; i < phases.length; i += 1) {
-      const ph = phases[i];
-      // Pick the phase containing this second; fallback to nearest start.
-      if (sec >= ph.sec && sec < ph.endSec) {
-        nearest = i;
-        nearestDelta = 0;
+  // For each player, walk through rows and collect their (rowIdx, x, y).
+  // Lines terminate at the row in which they appear in the departures list.
+  const playerPaths = activePlayers.map((p) => {
+    const points = [];
+    let terminated = false;
+    for (let ri = 0; ri < rows.length; ri += 1) {
+      const ord = columns[ri] || [];
+      const idx = ord.indexOf(p.player_id);
+      if (idx < 0) continue;
+      points.push({ rowIdx: ri, x: colX(idx), y: rowY(ri) });
+      if (rows[ri].departures.includes(p.player_id)) {
+        terminated = true;
         break;
       }
-      const delta = Math.abs(ph.sec - sec);
-      if (delta < nearestDelta) {
-        nearestDelta = delta;
-        nearest = i;
-      }
     }
-    setPhaseIdx(nearest);
+    return { player: p, points, terminated };
+  });
+
+  // Team rendering: each maximal clique becomes either an arc (size 2) or
+  // a rounded pill (size ≥3). Arcs are how non-transitive alliances stay
+  // honest — a chain A↔B↔C↔D draws three separate arcs, not one fake
+  // 4-stack pill. A player who appears in multiple cliques contributes to
+  // each of them (e.g. C draws both the A-C arc and the B-C arc) without
+  // any pretense that A and B are themselves allied.
+  const pills = [];
+  const arcs = [];
+  for (let ri = 0; ri < rows.length; ri += 1) {
+    const row = rows[ri];
+    const ord = columns[ri] || [];
+    for (const team of row.teams) {
+      if (team.length < 2) continue;
+      const cols = team
+        .map((pid) => ord.indexOf(pid))
+        .filter((v) => v >= 0);
+      if (cols.length < 2) continue;
+      if (team.length === 2) {
+        const [c1, c2] = cols.sort((a, b) => a - b);
+        arcs.push({
+          ri,
+          x1: colX(c1),
+          x2: colX(c2),
+          y: rowY(ri),
+          color: teamColor(team, playerByID, getPlayerColor),
+          stacking: row.stacking,
+        });
+        continue;
+      }
+      // size ≥ 3 → render as an enclosing rounded pill (clique implies all
+      // members are mutually allied, so a single enclosing rectangle is
+      // faithful).
+      const xs = cols.map((i) => colX(i));
+      const minX = Math.min(...xs) - NODE_R - 6;
+      const maxX = Math.max(...xs) + NODE_R + 6;
+      pills.push({
+        ri,
+        x: minX,
+        y: rowY(ri) - NODE_R - 6,
+        w: maxX - minX,
+        h: NODE_R * 2 + 12,
+        color: teamColor(team, playerByID, getPlayerColor),
+        stacking: row.stacking,
+        label: `${team.length}-stack`,
+      });
+    }
+  }
+
+  // Single-glyph emoji badges per event kind. Words ("ally", "break", etc.)
+  // are dropped — the colored pill + emoji conveys the type, and the body
+  // text already names the actors.
+  const kindBadgeLabel = (k) => {
+    if (k === 'ally') return '🤝';
+    if (k === 'break') return '💔';
+    if (k === 'stack') return '😈';
+    if (k === 'unstack') return '🕊️';
+    if (k === 'depart') return '🏳️';
+    if (k === 'stopped') return '💤';
+    if (k === 'chat') return '💬';
+    if (k === 'attack') return '⚔️';
+    if (k === 'drop' || k === 'reaver_drop' || k === 'dt_drop' || k === 'cliff_drop') return '🪂';
+    if (k === 'recall') return '🌀';
+    if (k === 'nuke') return '☢️';
+    return k;
   };
 
-  // ── Render ──────────────────────────────────────────────────────────────
+  const kindBadgeClass = (k) => `workflow-alliance-event-badge workflow-alliance-event-badge-${k.replace('_', '-')}`;
+
+  // ── Render ─────────────────────────────────────────────────────────────
   return (
-    <div className="workflow-card workflow-alliance-timeline">
-      <div className="workflow-alliance-graph-wrap" style={{ overflowX: 'auto' }}>
-        <svg
-          width={graphWidth}
-          height={graphHeight}
-          viewBox={`0 0 ${graphWidth} ${graphHeight}`}
-          className="workflow-alliance-graph"
-        >
-          {edges.map((e, idx) => (
-            <line
-              key={`edge-${idx}`}
-              x1={e.from.cx}
-              y1={e.from.cy}
-              x2={e.to.cx}
-              y2={e.to.cy}
-              stroke={e.color}
-              strokeWidth={2}
-              strokeOpacity={0.55}
-            />
-          ))}
-          {teamColumns.flatMap((col) => col.nodes.map((n) => {
-            const icon = getRaceIcon ? getRaceIcon(n.player.race) : null;
-            const labelY = n.cy + NODE_RADIUS + NODE_LABEL_GAP + (NODE_LABEL_HEIGHT * 0.7);
-            return (
-              <g key={`node-${n.pid}`}>
-                <circle
-                  cx={n.cx}
-                  cy={n.cy}
-                  r={NODE_RADIUS}
-                  fill={col.color}
-                  fillOpacity={0.22}
-                  stroke={col.color}
-                  strokeWidth={2}
-                />
-                {icon ? (
-                  <image
-                    href={icon}
-                    x={n.cx - 13}
-                    y={n.cy - 13}
-                    width={26}
-                    height={26}
-                  />
-                ) : (
+    <div className="workflow-card workflow-alliance-timeline-v2" ref={wrapRef}>
+      <div className="workflow-alliance-timeline-grid" style={{ gridTemplateColumns: `${svgWidth}px ${rightPanelWidth}px` }}>
+        <div className="workflow-alliance-svg-wrap">
+          <svg
+            width={svgWidth}
+            height={svgHeight}
+            viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+            className="workflow-alliance-svg"
+            preserveAspectRatio="xMinYMin meet"
+          >
+            {/* Faint row guides */}
+            {rows.map((r, ri) => (
+              <line
+                key={`row-guide-${ri}`}
+                x1={LEFT_LABEL_W - 4}
+                x2={svgWidth - 8}
+                y1={rowY(ri)}
+                y2={rowY(ri)}
+                stroke="rgba(148,163,184,0.10)"
+                strokeWidth={1}
+              />
+            ))}
+
+            {/* Time + phase labels on the left gutter */}
+            {rows.map((r, ri) => {
+              const tag = phaseTagFor(r.sec, earlyEndsAt, midEndsAt);
+              return (
+                <g key={`row-label-${ri}`}>
                   <text
-                    x={n.cx}
-                    y={n.cy + 4}
-                    textAnchor="middle"
+                    x={LEFT_LABEL_W - 10}
+                    y={rowY(ri) + 4}
+                    textAnchor="end"
                     fontSize={12}
-                    fill="#e5e7eb"
+                    fill="#cbd5e1"
                   >
-                    {String(n.player.race || '?').slice(0, 1).toUpperCase()}
+                    {ri === 0 && r.sec === 0 ? 'START' : formatMMSS(r.sec)}
                   </text>
-                )}
+                  {tag
+                    && tag !== 'START'
+                    && (ri === 0 || tag !== phaseTagFor(rows[ri - 1].sec, earlyEndsAt, midEndsAt)) ? (
+                    <text
+                      x={LEFT_LABEL_W - 10}
+                      y={rowY(ri) - 14}
+                      textAnchor="end"
+                      fontSize={9}
+                      fill="#64748b"
+                      letterSpacing={1}
+                    >
+                      {tag}
+                    </text>
+                  ) : null}
+                </g>
+              );
+            })}
+
+            {/* Pair arcs (drawn under nodes/lines). Curves above the node row
+                so vertical player lines stay visually unbroken. */}
+            {arcs.map((a, i) => {
+              const lift = Math.min(28, 8 + Math.abs(a.x2 - a.x1) * 0.18);
+              const cy = a.y - lift;
+              const d = `M ${a.x1} ${a.y} Q ${(a.x1 + a.x2) / 2} ${cy}, ${a.x2} ${a.y}`;
+              return (
+                <path
+                  key={`arc-${i}`}
+                  d={d}
+                  fill="none"
+                  stroke={a.stacking ? 'rgba(248, 113, 113, 0.7)' : 'rgba(148, 163, 184, 0.7)'}
+                  strokeWidth={a.stacking ? 3 : 2}
+                  strokeLinecap="round"
+                  opacity={0.85}
+                />
+              );
+            })}
+
+            {/* Clique pills (size ≥3 — every pair within is mutually allied). */}
+            {pills.map((p, i) => (
+              <rect
+                key={`pill-${i}`}
+                x={p.x}
+                y={p.y}
+                width={p.w}
+                height={p.h}
+                rx={p.h / 2}
+                fill={p.stacking ? 'rgba(248, 113, 113, 0.18)' : 'rgba(96, 165, 250, 0.14)'}
+                stroke={p.stacking ? 'rgba(248, 113, 113, 0.55)' : 'rgba(148, 163, 184, 0.45)'}
+                strokeWidth={1}
+              />
+            ))}
+            {/* Stacking label per row — sized from the largest clique present.
+                Sizes only count cliques of size ≥3 since pair-cliques carry no
+                stacking signal under the new model. */}
+            {rows.map((r, ri) => {
+              if (!r.stacking) return null;
+              const ord = columns[ri] || [];
+              const maxIdx = Math.max(0, Math.max(...ord.map((_, i) => i)));
+              const x = colX(maxIdx) + NODE_R + 8;
+              const cliqueSizes = r.teams
+                .map((t) => t.length)
+                .filter((n) => n >= 2)
+                .sort((a, b) => b - a);
+              const label = cliqueSizes.length >= 2 ? `${cliqueSizes.join('v')} stacked` : 'stacked';
+              return (
                 <text
-                  x={n.cx}
-                  y={labelY}
-                  textAnchor="middle"
+                  key={`stack-${ri}`}
+                  x={x}
+                  y={rowY(ri) + 4}
                   fontSize={11}
-                  fill="#cbd5e1"
+                  fill="#fca5a5"
+                  fontWeight="600"
                 >
-                  {String(n.player.name || `#${n.pid}`).slice(0, 14)}
+                  {label}
                 </text>
-              </g>
-            );
-          }))}
-        </svg>
-      </div>
+              );
+            })}
 
-      <div className="workflow-alliance-strip-meta">
-        <span>
-          <strong>{teamShape(currentPhase.teams)}</strong>
-          {' '}from {formatMMSS(currentPhase.sec)} to {formatMMSS(currentPhase.endSec)}
-          {currentPhase.stacking ? <span title="Uneven non-solo team sizes" style={{ marginLeft: 6 }}>😈</span> : null}
-        </span>
-      </div>
+            {/* Player lines (cubic-bezier between rows) */}
+            {playerPaths.map(({ player, points, terminated }) => {
+              if (points.length === 0) return null;
+              const color = playerHexColor(player, getPlayerColor);
+              const segs = [];
+              for (let i = 0; i < points.length - 1; i += 1) {
+                const p1 = points[i];
+                const p2 = points[i + 1];
+                const dy = (p2.y - p1.y) * 0.4;
+                segs.push(`M ${p1.x} ${p1.y} C ${p1.x} ${p1.y + dy}, ${p2.x} ${p2.y - dy}, ${p2.x} ${p2.y}`);
+              }
+              return (
+                <g key={`line-${player.player_id}`}>
+                  {segs.map((d, si) => (
+                    <path
+                      key={`seg-${si}`}
+                      d={d}
+                      stroke={color}
+                      strokeWidth={2}
+                      fill="none"
+                      strokeLinecap="round"
+                      opacity={0.85}
+                    />
+                  ))}
+                  {terminated ? (
+                    <g transform={`translate(${points[points.length - 1].x},${points[points.length - 1].y + NODE_R + 4})`}>
+                      <line x1={-5} y1={-5} x2={5} y2={5} stroke={color} strokeWidth={2} />
+                      <line x1={-5} y1={5} x2={5} y2={-5} stroke={color} strokeWidth={2} />
+                    </g>
+                  ) : null}
+                </g>
+              );
+            })}
 
-      <div
-        ref={stripRef}
-        className="workflow-alliance-strip"
-        onClick={handleStripClick}
-        role="slider"
-        tabIndex={0}
-        aria-valuemin={0}
-        aria-valuemax={totalDur}
-        aria-valuenow={currentPhase.sec}
-        style={{ position: 'relative', height: STRIP_TOP_PADDING + STRIP_HEIGHT + TIME_AXIS_HEIGHT, cursor: 'pointer', userSelect: 'none' }}
-      >
-        <svg
-          width="100%"
-          height={STRIP_TOP_PADDING + STRIP_HEIGHT + TIME_AXIS_HEIGHT}
-          viewBox={`0 0 ${stripWidth} ${STRIP_TOP_PADDING + STRIP_HEIGHT + TIME_AXIS_HEIGHT}`}
-          preserveAspectRatio="none"
-          style={{ display: 'block' }}
-        >
-          {phases.map((ph, i) => {
-            const x1 = stripScale(ph.sec);
-            const x2 = stripScale(ph.endSec);
-            const w = Math.max(1, x2 - x1);
-            const stacking = ph.stacking;
-            const isLongStack = stacking && ph.durationSec > stackingThresholdSeconds;
-            const isCurrent = i === phaseIdx;
+            {/* Player nodes per row (drawn last so they sit on top of lines/pills).
+                Names are re-rendered whenever the player swaps columns vs the
+                previous row, plus every NAME_REFRESH_INTERVAL rows even without
+                a swap so the reader doesn't lose track in long stable runs. */}
+            {playerPaths.map(({ player, points }) => {
+              const color = playerHexColor(player, getPlayerColor);
+              const icon = getRaceIcon ? getRaceIcon(player.race) : null;
+              const displayName = String(player.name || `#${player.player_id}`).slice(0, 14);
+              // Precompute which rows show this player's name.
+              const showNameAt = new Set();
+              let lastNamedRow = -Infinity;
+              let lastCol = -1;
+              for (let pi = 0; pi < points.length; pi += 1) {
+                const pt = points[pi];
+                const ord = columns[pt.rowIdx] || [];
+                const colIdx = ord.indexOf(player.player_id);
+                const colChanged = pi > 0 && colIdx !== lastCol;
+                const farFromLast = pt.rowIdx - lastNamedRow >= NAME_REFRESH_INTERVAL;
+                if (pi === 0 || colChanged || farFromLast) {
+                  showNameAt.add(pt.rowIdx);
+                  lastNamedRow = pt.rowIdx;
+                }
+                lastCol = colIdx;
+              }
+              // Approximate text width for backdrop (SVG can't measure pre-paint).
+              const nameW = Math.max(28, Math.min(120, displayName.length * 7 + 8));
+              return points.map((pt) => (
+                <g key={`node-${player.player_id}-${pt.rowIdx}`}>
+                  <circle
+                    cx={pt.x}
+                    cy={pt.y}
+                    r={NODE_R}
+                    fill={color}
+                    fillOpacity={0.25}
+                    stroke={color}
+                    strokeWidth={2}
+                  />
+                  {icon ? (
+                    <image
+                      href={icon}
+                      x={pt.x - 11}
+                      y={pt.y - 11}
+                      width={22}
+                      height={22}
+                    />
+                  ) : (
+                    <text
+                      x={pt.x}
+                      y={pt.y + 4}
+                      textAnchor="middle"
+                      fontSize={11}
+                      fill="#e5e7eb"
+                    >
+                      {String(player.race || '?').slice(0, 1).toUpperCase()}
+                    </text>
+                  )}
+                  {showNameAt.has(pt.rowIdx) ? (
+                    <g>
+                      <rect
+                        x={pt.x - nameW / 2}
+                        y={pt.y - NODE_R - 18}
+                        width={nameW}
+                        height={15}
+                        rx={3}
+                        fill="rgba(15, 23, 42, 0.92)"
+                        stroke={color}
+                        strokeWidth={1}
+                        strokeOpacity={0.55}
+                      />
+                      <text
+                        x={pt.x}
+                        y={pt.y - NODE_R - 7}
+                        textAnchor="middle"
+                        fontSize={10}
+                        fill="#e5e7eb"
+                        fontWeight="500"
+                      >
+                        {displayName}
+                      </text>
+                    </g>
+                  ) : null}
+                </g>
+              ));
+            })}
+          </svg>
+        </div>
+
+        {/* Right context panel — events anchored to rows. */}
+        <div className="workflow-alliance-context-panel" style={{ height: svgHeight, position: 'relative' }}>
+          {rows.map((r, ri) => {
+            const list = eventsByRowIdx[ri] || [];
+            if (list.length === 0) return null;
+            const top = rowY(ri) - 18;
             return (
-              <g key={`phase-${i}`}>
-                <rect
-                  x={x1}
-                  y={STRIP_TOP_PADDING}
-                  width={w}
-                  height={STRIP_HEIGHT}
-                  fill={stacking ? 'rgba(248, 113, 113, 0.45)' : 'rgba(96, 165, 250, 0.25)'}
-                  stroke={isCurrent ? '#fbbf24' : 'rgba(255,255,255,0.18)'}
-                  strokeWidth={isCurrent ? 2 : 1}
-                />
-                {w > 50 ? (
-                  <text
-                    x={x1 + w / 2}
-                    y={STRIP_TOP_PADDING + STRIP_HEIGHT / 2 + 4}
-                    textAnchor="middle"
-                    fontSize={11}
-                    fill="#e5e7eb"
-                    style={{ pointerEvents: 'none' }}
+              <div
+                key={`ctx-row-${ri}`}
+                className="workflow-alliance-context-row"
+                style={{ position: 'absolute', top, left: 0, right: 0 }}
+              >
+                {list.map((ev, i) => (
+                  <div
+                    key={`ev-${ri}-${i}`}
+                    className="workflow-alliance-event"
+                    title={ev.kind === 'chat' ? `${ev.data.name}: "${ev.data.message}"` : undefined}
                   >
-                    {teamShape(ph.teams)}
-                  </text>
-                ) : null}
-                {isLongStack ? (
-                  <text
-                    x={x1 + 6}
-                    y={STRIP_TOP_PADDING - 8}
-                    fontSize={16}
-                  >
-                    😈
-                  </text>
-                ) : null}
-              </g>
+                    <span className="workflow-alliance-event-time">{formatMMSS(ev.sec)}</span>
+                    <span className={kindBadgeClass(ev.kind)}>{kindBadgeLabel(ev.kind)}</span>
+                    <span className="workflow-alliance-event-body">
+                      {ev.kind === 'ally' || ev.kind === 'break' ? (
+                        <>
+                          <span style={{ color: ev.data.colorA || '#cbd5e1' }}>{ev.data.a}</span>
+                          {' '}{ev.kind === 'ally' ? '⇌' : '⇎'}{' '}
+                          <span style={{ color: ev.data.colorB || '#cbd5e1' }}>{ev.data.b}</span>
+                        </>
+                      ) : null}
+                      {ev.kind === 'stack' ? <span>uneven non-solo teams</span> : null}
+                      {ev.kind === 'unstack' ? <span>teams now even</span> : null}
+                      {ev.kind === 'depart' || ev.kind === 'stopped' ? (
+                        <>
+                          <span style={{ color: playerHexColor(playerByID[ev.data.pid], getPlayerColor) }}>{ev.data.name}</span>
+                          <span className="workflow-alliance-event-reason"> ({ev.data.reason})</span>
+                        </>
+                      ) : null}
+                      {ev.kind === 'chat' ? (
+                        <>
+                          <span style={{ color: ev.data.color }}>{ev.data.name}:</span>
+                          <span className="workflow-alliance-chat-message"> "{ev.data.message}"</span>
+                        </>
+                      ) : null}
+                      {(ev.kind === 'attack' || ev.kind === 'drop' || ev.kind === 'reaver_drop'
+                          || ev.kind === 'dt_drop' || ev.kind === 'cliff_drop'
+                          || ev.kind === 'recall' || ev.kind === 'nuke') ? (
+                        <>
+                          <span style={{ color: ev.data.actorColor || '#cbd5e1' }}>{ev.data.actor}</span>
+                          {ev.data.target ? (
+                            <>
+                              {' → '}
+                              <span style={{ color: ev.data.targetColor || '#cbd5e1' }}>{ev.data.target}</span>
+                            </>
+                          ) : null}
+                        </>
+                      ) : null}
+                    </span>
+                  </div>
+                ))}
+              </div>
             );
           })}
-          {/* Time axis ticks at 0%, 25%, 50%, 75%, 100%. */}
-          {[0, 0.25, 0.5, 0.75, 1].map((f) => {
-            const x = f * stripWidth;
-            const t = f * totalDur;
-            return (
-              <g key={`tick-${f}`}>
-                <line
-                  x1={x}
-                  y1={STRIP_TOP_PADDING + STRIP_HEIGHT}
-                  x2={x}
-                  y2={STRIP_TOP_PADDING + STRIP_HEIGHT + 5}
-                  stroke="#94a3b8"
-                />
-                <text
-                  x={Math.max(2, Math.min(stripWidth - 30, x))}
-                  y={STRIP_TOP_PADDING + STRIP_HEIGHT + 18}
-                  fontSize={10}
-                  fill="#94a3b8"
-                >
-                  {formatMMSS(t)}
-                </text>
-              </g>
-            );
-          })}
-          {/* Scrubber thumb at current phase mid-point. */}
-          {(() => {
-            const cx = stripScale((currentPhase.sec + currentPhase.endSec) / 2);
-            return (
-              <g>
-                <line
-                  x1={cx}
-                  y1={STRIP_TOP_PADDING - 4}
-                  x2={cx}
-                  y2={STRIP_TOP_PADDING + STRIP_HEIGHT + 4}
-                  stroke="#fbbf24"
-                  strokeWidth={2}
-                />
-                <circle cx={cx} cy={STRIP_TOP_PADDING + STRIP_HEIGHT / 2} r={5} fill="#fbbf24" />
-              </g>
-            );
-          })()}
-        </svg>
-      </div>
-
-      <div className="workflow-alliance-legend">
-        <span>Click any band on the strip to inspect that phase. Default is the longest-held topology.</span>
+        </div>
       </div>
     </div>
   );

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -4192,33 +4192,139 @@ body {
   }
 }
 
-.workflow-alliance-timeline {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.workflow-alliance-timeline-v2 {
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 8px;
 }
 
-.workflow-alliance-graph-wrap {
-  background: rgba(15, 23, 42, 0.45);
+.workflow-alliance-timeline-grid {
+  display: grid;
+  grid-template-columns: auto minmax(320px, 420px);
+  gap: 16px;
+  align-items: start;
+}
+
+.workflow-alliance-svg-wrap {
+  background: rgba(2, 6, 23, 0.55);
   border-radius: 6px;
   padding: 4px;
+  overflow-x: auto;
 }
 
-.workflow-alliance-strip-meta {
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.92);
+.workflow-alliance-svg {
+  display: block;
 }
 
-.workflow-alliance-strip {
-  width: 100%;
-  background: rgba(15, 23, 42, 0.45);
+.workflow-alliance-context-panel {
+  background: rgba(2, 6, 23, 0.4);
   border-radius: 6px;
+  padding: 4px 8px;
 }
 
-.workflow-alliance-legend {
+.workflow-alliance-context-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.workflow-alliance-event {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: rgba(226, 232, 240, 0.92);
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 6px;
+  padding: 4px 8px;
+  pointer-events: auto;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.workflow-alliance-event-time {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.72rem;
   color: rgba(148, 163, 184, 0.85);
+  min-width: 32px;
+}
+
+.workflow-alliance-event-badge {
+  font-size: 0.95rem;
+  line-height: 1;
+  border-radius: 999px;
+  padding: 2px 6px;
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.92);
+  white-space: nowrap;
+  min-width: 24px;
   text-align: center;
+}
+
+.workflow-alliance-event-badge-ally {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+
+.workflow-alliance-event-badge-break {
+  background: rgba(244, 114, 182, 0.18);
+  color: #f9a8d4;
+}
+
+.workflow-alliance-event-badge-stack {
+  background: rgba(248, 113, 113, 0.22);
+  color: #fca5a5;
+}
+
+.workflow-alliance-event-badge-unstack {
+  background: rgba(96, 165, 250, 0.18);
+  color: #93c5fd;
+}
+
+.workflow-alliance-event-badge-depart {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fca5a5;
+}
+
+.workflow-alliance-event-badge-stopped {
+  background: rgba(148, 163, 184, 0.22);
+  color: #cbd5e1;
+}
+
+.workflow-alliance-event-badge-chat {
+  background: rgba(56, 189, 248, 0.18);
+  color: #7dd3fc;
+}
+
+.workflow-alliance-event-badge-attack,
+.workflow-alliance-event-badge-drop,
+.workflow-alliance-event-badge-reaver-drop,
+.workflow-alliance-event-badge-dt-drop,
+.workflow-alliance-event-badge-cliff-drop,
+.workflow-alliance-event-badge-recall,
+.workflow-alliance-event-badge-nuke {
+  background: rgba(251, 191, 36, 0.18);
+  color: #fcd34d;
+}
+
+.workflow-alliance-event-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workflow-alliance-chat-message {
+  color: rgba(203, 213, 225, 0.92);
+  font-style: italic;
+}
+
+.workflow-alliance-event-reason {
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.72rem;
 }
 
 .workflow-team-stacking-marker {

--- a/internal/parser/alliances.go
+++ b/internal/parser/alliances.go
@@ -392,33 +392,188 @@ func injectActivitySnapshots(snapshots []AllianceSnapshot, activity Activity) []
 // effectiveTeamsAt returns the teams with players who have left or stopped
 // playing by sec dropped out. Empty teams are dropped from the slice. The
 // original teams slice is not mutated.
+//
+// Cliques can overlap (a player may belong to several maximal cliques), so a
+// pass-through of departure filtering would emit duplicate singletons —
+// every clique a departed player's lone partner survived in shrinks to {p}.
+// We dedupe: when a player is still part of a surviving size-≥2 clique, we
+// drop any singleton entry for them. When they're a singleton in multiple
+// shrunk cliques, only one survives.
 func effectiveTeamsAt(teams [][]byte, sec int, activity Activity) [][]byte {
-	out := make([][]byte, 0, len(teams))
+	departed := func(pid byte) bool {
+		if leaveAt, ok := activity.LeaveSecByPID[pid]; ok && leaveAt <= sec {
+			return true
+		}
+		if stoppedAt, ok := activity.StoppedSecByPID[pid]; ok && stoppedAt <= sec {
+			return true
+		}
+		return false
+	}
+	survived := make([][]byte, 0, len(teams))
 	for _, team := range teams {
 		filtered := make([]byte, 0, len(team))
 		for _, pid := range team {
-			if leaveAt, ok := activity.LeaveSecByPID[pid]; ok && leaveAt <= sec {
-				continue
-			}
-			if stoppedAt, ok := activity.StoppedSecByPID[pid]; ok && stoppedAt <= sec {
+			if departed(pid) {
 				continue
 			}
 			filtered = append(filtered, pid)
 		}
 		if len(filtered) > 0 {
-			out = append(out, filtered)
+			survived = append(survived, filtered)
 		}
+	}
+	inLarger := map[byte]bool{}
+	for _, team := range survived {
+		if len(team) >= 2 {
+			for _, pid := range team {
+				inLarger[pid] = true
+			}
+		}
+	}
+	out := make([][]byte, 0, len(survived))
+	seenSolo := map[byte]bool{}
+	for _, team := range survived {
+		if len(team) == 1 {
+			pid := team[0]
+			if inLarger[pid] || seenSolo[pid] {
+				continue
+			}
+			seenSolo[pid] = true
+		}
+		out = append(out, team)
 	}
 	return out
 }
 
-// mutualAllianceTeams computes connected components of the mutual-alliance
+// mutualAllianceTeams enumerates the maximal cliques of the mutual-alliance
 // graph (edge a↔b iff a∈allies[b] AND b∈allies[a], excluding self-loops).
-// Returns teams sorted by min(pid) within team, and teams ordered by their
-// min(pid) for stable rendering across snapshots.
+//
+// A "team" in Brood War semantics is a clique: every member must mutually
+// ally every other member. Connected components — the previous model — over-
+// reports teams: a chain A↔B↔C↔D (with no other edges) is NOT a 4-stack, it
+// is three overlapping pair-stacks {A,B}, {B,C}, {C,D}. Without this fix the
+// stacking detector flags a chain of pair-alliances as e.g. "4v2 stacked"
+// even though none of the four chain members all-mutually ally each other.
+// A player can legitimately appear in more than one returned clique — that
+// is the honest answer when the alliance graph is not transitive.
+//
+// Singletons (active players not in any mutual edge) are appended as solo
+// teams so every player has at least one entry to render against. Cliques
+// are sorted by size (larger first) then by min(pid) for stable output.
 func mutualAllianceTeams(allies map[byte]map[byte]bool, activePIDs []byte) [][]byte {
+	sortedPIDs := append([]byte(nil), activePIDs...)
+	sort.Slice(sortedPIDs, func(i, j int) bool { return sortedPIDs[i] < sortedPIDs[j] })
+
+	isActive := map[byte]bool{}
+	for _, pid := range sortedPIDs {
+		isActive[pid] = true
+	}
+
+	mutual := func(a, b byte) bool {
+		if a == b {
+			return false
+		}
+		aSet, ok := allies[a]
+		if !ok || !aSet[b] {
+			return false
+		}
+		bSet, ok := allies[b]
+		if !ok || !bSet[a] {
+			return false
+		}
+		return true
+	}
+
+	n := len(sortedPIDs)
+	// Brute-force subset enumeration is fine for melee (n≤8 → ≤256 subsets).
+	// If n grows past 16 we'd want Bron-Kerbosch; guard so we don't OOM if
+	// the assumption ever breaks.
+	if n > 16 {
+		// Fall back to a non-overlapping component grouping — same shape as
+		// the old algorithm — so the analyzer still produces *some* answer
+		// rather than spinning over 65k subsets.
+		return mutualAllianceTeamsComponents(allies, sortedPIDs, mutual)
+	}
+
+	type subset struct {
+		members []byte
+		mask    uint32
+	}
+	cliques := make([]subset, 0)
+	for mask := uint32(1); mask < (uint32(1) << uint(n)); mask++ {
+		members := make([]byte, 0, n)
+		for i := 0; i < n; i++ {
+			if mask&(uint32(1)<<uint(i)) != 0 {
+				members = append(members, sortedPIDs[i])
+			}
+		}
+		if len(members) < 2 {
+			continue
+		}
+		isClique := true
+		for i := 0; i < len(members) && isClique; i++ {
+			for j := i + 1; j < len(members); j++ {
+				if !mutual(members[i], members[j]) {
+					isClique = false
+					break
+				}
+			}
+		}
+		if !isClique {
+			continue
+		}
+		cliques = append(cliques, subset{members: members, mask: mask})
+	}
+
+	// Keep only maximal cliques.
+	maximal := make([]subset, 0, len(cliques))
+	for i, c := range cliques {
+		dominated := false
+		for j, d := range cliques {
+			if i == j {
+				continue
+			}
+			if c.mask != d.mask && (c.mask&d.mask) == c.mask {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			maximal = append(maximal, c)
+		}
+	}
+
+	out := make([][]byte, 0, len(maximal)+n)
+	inAClique := map[byte]bool{}
+	for _, c := range maximal {
+		team := append([]byte(nil), c.members...)
+		out = append(out, team)
+		for _, pid := range team {
+			inAClique[pid] = true
+		}
+	}
+	for _, pid := range sortedPIDs {
+		if !inAClique[pid] {
+			out = append(out, []byte{pid})
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if len(out[i]) != len(out[j]) {
+			return len(out[i]) > len(out[j])
+		}
+		return out[i][0] < out[j][0]
+	})
+	return out
+}
+
+// mutualAllianceTeamsComponents is the connected-component fallback used
+// only when player count exceeds the brute-force clique enumeration ceiling
+// (n>16). Melee never hits this path; included so the analyzer stays safe
+// if future replay formats grow the slot count.
+func mutualAllianceTeamsComponents(allies map[byte]map[byte]bool, sortedPIDs []byte, mutual func(a, b byte) bool) [][]byte {
 	parent := map[byte]byte{}
-	for _, pid := range activePIDs {
+	for _, pid := range sortedPIDs {
 		parent[pid] = pid
 	}
 	var find func(byte) byte
@@ -440,30 +595,18 @@ func mutualAllianceTeams(allies map[byte]map[byte]bool, activePIDs []byte) [][]b
 			parent[ra] = rb
 		}
 	}
-
-	for a, aSet := range allies {
-		for b := range aSet {
-			if a == b {
-				continue
-			}
-			if _, ok := parent[a]; !ok {
-				continue
-			}
-			if _, ok := parent[b]; !ok {
-				continue
-			}
-			if bSet, ok := allies[b]; ok && bSet[a] {
+	for i, a := range sortedPIDs {
+		for _, b := range sortedPIDs[i+1:] {
+			if mutual(a, b) {
 				union(a, b)
 			}
 		}
 	}
-
 	groups := map[byte][]byte{}
-	for _, pid := range activePIDs {
+	for _, pid := range sortedPIDs {
 		root := find(pid)
 		groups[root] = append(groups[root], pid)
 	}
-
 	teams := make([][]byte, 0, len(groups))
 	for _, g := range groups {
 		sort.Slice(g, func(i, j int) bool { return g[i] < g[j] })

--- a/internal/parser/alliances_test.go
+++ b/internal/parser/alliances_test.go
@@ -154,6 +154,42 @@ func TestAnalyzeAlliances_OneWayAlliance_NoMutual(t *testing.T) {
 	expectTeams(t, last.Teams, [][]byte{{1}, {2}, {3}})
 }
 
+// TestAnalyzeAlliances_ChainIsNotAClique exercises the case from replay 500
+// (003714,(8)Big Game Hunters.rep): pairwise mutual alliances A↔B, B↔C, C↔D
+// form a *chain* in the mutual-alliance graph. The old connected-component
+// algorithm rolled the chain up into a single 4-stack and flagged stacking
+// against a 2-stack opponent; cliques expose the chain as three pair-teams
+// (one of which the "central" players appear in twice) — no clique is bigger
+// than 2, so the stacking flag does not fire.
+func TestAnalyzeAlliances_ChainIsNotAClique(t *testing.T) {
+	a, b, c, d := p(1, 1), p(2, 2), p(3, 3), p(4, 4)
+	e, f := p(5, 5), p(6, 6)
+	players := []*models.Player{a, b, c, d, e, f}
+	cmds := []*models.Command{
+		// A↔B mutual.
+		allianceCmd(10, a, 1, 2),
+		allianceCmd(10, b, 1, 2),
+		// B also reciprocates C.
+		allianceCmd(20, b, 1, 2, 3),
+		allianceCmd(20, c, 2, 3),
+		// C also reciprocates D.
+		allianceCmd(30, c, 2, 3, 4),
+		allianceCmd(30, d, 3, 4),
+		// Disjoint 2-stack E↔F.
+		allianceCmd(40, e, 5, 6),
+		allianceCmd(40, f, 5, 6),
+	}
+	res := AnalyzeAlliances(players, cmds, 900, emptyActivity())
+
+	if res.TeamStackingFlag {
+		t.Fatalf("chain A-B-C-D vs 2-stack E-F must not flag stacking — chain has no clique larger than 2")
+	}
+	last := res.Snapshots[len(res.Snapshots)-1]
+	// Expected maximal cliques (size desc, then min pid):
+	// {1,2}, {2,3}, {3,4}, {5,6}.
+	expectTeams(t, last.Teams, [][]byte{{1, 2}, {2, 3}, {3, 4}, {5, 6}})
+}
+
 func TestAnalyzeAlliances_StackingBand_ExceedsThreshold(t *testing.T) {
 	a, b, c, d, e := p(1, 1), p(2, 2), p(3, 3), p(4, 4), p(5, 5)
 	players := []*models.Player{a, b, c, d, e}

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -9,7 +9,7 @@ import (
 
 // AlgorithmVersion is the current version of the pattern detection algorithm
 // Increment this when the algorithm changes to trigger re-detection
-const AlgorithmVersion = 22
+const AlgorithmVersion = 23
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string


### PR DESCRIPTION
fixes https://github.com/marianogappa/screpdb/issues/120

## What changes

- **Detection bug**: the previous analyzer used **connected-components / union-find** to group mutual alliances, which over-reports teams. A chain `A↔B↔C↔D` (no other edges) was rolled up into a single 4-stack even though no 3+ subset is actually all-mutual. Replaced with **maximal-clique enumeration** — every member of a "team" must reciprocate with every other member. Pair, triangle, and full quad cliques behave correctly; chains decompose into overlapping pair-cliques. `AlgorithmVersion` bumped `22 → 23` so existing replays get re-detected.
- **New Alliances tab**: Sankey-style timeline with vertical player lanes on a **non-linear time axis** (advances only at alliance changes + departures). Pair-cliques render as arcs, triangle+ as pills. Player columns use the in-game BW palette; names re-render periodically + on column changes with a dark backdrop. Right context panel docks alliance diffs, departures, all chat lines, and attack/drop/recall/nuke events within ±60s of a departure. Events use single-glyph emoji badges (🤝 💔 😈 🕊️ 🏳️ 💤 💬 ⚔️ 🪂 🌀 ☢️).
- **Stable layout**: brute-force search over every permutation of non-permanent-solo players picks the initial ordering that minimises movement + arc length. Per-row tie-break prefers preserving the centroid of prior positions over picking the bigger clique first, so a freshly-formed triangle doesn't hijack column 0 from an already-anchored pair.

## Replay 500 — the case from the issue

A 4-stack vs 2-stack vs 1 lobby. fadsh chats *"im no ally"* / *"no tem"* / *"gg"* and quits at 4:55, complaining he was never properly allied. Old UI showed him inside a stacked 4-pill at 4:12.

Trace of the mutual graph at 4:12:
- D↔C ✓ &nbsp; C↔Y ✓ &nbsp; Y↔f ✓
- D↔Y ✗ (D never includes Y) &nbsp; D↔f ✗ &nbsp; C↔f ✗

So D—C—Y—f is a **chain**, not a clique. fadsh was right.

After the fix:
- 4:12 surfaces only `🤝 ChosenEnemy ⇌ YuriSenna7` (the pair that closed the chain). No fake 4-stack pill, no `+ stack`.
- 11:28 — DaRkSyN finally adds YuriSenna7 to his alliance set → triangle `{D,C,Y}` forms → `😈 uneven non-solo teams`. Stacking starts **here**, 6+ minutes after fadsh quit.
- Right panel shows fadsh's chat (`"ally"`, `"im no ally"`, `"yuri"`, `"no tem"`, `"gg"`) docked next to his departure, and the 17:21 attack on DaRkSyN that preceded his 17:51 quit.

Screenshot of the new Alliances tab on replay 500 is in the PR thread.

## Test plan

- [ ] `go test ./...` — 251 pass
- [ ] `make build` && `./screpdb dashboard` against a DB with replay 500 ingested
- [ ] Open the Alliances tab; expect 7 player columns with BW colours, chain D—C—Y—f visible as three adjacent arcs at 4:12, the real `{D,C,Y}` triangle pill appearing only at 11:28
- [ ] Smoke-test a 1v1 melee — the tab early-returns to empty, no regression
- [ ] Smoke-test a clean 2v2 with no leaves — both pairs render as full-length arcs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
