### PR TITLE
feat(dashboard): games-list polish + per-player gate fix

### DIFF
--- a/internal/dashboard/endpoint_custom_markers_definitions.go
+++ b/internal/dashboard/endpoint_custom_markers_definitions.go
@@ -58,9 +58,6 @@ var staticGameEventFeatures = []gameEventFeature{
 // ordered strip without a parallel lookup table.
 var staticFeaturingOrder = []string{
 	// signature markers (KindMarker, persistent presence)
-	"carriers",
-	"battlecruisers",
-	"ten_plus_scouts",
 	"mech",
 	// game-event-only chips (sourced from worldstate, not markers)
 	"cannon_rush",
@@ -73,7 +70,6 @@ var staticFeaturingOrder = []string{
 	// late-game custom-evaluator markers
 	"threw_nukes",
 	"made_recalls",
-	"cliff_drop",
 	"mech_transition",
 	// transition markers (KindMarker)
 	"one_one_one",
@@ -97,6 +93,12 @@ var staticFeaturingOrder = []string{
 	"bo_1_rax_1_fac",
 	"bo_rax_cc",
 	"bo_cc_first",
+	// money-map markers — rendered last so regular markers take priority on
+	// mixed/regular game listings; on Money games they trail Mind Control etc.
+	"carriers",
+	"battlecruisers",
+	"ten_plus_scouts",
+	"cliff_drop",
 }
 
 // handlerMarkersDefinitions serves the per-marker Pill metadata plus ordering

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -255,16 +255,12 @@ var workflowFeaturingFilters = []struct {
 	IconLabel string
 	Emoji     string
 }{
-	{Key: "carriers", Label: "Carrier", Group: "marker", IconKey: "carrier"},
-	{Key: "battlecruisers", Label: "Battlecruiser", Group: "marker", IconKey: "battlecruiser"},
-	{Key: "ten_plus_scouts", Label: "10+ Scouts", Group: "marker", IconKey: "scout", IconLabel: "10+"},
 	{Key: "mech", Label: "Mech", Group: "marker", IconKeys: []string{"siegetank", "goliath"}, IconLabel: "Mech"},
 	{Key: "sk_terran", Label: "SK Terran", Group: "marker", IconKeys: []string{"marine", "medic"}, IconLabel: "SK Terran"},
 	{Key: "one_one_one", Label: "1-1-1", Group: "marker"},
 	{Key: "mech_transition", Label: "Mech Transition", Group: "marker", IconKeys: []string{"siegetank", "goliath"}, IconLabel: "Mech transition"},
 	{Key: "mutalisk_timing", Label: "Mutalisk timing", Group: "marker", IconKey: "mutalisk", IconLabel: "timing"},
 	{Key: "turret_timing", Label: "Turret timing", Group: "marker", IconKey: "missileturret", IconLabel: "Timing"},
-	{Key: "cliff_drop", Label: "Cliff drop", Group: "marker", IconKey: "dropship", IconLabel: "Cliff drop"},
 	{Key: "cannon_rush", Label: "Cannon Rush", Group: "marker", IconKey: "photoncannon", IconLabel: "Rush"},
 	{Key: "bunker_rush", Label: "Bunker Rush", Group: "marker", IconKey: "bunker", IconLabel: "Rush"},
 	{Key: "zergling_rush", Label: "Zergling Rush", Group: "marker", IconKey: "zergling", IconLabel: "Rush"},
@@ -275,6 +271,11 @@ var workflowFeaturingFilters = []struct {
 	{Key: "nukes", Label: "Nukes", Group: "marker", IconKey: "ghost", IconLabel: "Nuke"},
 	{Key: "recalls", Label: "Recalls", Group: "marker", IconKey: "arbiter", IconLabel: "Recall"},
 	{Key: "team_stacking", Label: "Team stacking", Group: "marker", Emoji: "😈"},
+	// Money-map markers — rendered last so regular markers take priority.
+	{Key: "carriers", Label: "Carrier", Group: "marker", IconKey: "carrier"},
+	{Key: "battlecruisers", Label: "Battlecruiser", Group: "marker", IconKey: "battlecruiser"},
+	{Key: "ten_plus_scouts", Label: "10+ Scouts", Group: "marker", IconKey: "scout", IconLabel: "10+"},
+	{Key: "cliff_drop", Label: "Cliff drop", Group: "marker", IconKey: "dropship", IconLabel: "Cliff drop"},
 	// Build order pills — keys & labels kept in sync with internal/markers.
 	// Suppressed in render for Money maps (game-list + replay-summary
 	// featuring strips); BO tab and per-player summary pills still show.

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -3973,6 +3973,17 @@ function App() {
             <button type="button" className={`btn-manage ${activeView === 'players' ? 'workflow-nav-active' : ''}`} onClick={() => navigateMainView('players')}>Players</button>
           </div>
           <div className="workflow-nav-group">
+            {latestVersion ? (
+              <a
+                href={latestVersionUrl || 'https://github.com/marianogappa/screpdb/releases/latest'}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="workflow-nav-update-available"
+                title={`Update available — current version ${currentVersion}`}
+              >
+                🆕 Update available
+              </a>
+            ) : null}
             <button
               type="button"
               onClick={() => {
@@ -4012,7 +4023,20 @@ function App() {
           </div>
         </div>
 
-        {error && <div className="error-message">{error}</div>}
+        {error && (
+          <div className="error-message" role="alert">
+            <span className="error-message-text">{error}</span>
+            <button
+              type="button"
+              className="error-message-dismiss"
+              aria-label="Dismiss error"
+              title="Dismiss"
+              onClick={() => setError(null)}
+            >
+              ×
+            </button>
+          </div>
+        )}
 
         {activeView === 'games' && (
           <div className="workflow-panel">
@@ -4635,12 +4659,17 @@ function App() {
                 </div>
                 <div className="workflow-meta workflow-meta--game-header">
                   <span>{formatRelativeReplayDate(mainGame.replay_date)}</span>
+                  <span className="workflow-meta-sep" aria-hidden="true">·</span>
                   <span>{formatMapNameWithKind(mainGame.map_name, mainGame.map_kind)}</span>
+                  <span className="workflow-meta-sep" aria-hidden="true">·</span>
                   <span>{formatDuration(mainGame.duration_seconds)}</span>
                   {mainGame.file_path ? (
-                    <code className="workflow-meta-filepath-text" title={mainGame.file_path}>
-                      {mainGame.file_path.replace(/\\/g, '/').split('/').pop()}
-                    </code>
+                    <>
+                      <span className="workflow-meta-sep" aria-hidden="true">·</span>
+                      <code className="workflow-meta-filepath-text" title={mainGame.file_path}>
+                        {mainGame.file_path.replace(/\\/g, '/').split('/').pop()}
+                      </code>
+                    </>
                   ) : null}
                   {mainGame.file_path ? (
                     <button
@@ -6078,20 +6107,13 @@ function App() {
         <div className="footer-left">
           {replayCount !== null ? (
             <>
-              {replayCount.toLocaleString()} replays in database.{' '}
+              {replayCount.toLocaleString()} replays in database
+              <span className="workflow-meta-sep" aria-hidden="true"> · </span>
               <a href="https://github.com/marianogappa/screpdb" target="_blank" rel="noopener noreferrer">screpdb</a>
               {' by '}
               <a href="https://marianogappa.github.io" target="_blank" rel="noopener noreferrer">Mariano Gappa</a>
-              {'. '}
+              <span className="workflow-meta-sep" aria-hidden="true"> · </span>
               <a href="https://github.com/marianogappa/screpdb/issues" target="_blank" rel="noopener noreferrer">🐞 Report an issue</a>
-              {latestVersion ? (
-                <>
-                  {'. '}
-                  <a href={latestVersionUrl || 'https://github.com/marianogappa/screpdb/releases/latest'} target="_blank" rel="noopener noreferrer">
-                    🆕 Update available (current version {currentVersion})
-                  </a>
-                </>
-              ) : null}
             </>
           ) : (
             'Loading replay count...'

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -330,12 +330,38 @@ body {
 }
 
 .error-message {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
   padding: 12px;
   background: rgba(255, 50, 50, 0.2);
   border: 1px solid rgba(255, 50, 50, 0.5);
   border-radius: 4px;
   color: #ff6666;
   margin-bottom: 20px;
+}
+
+.error-message-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.error-message-dismiss {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0 6px;
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity 0.15s ease;
+}
+
+.error-message-dismiss:hover {
+  opacity: 1;
 }
 
 .success-message {
@@ -1910,6 +1936,24 @@ body {
   transition: color 0.15s ease, background 0.15s ease;
 }
 
+.workflow-nav-update-available {
+  padding: 8px 12px;
+  border-radius: 4px;
+  color: rgba(140, 220, 160, 0.98);
+  background: rgba(80, 160, 100, 0.14);
+  border: 1px solid rgba(120, 200, 140, 0.35);
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.workflow-nav-update-available:hover {
+  color: #c9f5d4;
+  background: rgba(80, 160, 100, 0.22);
+  border-color: rgba(140, 220, 160, 0.55);
+  text-decoration: none;
+}
+
 .workflow-nav-text-action:hover {
   color: #fff;
   background: rgba(255, 255, 255, 0.06);
@@ -2238,6 +2282,16 @@ body {
   flex-wrap: wrap;
   margin-bottom: 12px;
   color: rgba(255, 255, 255, 0.8);
+}
+
+.workflow-meta--game-header {
+  gap: 8px;
+  align-items: center;
+}
+
+.workflow-meta-sep {
+  color: rgba(255, 255, 255, 0.35);
+  user-select: none;
 }
 
 .workflow-summary-map-row {
@@ -2889,12 +2943,18 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
+  gap: 8px;
   color: rgba(255, 255, 255, 0.86);
+  font-size: 12px;
 }
 
 .workflow-pagination-row-centered {
   justify-content: center;
+}
+
+.workflow-pagination-row .btn-switch {
+  padding: 3px 8px;
+  font-size: 11px;
 }
 
 .workflow-pattern-pill-inline {

--- a/internal/patterns/detectors/player_marker.go
+++ b/internal/patterns/detectors/player_marker.go
@@ -331,7 +331,24 @@ func (d *MarkerPlayerDetector) ShouldSave() bool {
 	gate := d.resolveMinReplaySeconds()
 	if gate > 0 {
 		replay := d.GetReplay()
-		if replay == nil || replay.DurationSeconds < gate {
+		if replay == nil {
+			return false
+		}
+		// Compare against the player's effective time-in-game, not the
+		// whole replay's duration. In non-1v1 games a player can leave
+		// or stop playing long before the replay ends — using the
+		// replay duration would wrongly flag e.g. "never upgraded" on
+		// a player who quit at 5min in a 30min FFA, even though they
+		// never had a chance to research/upgrade past the 10-min floor.
+		// Last command second is more robust than leaveSec — some replays
+		// record a spurious early leave_game for players who keep playing.
+		playerTime := replay.DurationSeconds
+		if ws := d.GetWorldState(); ws != nil {
+			if lastSec, ok := ws.LastCommandSecond(d.GetReplayPlayerID()); ok && lastSec < playerTime {
+				playerTime = lastSec
+			}
+		}
+		if playerTime < gate {
 			return false
 		}
 	}

--- a/internal/patterns/detectors/player_marker_test.go
+++ b/internal/patterns/detectors/player_marker_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/marianogappa/screpdb/internal/cmdenrich"
-	"github.com/marianogappa/screpdb/internal/patterns/markers"
 	"github.com/marianogappa/screpdb/internal/models"
+	"github.com/marianogappa/screpdb/internal/patterns/markers"
+	"github.com/marianogappa/screpdb/internal/patterns/worldstate"
 )
 
 // recordingState is a test PredicateState that captures every observed fact.
@@ -291,6 +292,61 @@ func TestMarkerDetector_MatchupGate_OneVOne_MissingBucketFallsBack(t *testing.T)
 func TestMarkerDetector_MatchupGate_NonOneVOne_UsesFlatFallback(t *testing.T) {
 	if runGateTest(t, newGateTestMarker(), "Protoss", "Zerg", "2v2", 8*60) {
 		t.Fatalf("expected suppression at 8:00 in 2v2 (non-1v1 → flat 10:00 fallback even with matchup map populated)")
+	}
+}
+
+// runGateTestWithLastCommand builds a no-Tech replay where the target player's
+// last command is at lastCmdSec, the replay runs to durationSec, and the
+// detector receives a worldstate that tracks per-player last command times.
+// Used to lock in the per-player time-in-game gate: a player who left or
+// stopped playing before the gate threshold must NOT trigger "never X"
+// markers even if the replay kept running long enough overall.
+func runGateTestWithLastCommand(t *testing.T, mk markers.Marker, teamFormat string, durationSec, lastCmdSec int) bool {
+	t.Helper()
+	builder := NewTestReplayBuilder().
+		WithPlayer(1, "own", "Protoss", 1).
+		WithPlayer(2, "opp", "Zerg", 2).
+		WithPlayer(3, "ally", "Protoss", 1).
+		WithPlayer(4, "ally2", "Zerg", 2).
+		WithDurationSeconds(durationSec).
+		WithCommand(1, lastCmdSec, models.ActionTypeBuild, models.GeneralUnitGateway)
+	replay, players := builder.Build()
+	replay.TeamFormat = teamFormat
+
+	ws := worldstate.NewEngine(replay, players, &models.ReplayMapContext{})
+	for _, cmd := range builder.GetCommands() {
+		ws.ProcessCommand(cmd)
+	}
+	ws.Finalize()
+
+	d := NewMarkerPlayerDetector(mk)
+	d.SetReplayPlayerID(1)
+	d.SetWorldState(ws)
+	d.Initialize(replay, players)
+	for _, cmd := range builder.GetCommands() {
+		d.ProcessCommand(cmd)
+	}
+	d.Finalize()
+	return d.ShouldSave()
+}
+
+// Non-1v1 (2v2), replay 20:00, target player's last command at 5:00. Flat
+// 10:00 floor applies (TeamFormat != "1v1"). Pre-fix, replay duration alone
+// gated this in → marker wrongly fired for a player who quit at 5:00 in a
+// 20:00 game. Post-fix, the player's last-command second is the effective
+// time-in-game and the marker is suppressed.
+func TestMarkerDetector_NonOneVOne_PlayerLeftBeforeFlatGate_Suppressed(t *testing.T) {
+	if runGateTestWithLastCommand(t, newGateTestMarker(), "2v2", 20*60, 5*60) {
+		t.Fatalf("expected suppression: 2v2 player whose last command was at 5:00 must not get a never_X marker on a 20:00 replay (10:00 floor)")
+	}
+}
+
+// Same 2v2 / 20:00 game, but the target player kept issuing commands past
+// the 10:00 floor (last command at 12:00). Marker should fire normally —
+// the per-player gate is satisfied.
+func TestMarkerDetector_NonOneVOne_PlayerStayedPastFlatGate_Fires(t *testing.T) {
+	if !runGateTestWithLastCommand(t, newGateTestMarker(), "2v2", 20*60, 12*60) {
+		t.Fatalf("expected fire: 2v2 player active until 12:00 must get the never_X marker on a 20:00 replay (10:00 floor)")
 	}
 }
 

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -303,21 +303,6 @@
   "never_upgraded.rep": {
     "detections": [
       {
-        "replay_player_id": 0,
-        "pattern_name": "Never researched",
-        "value": "831"
-      },
-      {
-        "replay_player_id": 0,
-        "pattern_name": "Never upgraded",
-        "value": "831"
-      },
-      {
-        "replay_player_id": 0,
-        "pattern_name": "Never used hotkeys",
-        "value": "831"
-      },
-      {
         "replay_player_id": 1,
         "pattern_name": "Build Order: 11 Hatch",
         "value": "{\"expert_actuals\":[{\"second\":98,\"found\":true},{\"second\":115,\"found\":true}]}"

--- a/internal/patterns/worldstate/engine.go
+++ b/internal/patterns/worldstate/engine.go
@@ -177,6 +177,7 @@ type Engine struct {
 	streamCommands []*models.Command
 	polygonGeoms   []PolygonGeom
 	leaveSec       map[byte]int
+	lastCmdSec     map[byte]int
 	finalized      bool
 }
 
@@ -200,6 +201,7 @@ func NewEngine(replay *models.Replay, players []*models.Player, mapCtx *models.R
 		entries:               make([]NarrativeEntry, 0, 256),
 		replayEvents:          make([]ReplayEvent, 0, 256),
 		leaveSec:              map[byte]int{},
+		lastCmdSec:            map[byte]int{},
 	}
 	for _, p := range players {
 		e.players[p.PlayerID] = p
@@ -265,6 +267,19 @@ func NewEngine(replay *models.Replay, players []*models.Player, mapCtx *models.R
 
 	e.assignDisplayNames()
 	return e
+}
+
+// LastCommandSecond reports the second of the player's last observed command
+// (any action that reached ProcessCommand). Returns ok=false for players who
+// issued zero commands. Used by per-player marker gates that must distinguish
+// "player had no time" from "player had time but didn't act" — leaveSec alone
+// is unreliable here because some replays record an early spurious leave_game
+// for players who keep playing afterwards. The last-command second is the
+// most robust "still playing by threshold" signal: if a player left, was
+// dropped, or AFK'd before the gate, their last command precedes it.
+func (e *Engine) LastCommandSecond(pid byte) (int, bool) {
+	sec, ok := e.lastCmdSec[pid]
+	return sec, ok
 }
 
 // EnrichedStream returns a copy of the full per-replay enriched-command
@@ -502,6 +517,11 @@ func (e *Engine) ProcessCommand(command *models.Command) {
 	sec := command.SecondsFromGameStart
 	if sec < 0 {
 		sec = 0
+	}
+	if pid, ok := e.playerIDFromCommand(command); ok {
+		if sec > e.lastCmdSec[pid] {
+			e.lastCmdSec[pid] = sec
+		}
 	}
 	if isLeaveAction(command.ActionType) {
 		if pid, ok := e.playerIDFromCommand(command); ok {


### PR DESCRIPTION
## Summary

Closes #123. Bundles the three items from the issue plus follow-ups requested during review, and a separate marker-gate bug fix found during the same pass.

### feat(dashboard): games-list polish + UI follow-ups

- **Update notice moved to top-right nav.** With the games list at 100 rows the footer is well below the fold and a new release is easy to miss. The 🆕 Update available link now sits next to Settings / Ingest (green call-to-action style).
- **Money-map markers render last** in featuring strips so regular markers (mech, rushes, mind control, etc.) take priority. Applies to both the games-list table pills (`workflowFeaturingFilters`) and the game-detail strip (`staticFeaturingOrder`). The 4 markers reordered: `carriers`, `battlecruisers`, `ten_plus_scouts`, `cliff_drop`.
- **Middle-dot separators** between text-meta elements in the game-detail header row: `19d @ 1.56pm · Neo Sylphid 3.2 · 13:17 · MM-…rep`, then the action buttons.
- **Footer uses the same middle-dot aesthetic** instead of period separators: `494 replays in database · screpdb by Mariano Gappa · 🐞 Report an issue`.
- **Error banner is dismissible** via an × button (aria-label="Dismiss error", role="alert"). Flex layout so long messages wrap cleanly.
- **Pagination sized down** to match table density: smaller buttons (3px/8px padding, 11px font), 12px page-info text. Scoped via `.workflow-pagination-row` so other `.btn-switch` usages elsewhere are untouched.

### fix(markers): gate never_X on per-player time-in-game

The 10-minute floor for `never_researched` / `never_upgraded` / `never_used_hotkeys` (and `viewport_multitasking`) compared against the whole replay's duration. In FFA / team games a player can leave or stop playing well before the floor while the replay keeps running — they were wrongly flagged "never upgraded" despite never having had the chance.

Worldstate now tracks per-player last-command second (`lastCmdSec` map, exposed via `LastCommandSecond(pid)`). `ShouldSave` compares the gate against `min(replay.DurationSeconds, lastCommandSecond)`. Last-command second is more robust than `leave_game` alone — some replays record a spurious early leave_game for players who keep playing.

Two new unit tests cover the fix:
- 2v2 / 20:00 replay, target player's last command at 5:00 → suppressed.
- Same setup but active until 12:00 → fires.

The existing `never_upgraded.rep` golden had P0 with a single command at second 2, so pre-fix three "never X" markers fired vacuously — the golden has been refreshed to reflect the correct (post-fix) behavior.

## Test plan

- [x] `go test ./...` — 258 tests pass across 35 packages.
- [x] Local preview (`screpdb-dashboard-alliances` config, port 8766):
  - Money-map game in games list: row pills now `Zergling Rush, Battlecruiser` (regular first, money second).
  - Game detail header reads `3d @ 12.15am · 💰 Big Game Hunters · 20:02 · 003714,(8)Big Game Hunters.rep` then the two buttons, with muted dots.
  - Featuring strip on the same game: `Zergling rush, Battlecruisers`.
  - Footer: `494 replays in database · screpdb by Mariano Gappa · 🐞 Report an issue`.
  - Update-available link injected via DOM to verify CSS — green text, green-tinted background and border, computed styles match.
  - Error banner: visually verified with a synthetic error — × button styled subtly, clickable, `aria-label` and `role="alert"` present.
  - Pagination buttons measurably smaller (28px tall → 21px) and proportions match the table content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
