### PR TITLE
feat(markers): per-matchup gate for never_researched / never_upgraded (1v1)

### DIFF
--- a/internal/patterns/detectors/base.go
+++ b/internal/patterns/detectors/base.go
@@ -269,6 +269,26 @@ func getPlayerByReplayPlayerID(players []*models.Player, replayPlayerID byte) *m
 	return nil
 }
 
+// getOpponentInOneVOne returns the single non-observer opponent on a different
+// team than own. Returns nil if zero or more than one such player is found —
+// callers should use this only after confirming TeamFormat == "1v1".
+func getOpponentInOneVOne(players []*models.Player, own *models.Player) *models.Player {
+	var found *models.Player
+	for _, p := range players {
+		if p == nil || p == own || p.IsObserver {
+			continue
+		}
+		if p.Team == own.Team {
+			continue
+		}
+		if found != nil {
+			return nil
+		}
+		found = p
+	}
+	return found
+}
+
 func isPlayerRace(players []*models.Player, replayPlayerID byte, race string) bool {
 	player := getPlayerByReplayPlayerID(players, replayPlayerID)
 	if player == nil {

--- a/internal/patterns/detectors/player_marker.go
+++ b/internal/patterns/detectors/player_marker.go
@@ -328,11 +328,61 @@ func (d *MarkerPlayerDetector) ShouldSave() bool {
 	if !d.IsFinished() || !d.matched {
 		return false
 	}
-	if d.marker.MinReplaySeconds > 0 {
+	gate := d.resolveMinReplaySeconds()
+	if gate > 0 {
 		replay := d.GetReplay()
-		if replay == nil || replay.DurationSeconds < d.marker.MinReplaySeconds {
+		if replay == nil || replay.DurationSeconds < gate {
 			return false
 		}
 	}
 	return true
+}
+
+// matchupGateMinSeconds is a hard lower bound applied on top of any
+// per-(own_race, opp_race) gate from Marker.MinReplaySecondsByMatchup.
+// Several Upgrade matchups have a progamer p5 of first-Upgrade around
+// 2:00-3:00 (e.g. ZvZ Speed, PvT Singularity Charge). Used alone, those
+// gates would flag "never upgraded" on successful 4-pool / Bunker rush /
+// Proxy gate finishes — exactly the rush-suppression case the matchup
+// gate was meant to preserve. 4 min is above the typical successful-rush
+// game-end time, so short rushes stay suppressed; longer games still get
+// the matchup-aware gate raised above this floor when applicable
+// (e.g. PvT first-Tech p5 = 8:16).
+const matchupGateMinSeconds = 4 * 60
+
+// resolveMinReplaySeconds picks the effective duration gate for this marker.
+// For 1v1 replays we prefer a per-(own_race, opp_race) entry from
+// MinReplaySecondsByMatchup so "never X" markers respect matchup-typical
+// first-research / first-upgrade timings, lifted to at least
+// matchupGateMinSeconds to keep short rushes suppressed. For non-1v1 or
+// a missing bucket we fall back to the flat MinReplaySeconds.
+func (d *MarkerPlayerDetector) resolveMinReplaySeconds() int {
+	if len(d.marker.MinReplaySecondsByMatchup) == 0 {
+		return d.marker.MinReplaySeconds
+	}
+	replay := d.GetReplay()
+	if replay == nil || replay.TeamFormat != "1v1" {
+		return d.marker.MinReplaySeconds
+	}
+	players := d.GetPlayers()
+	own := getPlayerByReplayPlayerID(players, d.GetReplayPlayerID())
+	if own == nil {
+		return d.marker.MinReplaySeconds
+	}
+	opp := getOpponentInOneVOne(players, own)
+	if opp == nil {
+		return d.marker.MinReplaySeconds
+	}
+	byOpp, ok := d.marker.MinReplaySecondsByMatchup[markers.Race(own.Race)]
+	if !ok {
+		return d.marker.MinReplaySeconds
+	}
+	v, ok := byOpp[markers.Race(opp.Race)]
+	if !ok {
+		return d.marker.MinReplaySeconds
+	}
+	if v < matchupGateMinSeconds {
+		return matchupGateMinSeconds
+	}
+	return v
 }

--- a/internal/patterns/detectors/player_marker_test.go
+++ b/internal/patterns/detectors/player_marker_test.go
@@ -221,6 +221,98 @@ func TestBuildDedup_PendingFromBeforeCapFlushesAtCap(t *testing.T) {
 	}
 }
 
+// newGateTestMarker builds a never_researched-style marker with a
+// per-(own_race, opp_race) gate of 7:00 for (P, Z) only, on top of a flat
+// 10-minute MinReplaySeconds fallback. Used by the matchup-gate tests.
+func newGateTestMarker() markers.Marker {
+	return markers.Marker{
+		Name:             "Test Never Researched",
+		PatternName:      "Test Never Researched",
+		FeatureKey:       "test_never_researched",
+		Kind:             markers.KindMarker,
+		Rule:             markers.Not(markers.TechExists()),
+		RuleDeadline:     10 * 60 * 60,
+		MinReplaySeconds: 10 * 60,
+		MinReplaySecondsByMatchup: map[markers.Race]map[markers.Race]int{
+			markers.RaceProtoss: {markers.RaceZerg: 7 * 60},
+		},
+	}
+}
+
+// runGateTest builds a no-Tech 1v1 replay with the given duration / team-format
+// and reports whether the detector saved the marker.
+func runGateTest(t *testing.T, mk markers.Marker, ownRace, oppRace string, teamFormat string, durationSeconds int) bool {
+	t.Helper()
+	builder := NewTestReplayBuilder().
+		WithPlayer(1, "own", ownRace, 1).
+		WithPlayer(2, "opp", oppRace, 2).
+		WithDurationSeconds(durationSeconds)
+	replay, players := builder.Build()
+	replay.TeamFormat = teamFormat
+
+	d := NewMarkerPlayerDetector(mk)
+	d.SetReplayPlayerID(1)
+	d.Initialize(replay, players)
+	for _, cmd := range builder.GetCommands() {
+		d.ProcessCommand(cmd)
+	}
+	d.Finalize()
+	return d.ShouldSave()
+}
+
+// 1v1 PvZ at 5:00. Per-matchup gate (P vs Z) is 7:00, so the marker is
+// suppressed — even though the flat 10:00 fallback would also have suppressed
+// it. (Sanity case.)
+func TestMarkerDetector_MatchupGate_OneVOne_BelowMatchupThreshold(t *testing.T) {
+	if runGateTest(t, newGateTestMarker(), "Protoss", "Zerg", "1v1", 5*60) {
+		t.Fatalf("expected suppression at 5:00 in 1v1 PvZ (below P-vs-Z 7:00 floor)")
+	}
+}
+
+// 1v1 PvZ at 8:00. Per-matchup gate is 7:00 → fire. Flat fallback would have
+// suppressed at 8:00 (< 10:00); this proves the matchup gate REPLACES the
+// flat floor for 1v1, not stacks above it.
+func TestMarkerDetector_MatchupGate_OneVOne_AboveMatchupBelowFlat(t *testing.T) {
+	if !runGateTest(t, newGateTestMarker(), "Protoss", "Zerg", "1v1", 8*60) {
+		t.Fatalf("expected fire at 8:00 in 1v1 PvZ (above P-vs-Z 7:00 floor, despite < 10:00 flat fallback)")
+	}
+}
+
+// 1v1 ZvP at 8:00. No entry for (Z, P) in the map → fall back to flat 10:00
+// MinReplaySeconds → suppress.
+func TestMarkerDetector_MatchupGate_OneVOne_MissingBucketFallsBack(t *testing.T) {
+	if runGateTest(t, newGateTestMarker(), "Zerg", "Protoss", "1v1", 8*60) {
+		t.Fatalf("expected suppression at 8:00 in 1v1 ZvP (no per-matchup entry → flat 10:00 fallback)")
+	}
+}
+
+// 2v2 PvZ stand-in at 8:00: TeamFormat != "1v1" → matchup map is ignored even
+// though (P, Z) is populated. Flat 10:00 fallback applies → suppress.
+func TestMarkerDetector_MatchupGate_NonOneVOne_UsesFlatFallback(t *testing.T) {
+	if runGateTest(t, newGateTestMarker(), "Protoss", "Zerg", "2v2", 8*60) {
+		t.Fatalf("expected suppression at 8:00 in 2v2 (non-1v1 → flat 10:00 fallback even with matchup map populated)")
+	}
+}
+
+// A matchup entry below matchupGateMinSeconds is lifted to that floor so
+// successful rushes stay suppressed even when progamer p5 is very early
+// (e.g. ZvZ first-Upgrade ≈ 2:05 would otherwise fire on a 2:30 4-pool win).
+func TestMarkerDetector_MatchupGate_HardFloorLiftsLowMatchupValue(t *testing.T) {
+	mk := newGateTestMarker()
+	// Override the (P, Z) entry with a value well below the hard floor.
+	mk.MinReplaySecondsByMatchup = map[markers.Race]map[markers.Race]int{
+		markers.RaceProtoss: {markers.RaceZerg: 100}, // 1:40, below 4:00
+	}
+	// Game at 3:00 — above matchup value (100) but below hard floor (240) → suppress.
+	if runGateTest(t, mk, "Protoss", "Zerg", "1v1", 3*60) {
+		t.Fatalf("expected suppression at 3:00 with matchup value 1:40 (lifted to 4:00 hard floor)")
+	}
+	// Game at 5:00 — above hard floor → fire.
+	if !runGateTest(t, mk, "Protoss", "Zerg", "1v1", 5*60) {
+		t.Fatalf("expected fire at 5:00 with matchup value 1:40 (above lifted 4:00 floor)")
+	}
+}
+
 func newRecordingBuildDetector() (*MarkerPlayerDetector, *recordingState) {
 	rec := &recordingState{}
 	d := &MarkerPlayerDetector{

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -887,11 +887,31 @@ func allMarkers() []Marker {
 			Kind:             KindMarker,
 			Rule:             Not(UpgradeExists()),
 			RuleDeadline:     endOfReplaySentinel,
-			MinReplaySeconds: 10 * 60,
+			MinReplaySeconds: 10 * 60, // fallback for non-1v1
+			// 1v1 floor per (own_race, opp_race): p5 of first-Upgrade time
+			// across 5708 progamer 1v1 player-games. Buckets with <20 samples
+			// are omitted and fall through to MinReplaySeconds.
+			MinReplaySecondsByMatchup: map[Race]map[Race]int{
+				RaceTerran: {
+					RaceTerran:  264, // n=118, p5=4:24
+					RaceProtoss: 293, // n=315, p5=4:53
+					RaceZerg:    233, // n=358, p5=3:53
+				},
+				RaceProtoss: {
+					RaceTerran:  163, // n=366, p5=2:43
+					RaceProtoss: 169, // n=235, p5=2:49
+					RaceZerg:    237, // n=536, p5=3:57
+				},
+				RaceZerg: {
+					RaceTerran:  175, // n=407, p5=2:55
+					RaceProtoss: 128, // n=592, p5=2:08
+					RaceZerg:    125, // n=444, p5=2:05
+				},
+			},
 			SummaryPlayer: &Pill{
 				Label: "🚫 upgrades",
 				Style: PillStyleNegative,
-				Title: "No Upgrade commands in this replay for this player (10+ minute games).",
+				Title: "No Upgrade commands in this replay for this player (suppressed on games shorter than matchup-typical first upgrade).",
 			},
 		},
 		{
@@ -901,11 +921,30 @@ func allMarkers() []Marker {
 			Kind:             KindMarker,
 			Rule:             Not(TechExists()),
 			RuleDeadline:     endOfReplaySentinel,
-			MinReplaySeconds: 10 * 60,
+			MinReplaySeconds: 10 * 60, // fallback for non-1v1 (and ZvZ in 1v1, omitted below for n<20)
+			// 1v1 floor per (own_race, opp_race): p5 of first-Tech time
+			// across 5708 progamer 1v1 player-games. Buckets with <20 samples
+			// are omitted (ZvZ has n=17 → falls through to MinReplaySeconds).
+			MinReplaySecondsByMatchup: map[Race]map[Race]int{
+				RaceTerran: {
+					RaceTerran:  245, // n=141, p5=4:05
+					RaceProtoss: 238, // n=341, p5=3:58
+					RaceZerg:    252, // n=368, p5=4:12
+				},
+				RaceProtoss: {
+					RaceTerran:  496, // n=176, p5=8:16
+					RaceProtoss: 332, // n=74,  p5=5:32
+					RaceZerg:    396, // n=407, p5=6:36
+				},
+				RaceZerg: {
+					RaceTerran:  243, // n=264, p5=4:03
+					RaceProtoss: 339, // n=372, p5=5:39
+				},
+			},
 			SummaryPlayer: &Pill{
 				Label: "🚫 researches",
 				Style: PillStyleNegative,
-				Title: "No Tech commands in this replay for this player (10+ minute games).",
+				Title: "No Tech commands in this replay for this player (suppressed on games shorter than matchup-typical first research).",
 			},
 		},
 

--- a/internal/patterns/markers/types.go
+++ b/internal/patterns/markers/types.go
@@ -358,6 +358,16 @@ type Marker struct {
 	// Used by "never X" markers that would otherwise trip on short games.
 	MinReplaySeconds int
 
+	// MinReplaySecondsByMatchup gates this marker on replay duration using a
+	// per-(own_race, opp_race) threshold. Outer key is the player's race,
+	// inner key is the opponent's race. Consulted ONLY for 1v1 replays; for
+	// non-1v1 (team games, FFA) MinReplaySeconds is used instead. Used by
+	// "never X" markers whose "valid game" length depends on the matchup —
+	// e.g. ZvZ first research is much earlier than PvP first research, so a
+	// flat 10-min floor over-fires on short PvP games. Missing entries fall
+	// back to MinReplaySeconds.
+	MinReplaySecondsByMatchup map[Race]map[Race]int
+
 	// Rule is the predicate-DSL path — tree of PredicateState factories.
 	// If non-nil, the marker emits ValueBool:true on match.
 	Rule Predicate


### PR DESCRIPTION
## Summary

- Per-(own_race, opp_race) duration gate for `never_researched` / `never_upgraded` in 1v1, derived from p5 of first-Tech / first-Upgrade across 5708 progamer 1v1 player-games (offline benchmark, not retained).
- 4-min hard floor stacked on the matchup gate so successful rushes (4-pool, Bunker, Proxy gate) stay suppressed — several Upgrade buckets have a raw p5 around 2:00-3:00 that would otherwise fire on a 2:30 4-pool win.
- Non-1v1 (team games, FFA) keeps the existing flat 10-min floor — opponent race is not well-defined off 1v1 and the corpus is 1v1.

## Why

`MinReplaySeconds: 10 * 60` aggregates poorly across a player's summary: 20 % of games "without research" mixes "skipped research on a normal game" with "game ended before research was due." The new gate uses matchup-typical first-event timing as the suppression threshold, so the marker carries a real signal when it fires.

## Per-bucket p5 reference

|                | first-Tech              | first-Upgrade          |
| -------------- | ----------------------- | ---------------------- |
| T vs T, T vs P, T vs Z | 4:05, 3:58, 4:12 | 4:24, 4:53, 3:53      |
| P vs T, P vs P, P vs Z | 8:16, 5:32, 6:36 | 2:43\*, 2:49\*, 3:57\* |
| Z vs T, Z vs P, Z vs Z | 4:03, 5:39, (n=17 dropped) | 2:55\*, 2:08\*, 2:05\* |

`*` = below the 4 min hard floor → effective gate = 4:00. ZvZ first-Tech (n < 20) is dropped from the map and falls back to the 10 min flat floor for that one bucket.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` — 256 tests, all green (including the `bo_4_pool.rep` golden, which still does NOT trip `Never upgraded` thanks to the 4-min hard floor)
- [x] New unit tests in `internal/patterns/detectors/player_marker_test.go` covering: 1v1 below / above matchup gate; missing-bucket fallback to flat floor; non-1v1 fallback; hard-floor lift when matchup value < 4:00
- [ ] Dashboard spot-check on a player summary before merge — the % of games with the `🚫 researches` / `🚫 upgrades` pills should drop modestly, weighted toward shorter games and Protoss / Zerg matchups
- [ ] Confirm the redesigned tooltip text reads well on the player summary pill

## Note for reviewer

The plan as originally signed off said "replace the 10-min floor with the matchup p5, no stacking." When I pasted the raw p5 values, `bo_4_pool.rep` (the curated 2:30 PvZ-Zerg 4-pool replay) started tripping `Never upgraded` because Z vs P first-Upgrade p5 = 2:08 — exactly the rush-suppression case the proposal called out by name. I added the 4 min hard floor (`matchupGateMinSeconds` in `player_marker.go`) to preserve that intent.

If you want literal p5 with no floor, revert the `if v < matchupGateMinSeconds` branch in `resolveMinReplaySeconds` and refresh the golden with `UPDATE_GOLDEN=1 go test ./internal/patterns/markers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
