### PR TITLE
feat: alliance event context + DT-drop classification (closes #133)

### DIFF
--- a/internal/dashboard/db/sqlc/queries/player_summary.sql
+++ b/internal/dashboard/db/sqlc/queries/player_summary.sql
@@ -30,7 +30,10 @@ ORDER BY games DESC, own_race, opp_race;
 -- 1v1 only. Per-(own_race, opp_race, marker_event_type) replay counts. The
 -- consumer splits build-order markers (event_type LIKE 'bo_%') from the rest
 -- and surfaces the top-N per matchup. Excludes meta markers that are not
--- meaningful per-matchup features.
+-- meaningful per-matchup features. Drop subtype game events
+-- (dt_drop / reaver_drop / cliff_drop) are also surfaced alongside the
+-- generic `made_drops` marker so subtype-level signal lands on the Player
+-- summary cards.
 SELECT
   self.race AS own_race,
   opp.race AS opp_race,
@@ -44,13 +47,17 @@ WHERE lower(trim(self.name)) = ?
   AND lower(trim(coalesce(self.type, ''))) = 'human'
   AND opp.is_observer = 0
   AND lower(trim(coalesce(opp.type, ''))) = 'human'
-  AND re.event_kind = 'marker'
-  AND re.event_type NOT IN (
-    'used_hotkey_groups',
-    'viewport_multitasking',
-    'mid_game_starts',
-    'late_game_starts',
-    'never_used_hotkeys'
+  AND (
+    (re.event_kind = 'marker' AND re.event_type NOT IN (
+      'used_hotkey_groups',
+      'viewport_multitasking',
+      'mid_game_starts',
+      'late_game_starts',
+      'never_used_hotkeys'
+    ))
+    OR (re.event_kind = 'game_event' AND re.event_type IN (
+      'dt_drop', 'reaver_drop', 'cliff_drop'
+    ))
   )
   AND 2 = (
     SELECT COUNT(*) FROM players p
@@ -90,7 +97,9 @@ GROUP BY p.race, r.team_format, r.map_kind;
 -- Per-(own_race, team_format, map_kind, marker) replay counts for the by-
 -- format summary cards. Same exclusion list as the per-matchup query so
 -- meta markers (hotkeys, viewport multitasking, phase boundaries) don't
--- pollute the top-N pills.
+-- pollute the top-N pills. Drop subtype game events
+-- (dt_drop / reaver_drop / cliff_drop) are also surfaced alongside the
+-- generic `made_drops` marker for subtype-level signal.
 SELECT
   p.race AS own_race,
   r.team_format AS team_format,
@@ -106,13 +115,17 @@ WHERE lower(trim(p.name)) = ?
   AND r.map_kind IN ('Regular', 'Money')
   AND r.team_format LIKE '%v%'
   AND r.team_format != '1v1'
-  AND re.event_kind = 'marker'
-  AND re.event_type NOT IN (
-    'used_hotkey_groups',
-    'viewport_multitasking',
-    'mid_game_starts',
-    'late_game_starts',
-    'never_used_hotkeys'
+  AND (
+    (re.event_kind = 'marker' AND re.event_type NOT IN (
+      'used_hotkey_groups',
+      'viewport_multitasking',
+      'mid_game_starts',
+      'late_game_starts',
+      'never_used_hotkeys'
+    ))
+    OR (re.event_kind = 'game_event' AND re.event_type IN (
+      'dt_drop', 'reaver_drop', 'cliff_drop'
+    ))
   )
 GROUP BY p.race, r.team_format, r.map_kind, re.event_type;
 

--- a/internal/dashboard/db/sqlcgen/player_summary.sql.go
+++ b/internal/dashboard/db/sqlcgen/player_summary.sql.go
@@ -143,13 +143,17 @@ WHERE lower(trim(p.name)) = ?
   AND r.map_kind IN ('Regular', 'Money')
   AND r.team_format LIKE '%v%'
   AND r.team_format != '1v1'
-  AND re.event_kind = 'marker'
-  AND re.event_type NOT IN (
-    'used_hotkey_groups',
-    'viewport_multitasking',
-    'mid_game_starts',
-    'late_game_starts',
-    'never_used_hotkeys'
+  AND (
+    (re.event_kind = 'marker' AND re.event_type NOT IN (
+      'used_hotkey_groups',
+      'viewport_multitasking',
+      'mid_game_starts',
+      'late_game_starts',
+      'never_used_hotkeys'
+    ))
+    OR (re.event_kind = 'game_event' AND re.event_type IN (
+      'dt_drop', 'reaver_drop', 'cliff_drop'
+    ))
   )
 GROUP BY p.race, r.team_format, r.map_kind, re.event_type
 `
@@ -165,7 +169,9 @@ type ListPlayerByFormatMarkerCountsRow struct {
 // Per-(own_race, team_format, map_kind, marker) replay counts for the by-
 // format summary cards. Same exclusion list as the per-matchup query so
 // meta markers (hotkeys, viewport multitasking, phase boundaries) don't
-// pollute the top-N pills.
+// pollute the top-N pills. Drop subtype game events
+// (dt_drop / reaver_drop / cliff_drop) are also surfaced alongside the
+// generic `made_drops` marker for subtype-level signal.
 func (q *Queries) ListPlayerByFormatMarkerCounts(ctx context.Context, name string) ([]ListPlayerByFormatMarkerCountsRow, error) {
 	rows, err := q.db.QueryContext(ctx, ListPlayerByFormatMarkerCounts, name)
 	if err != nil {
@@ -277,13 +283,17 @@ WHERE lower(trim(self.name)) = ?
   AND lower(trim(coalesce(self.type, ''))) = 'human'
   AND opp.is_observer = 0
   AND lower(trim(coalesce(opp.type, ''))) = 'human'
-  AND re.event_kind = 'marker'
-  AND re.event_type NOT IN (
-    'used_hotkey_groups',
-    'viewport_multitasking',
-    'mid_game_starts',
-    'late_game_starts',
-    'never_used_hotkeys'
+  AND (
+    (re.event_kind = 'marker' AND re.event_type NOT IN (
+      'used_hotkey_groups',
+      'viewport_multitasking',
+      'mid_game_starts',
+      'late_game_starts',
+      'never_used_hotkeys'
+    ))
+    OR (re.event_kind = 'game_event' AND re.event_type IN (
+      'dt_drop', 'reaver_drop', 'cliff_drop'
+    ))
   )
   AND 2 = (
     SELECT COUNT(*) FROM players p
@@ -304,7 +314,10 @@ type ListPlayerMatchupMarkerCountsRow struct {
 // 1v1 only. Per-(own_race, opp_race, marker_event_type) replay counts. The
 // consumer splits build-order markers (event_type LIKE 'bo_%') from the rest
 // and surfaces the top-N per matchup. Excludes meta markers that are not
-// meaningful per-matchup features.
+// meaningful per-matchup features. Drop subtype game events
+// (dt_drop / reaver_drop / cliff_drop) are also surfaced alongside the
+// generic `made_drops` marker so subtype-level signal lands on the Player
+// summary cards.
 func (q *Queries) ListPlayerMatchupMarkerCounts(ctx context.Context, name string) ([]ListPlayerMatchupMarkerCountsRow, error) {
 	rows, err := q.db.QueryContext(ctx, ListPlayerMatchupMarkerCounts, name)
 	if err != nil {

--- a/internal/dashboard/endpoint_custom_markers_definitions.go
+++ b/internal/dashboard/endpoint_custom_markers_definitions.go
@@ -26,10 +26,15 @@ type markerDefinition struct {
 // gameEventFeature covers the game-event-only featuring chips (cannon_rush,
 // bunker_rush, zergling_rush, mind_control) that aren't markers but still need
 // a frontend-renderable entry in the Featuring strip.
+//
+// IconKeys (multi-icon) wins over IconKey when both are populated — mirrors
+// the marker-filter chip layout so subtype pills (DT Drop, Reaver Drop) can
+// surface a shuttle + payload-unit pair like the games-list filter row.
 type gameEventFeature struct {
-	Key     string `json:"key"`
-	Label   string `json:"label"`
-	IconKey string `json:"icon_key"`
+	Key      string   `json:"key"`
+	Label    string   `json:"label"`
+	IconKey  string   `json:"icon_key,omitempty"`
+	IconKeys []string `json:"icon_keys,omitempty"`
 }
 
 type markersDefinitionsResponse struct {
@@ -51,8 +56,8 @@ var staticGameEventFeatures = []gameEventFeature{
 	{Key: "proxy_rax", Label: "Proxy barracks", IconKey: "barracks"},
 	{Key: "proxy_factory", Label: "Proxy factory", IconKey: "factory"},
 	{Key: "drop", Label: "Drop", IconKey: "shuttle"},
-	{Key: "dt_drop", Label: "DT Drop", IconKey: "darktemplar"},
-	{Key: "reaver_drop", Label: "Reaver Drop", IconKey: "reaver"},
+	{Key: "dt_drop", Label: "DT Drop", IconKeys: []string{"shuttle", "darktemplar"}},
+	{Key: "reaver_drop", Label: "Reaver Drop", IconKeys: []string{"shuttle", "reaver"}},
 	{Key: "mind_control", Label: "Mind control", IconKey: "darkarchon"},
 }
 

--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -202,6 +202,7 @@ func (d *Dashboard) populateDetectedPatternsForGameDetail(detail *workflowGameDe
 	}
 	detail.GameEvents = replayEventsFromRows(eventRows, mapLayout, startClockByPlayerID)
 	detail.GameEvents = resolveRecallTargetOwners(detail.GameEvents, detail.Players)
+	detail.GameEvents = resolveAllianceTeamPlayers(detail.GameEvents, detail.Players, displayByName)
 	for i := range detail.GameEvents {
 		event := &detail.GameEvents[i]
 		if event.Actor != nil {
@@ -217,6 +218,14 @@ func (d *Dashboard) populateDetectedPatternsForGameDetail(detail *workflowGameDe
 		if event.TargetOwner != nil {
 			if displayName, ok := displayByName[event.TargetOwner.Name]; ok {
 				event.TargetOwner.Name = displayName
+			}
+		}
+		for ti := range event.AllianceTeams {
+			team := event.AllianceTeams[ti]
+			for pi := range team {
+				if displayName, ok := displayByName[team[pi].Name]; ok {
+					team[pi].Name = displayName
+				}
 			}
 		}
 	}
@@ -1498,7 +1507,85 @@ func replayEventsFromRows(rows []db.ReplayEventRow, mapLayout *models.MapContext
 		if isDropEventType(event.Type) && row.Payload != nil && *row.Payload != "" {
 			applyDropPayload(&event, *row.Payload, baseMetas)
 		}
+		if event.Type == "late_alliance" && row.Payload != nil && *row.Payload != "" {
+			applyAlliancePayload(&event, *row.Payload)
+		}
 		events = append(events, event)
+	}
+	return events
+}
+
+// applyAlliancePayload decodes the {"teams":[["A","B"],["C"]]} payload that
+// parser.BuildAllianceDerivedEvents writes for late_alliance events and stamps
+// event.AllianceTeams with name-only player entries. PlayerID and Color are
+// filled in a second pass (resolveAllianceTeamPlayers) which has access to the
+// player roster.
+func applyAlliancePayload(event *workflowGameEvent, raw string) {
+	var pl struct {
+		Teams [][]string `json:"teams"`
+	}
+	if err := json.Unmarshal([]byte(raw), &pl); err != nil {
+		return
+	}
+	teams := make([][]workflowGameEventPlayer, 0, len(pl.Teams))
+	for _, team := range pl.Teams {
+		if len(team) < 2 {
+			continue
+		}
+		row := make([]workflowGameEventPlayer, 0, len(team))
+		for _, name := range team {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			row = append(row, workflowGameEventPlayer{Name: name})
+		}
+		if len(row) >= 2 {
+			teams = append(teams, row)
+		}
+	}
+	if len(teams) > 0 {
+		event.AllianceTeams = teams
+	}
+}
+
+// resolveAllianceTeamPlayers fills PlayerID and Color on each entry of every
+// event's AllianceTeams. Mirrors the post-hoc resolution pattern used by
+// resolveRecallTargetOwners — applyAlliancePayload runs inside
+// replayEventsFromRows where the player roster isn't available.
+//
+// Lookups are keyed by both the raw player name (as stored in the alliance
+// payload) and the display name (post displayByName aliasing) to cover both
+// cases — detail.Players carries the display name in .Name, so a raw-name
+// payload entry like "chobo86" would otherwise miss the lookup for a player
+// whose display name is "chobo86 (you)".
+func resolveAllianceTeamPlayers(events []workflowGameEvent, players []workflowGamePlayer, displayByName map[string]string) []workflowGameEvent {
+	if len(events) == 0 {
+		return events
+	}
+	byName := make(map[string]*workflowGamePlayer, len(players)*2)
+	for i := range players {
+		byName[players[i].Name] = &players[i]
+	}
+	// Map raw payload names back to the patched display-name entry in detail.Players.
+	for raw, display := range displayByName {
+		if p, ok := byName[display]; ok {
+			byName[raw] = p
+		}
+	}
+	for i := range events {
+		if events[i].Type != "late_alliance" || len(events[i].AllianceTeams) == 0 {
+			continue
+		}
+		for ti := range events[i].AllianceTeams {
+			team := events[i].AllianceTeams[ti]
+			for pi := range team {
+				if p, ok := byName[team[pi].Name]; ok {
+					team[pi].PlayerID = p.PlayerID
+					team[pi].Color = p.Color
+				}
+			}
+		}
 	}
 	return events
 }

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -549,6 +549,11 @@ type workflowGameEvent struct {
 	DropTargetVia  string `json:"drop_target_via,omitempty"`  // "a" | "p"
 	DropCount      int64  `json:"drop_count,omitempty"`        // omitted when 1
 	DropLastSecond int64  `json:"drop_last_second,omitempty"`  // omitted when equal to Second
+	// AllianceTeams: populated only for late_alliance events. Each entry is
+	// one team grouping at the moment the topology changed. Only teams of
+	// size ≥2 are included (solos filtered for clarity). Source is the
+	// {"teams":[["A","B"],...]} payload written by parser.BuildAllianceDerivedEvents.
+	AllianceTeams [][]workflowGameEventPlayer `json:"alliance_teams,omitempty"`
 }
 
 type workflowGameEventPlayer struct {

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -188,11 +188,45 @@ const playerGameSummarySignalParts = (player, gameEvents) => {
     return { positive: [], noScout: null };
   }
 
-  if (playerIsActorForGameEventTypes(events, pid, DROP_ACTOR_EVENT_TYPES)) {
+  // Drop pills — one per variant the player was the actor for. Filter UI
+  // dictates the icon layout: DT Drop / Reaver Drop ride two icons (shuttle
+  // + payload unit) side-by-side; generic Drop and Cliff drop keep the
+  // single transport icon. The post-process elideGenericDropPill drops the
+  // generic "drop" entry when any specific variant fired.
+  const transportIcon = dropTransportIconForRace(player?.race);
+  if (playerIsActorForGameEventTypes(events, pid, ['drop'])) {
     positive.push({
-      key: `ge-drop-${pid}`,
-      icon: dropTransportIconForRace(player?.race),
-      label: 'Dropped',
+      key: 'drop',
+      domKey: `ge-drop-${pid}`,
+      icons: [transportIcon].filter(Boolean),
+      label: 'Drop',
+      className: 'workflow-pattern-pill workflow-pattern-pill-strong',
+    });
+  }
+  if (playerIsActorForGameEventTypes(events, pid, ['dt_drop'])) {
+    positive.push({
+      key: 'dt_drop',
+      domKey: `ge-dt-drop-${pid}`,
+      icons: [getUnitIcon('shuttle'), getUnitIcon('darktemplar')].filter(Boolean),
+      label: 'DT Drop',
+      className: 'workflow-pattern-pill workflow-pattern-pill-strong',
+    });
+  }
+  if (playerIsActorForGameEventTypes(events, pid, ['reaver_drop'])) {
+    positive.push({
+      key: 'reaver_drop',
+      domKey: `ge-reaver-drop-${pid}`,
+      icons: [getUnitIcon('shuttle'), getUnitIcon('reaver')].filter(Boolean),
+      label: 'Reaver Drop',
+      className: 'workflow-pattern-pill workflow-pattern-pill-strong',
+    });
+  }
+  if (playerIsActorForGameEventTypes(events, pid, ['cliff_drop'])) {
+    positive.push({
+      key: 'cliff_drop',
+      domKey: `ge-cliff-drop-${pid}`,
+      icons: [getUnitIcon('dropship')].filter(Boolean),
+      label: 'Cliff drop',
       className: 'workflow-pattern-pill workflow-pattern-pill-strong',
     });
   }
@@ -237,15 +271,21 @@ const playerGameSummarySignalParts = (player, gameEvents) => {
     });
   }
 
-  return { positive, noScout: null };
+  return { positive: elideGenericDropPill(positive), noScout: null };
 };
 
-const renderGameSummarySignalPill = (pill) => (
-  <span key={pill.key} className={pill.className} title={pill.title}>
-    {pill.icon ? <img src={pill.icon} alt="" className="workflow-pattern-icon" /> : null}
-    <span>{pill.label}</span>
-  </span>
-);
+const renderGameSummarySignalPill = (pill) => {
+  // Backwards-compat: older entries use { icon }, drop pills use { icons: [] }.
+  const icons = Array.isArray(pill.icons) ? pill.icons : (pill.icon ? [pill.icon] : []);
+  return (
+    <span key={pill.domKey || pill.key} className={pill.className} title={pill.title}>
+      {icons.map((url, i) => (
+        <img key={`${pill.key || pill.domKey}-i${i}`} src={url} alt="" className="workflow-pattern-icon" />
+      ))}
+      <span>{pill.label}</span>
+    </span>
+  );
+};
 
 const isStructuralGameEventType = (eventType) => ['player_start', 'location_inactive'].includes(normalizeEventType(eventType));
 
@@ -261,6 +301,15 @@ const isActorAtOwnNaturalBase = (event) => {
   }
   const naturalOfNum = Number(naturalOf);
   return Number.isFinite(naturalOfNum) && actorStart === naturalOfNum;
+};
+
+// joinWithAnd renders a name list as "A and B" / "A, B, and C" — used by the
+// alliance event description for 2+ player teams.
+const joinWithAnd = (items) => {
+  if (!Array.isArray(items) || items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
 };
 
 const gameEventLocationLabel = (event) => {
@@ -308,6 +357,12 @@ const gameEventDescription = (event, registry) => {
   if (eventType === 'leave_game') return actor ? `${actor} leaves the game` : 'Player leaves the game';
   if (eventType === 'player_stopped_playing') return actor ? `${actor} stops playing` : 'Player stops playing';
   if (eventType === 'late_alliance') {
+    const teams = Array.isArray(event?.alliance_teams) ? event.alliance_teams : [];
+    const teamPhrases = teams
+      .map((team) => Array.isArray(team) ? team.map((p) => String(p?.name || '').trim()).filter(Boolean) : [])
+      .filter((names) => names.length >= 2)
+      .map((names) => `${joinWithAnd(names)} form an alliance`);
+    if (teamPhrases.length > 0) return teamPhrases.join('; ');
     if (actor && target) return `${actor} allies with ${target}`;
     return actor ? `${actor} forms an alliance` : 'Alliance';
   }
@@ -320,7 +375,10 @@ const gameEventDescription = (event, registry) => {
   if (eventType === 'attack') return actor && target && location ? `${actor} attacks ${target} at ${location}` : 'Attack';
   if (eventType === 'scout') return actor && target && location ? `${actor} scouts ${target} at ${location}` : 'Scout';
   if (eventType === 'cliff_drop' || eventType === 'drop' || eventType === 'reaver_drop' || eventType === 'dt_drop') {
-    const fallback = eventType === 'cliff_drop' ? 'Cliff drop' : 'Drop';
+    const fallback = eventType === 'cliff_drop' ? 'Cliff drop'
+      : eventType === 'dt_drop' ? 'DT drop'
+      : eventType === 'reaver_drop' ? 'Reaver drop'
+      : 'Drop';
     if (!actor || !target || !location) return fallback;
     // event.base is the destination polygon for drops (toReplayEvent stamps
     // DstPolyID there). Source, when worldstate could resolve it, lives on
@@ -331,7 +389,10 @@ const gameEventDescription = (event, registry) => {
     if (eventType === 'cliff_drop') {
       return `${actor} cliff drops${dropCount}${fromClause} ${target} at ${location}`;
     }
-    return `${actor} drops${dropCount}${fromClause} on ${target} at ${location}`;
+    const verb = eventType === 'dt_drop' ? 'DT drops'
+      : eventType === 'reaver_drop' ? 'Reaver drops'
+      : 'drops';
+    return `${actor} ${verb}${dropCount}${fromClause} on ${target} at ${location}`;
   }
   if (eventType === 'recall') {
     // CastRecall's X/Y is the *source* of the teleport; the destination is
@@ -420,6 +481,31 @@ const renderGameEventDescription = (event, registry, playerRaceByID) => {
   if (eventType === 'leave_game') return actorName ? <>{actorSpan} leaves the game</> : 'Player leaves the game';
   if (eventType === 'player_stopped_playing') return actorName ? <>{actorSpan} stops playing</> : 'Player stops playing';
   if (eventType === 'late_alliance') {
+    const teams = Array.isArray(event?.alliance_teams) ? event.alliance_teams : [];
+    const teamPhrases = teams
+      .map((team) => Array.isArray(team) ? team.filter((p) => String(p?.name || '').trim()) : [])
+      .filter((row) => row.length >= 2);
+    if (teamPhrases.length > 0) {
+      return (
+        <>
+          {teamPhrases.map((row, ti) => {
+            const spans = row.map((p, pi) => (
+              <React.Fragment key={`a-${ti}-${pi}`}>
+                {gamePlayerNameSpan(p, `a-${ti}-p-${pi}`)}
+                {pi < row.length - 2 ? ', ' : null}
+                {pi === row.length - 2 ? (row.length === 2 ? ' and ' : ', and ') : null}
+              </React.Fragment>
+            ));
+            return (
+              <React.Fragment key={`team-${ti}`}>
+                {ti > 0 ? '; ' : null}
+                {spans} form an alliance
+              </React.Fragment>
+            );
+          })}
+        </>
+      );
+    }
     if (actorName && targetName) return <>{actorSpan} allies with {targetSpan}</>;
     return actorName ? <>{actorSpan} forms an alliance</> : 'Alliance';
   }
@@ -440,7 +526,10 @@ const renderGameEventDescription = (event, registry, playerRaceByID) => {
       : 'Scout';
   }
   if (eventType === 'cliff_drop' || eventType === 'drop' || eventType === 'reaver_drop' || eventType === 'dt_drop') {
-    const fallback = eventType === 'cliff_drop' ? 'Cliff drop' : 'Drop';
+    const fallback = eventType === 'cliff_drop' ? 'Cliff drop'
+      : eventType === 'dt_drop' ? 'DT drop'
+      : eventType === 'reaver_drop' ? 'Reaver drop'
+      : 'Drop';
     if (!actorName || !targetName || !location) return fallback;
     const sourceLabel = String(event?.source_base?.name || '').trim();
     const dropCount = Number(event?.drop_count || 0) > 1 ? ` (×${event.drop_count})` : '';
@@ -464,7 +553,10 @@ const renderGameEventDescription = (event, registry, playerRaceByID) => {
     if (eventType === 'cliff_drop') {
       return <>{actorSpan} cliff drops{vesselIcon}{dropCount}{fromClause} {targetSpan} at {location}</>;
     }
-    return <>{actorSpan} drops{vesselIcon}{dropCount}{fromClause} on {targetSpan} at {location}</>;
+    const verb = eventType === 'dt_drop' ? 'DT drops'
+      : eventType === 'reaver_drop' ? 'Reaver drops'
+      : 'drops';
+    return <>{actorSpan} {verb}{vesselIcon}{dropCount}{fromClause} on {targetSpan} at {location}</>;
   }
   if (eventType === 'recall') {
     if (!actorName) return 'Recall';
@@ -637,6 +729,14 @@ const collectFeaturingKeysFromMainGame = (mainGame) => {
     if (t === 'proxy_gate')     keys.add('proxy_gate');
     if (t === 'proxy_rax')      keys.add('proxy_rax');
     if (t === 'proxy_factory')  keys.add('proxy_factory');
+    // Drop variants: every variant lights the generic 'drop' key; specific
+    // subtypes (dt_drop / reaver_drop / cliff_drop) also light their own
+    // key. The post-process elision below drops the generic chip when a
+    // specific variant is present (avoids redundant "Drop + DT Drop").
+    if (t === 'drop' || t === 'dt_drop' || t === 'reaver_drop' || t === 'cliff_drop') {
+      keys.add('drop');
+      keys.add(t);
+    }
   });
 
   (mainGame?.players || []).forEach((p) => {
@@ -663,6 +763,10 @@ const collectFeaturingKeysFromMainGame = (mainGame) => {
 // zergling_rush, mind_control) come from the backend-provided featuring_order
 // and game_event_features lists. Marker pills come from the marker registry's
 // games_list field; markers without one surface via a minimal fallback.
+//
+// Post-process: when a more-specific drop variant pill is present
+// (dt_drop / reaver_drop / cliff_drop), the generic "drop" pill is elided
+// so the strip doesn't carry both "Drop" + "DT Drop".
 const buildMainGameFeaturingPills = (mainGame, markerDefs) => {
   if (!mainGame) return [];
   const { keys, rowByKey } = collectFeaturingKeysFromMainGame(mainGame);
@@ -671,7 +775,7 @@ const buildMainGameFeaturingPills = (mainGame, markerDefs) => {
   const gameEventFeaturesByKey = {};
   (markerDefs?.game_event_features || []).forEach((f) => { gameEventFeaturesByKey[f.key] = f; });
 
-  return order
+  const pills = order
     .filter((key) => keys.has(key))
     .map((key) => {
       const def = registry[key];
@@ -686,16 +790,49 @@ const buildMainGameFeaturingPills = (mainGame, markerDefs) => {
         return { key, label: def.games_list.label || def.name, iconKey: def.games_list.icon_key || '' };
       }
       const ge = gameEventFeaturesByKey[key];
-      if (ge) return { key, label: ge.label, iconKey: ge.icon_key };
+      if (ge) return { key, label: ge.label, iconKey: ge.icon_key || '', iconKeys: ge.icon_keys || [] };
       return { key, label: def?.name || key, iconKey: '' };
     });
+
+  return elideGenericDropPill(pills);
+};
+
+// elideGenericDropPill removes the generic "drop" pill from a pill list when
+// any more-specific drop variant (dt_drop / reaver_drop / cliff_drop) is
+// present in the same list. Operates on entries shaped like { key, ... } so
+// the same helper can be reused across the main featuring strip, per-player
+// signal pills, and the games-list table column.
+const SPECIFIC_DROP_KEYS = new Set(['dt_drop', 'reaver_drop', 'cliff_drop']);
+const elideGenericDropPill = (pills) => {
+  if (!Array.isArray(pills) || pills.length === 0) return pills;
+  const hasSpecific = pills.some((p) => SPECIFIC_DROP_KEYS.has(String(p?.key || '')));
+  if (!hasSpecific) return pills;
+  return pills.filter((p) => String(p?.key || '') !== 'drop');
+};
+
+// elideGenericDropLabels mirrors elideGenericDropPill for the games-list
+// table, whose Featuring column carries plain strings ("Drop", "DT Drop",
+// "DT Drop 7:59") rather than {key, ...} objects. We match on the
+// pre-timestamp prefix so suffixes like " 7:59" don't break detection.
+const SPECIFIC_DROP_LABEL_PREFIXES = ['DT Drop', 'Reaver Drop', 'Cliff drop'];
+const elideGenericDropLabels = (labels) => {
+  if (!Array.isArray(labels) || labels.length === 0) return labels;
+  const startsWith = (s, prefix) => typeof s === 'string' && (s === prefix || s.startsWith(`${prefix} `));
+  const hasSpecific = labels.some((l) => SPECIFIC_DROP_LABEL_PREFIXES.some((p) => startsWith(l, p)));
+  if (!hasSpecific) return labels;
+  return labels.filter((l) => !startsWith(l, 'Drop'));
 };
 
 const renderFeaturingPill = (pill, keyPrefix) => {
-  const icon = pill.iconKey ? getUnitIcon(pill.iconKey) : null;
+  const iconKeys = (Array.isArray(pill.iconKeys) && pill.iconKeys.length)
+    ? pill.iconKeys
+    : (pill.iconKey ? [pill.iconKey] : []);
+  const iconUrls = iconKeys.map((k) => getUnitIcon(k)).filter(Boolean);
   return (
     <span key={`${keyPrefix}-${pill.key}`} className="workflow-pattern-pill workflow-pattern-pill-strong workflow-summary-feature-pill">
-      {icon ? <img src={icon} alt="" className="workflow-pattern-icon" /> : null}
+      {iconUrls.map((url, i) => (
+        <img key={`${pill.key}-i${i}`} src={url} alt="" className="workflow-pattern-icon" />
+      ))}
       <span>{pill.label}</span>
     </span>
   );
@@ -1269,14 +1406,37 @@ const filterSummaryPillPatterns = (patterns, trustGameEventsForDrops = false) =>
 // temporal placeholders stripped) so the labels read as static prose
 // ("Recalls", "Threw Nukes", "Became Zerg") instead of the per-replay
 // "Recalls at min N" / "Threw Nukes at N mins" form.
-const renderAggregatePatternEntry = (entry, key, registry) => {
-  const pattern = { event_type: entry.pattern_name };
+const renderAggregatePatternEntry = (entry, key, registry, gameEventFeaturesByKey) => {
+  const patternKey = String(entry?.pattern_name || '');
+  // Game-event features (dt_drop / reaver_drop / cliff_drop) aren't in the
+  // marker registry — resolve them via the game_event_features metadata so
+  // the pill renders with the proper label + multi-icon layout (matching
+  // the filter row and game-detail strip).
+  const ge = gameEventFeaturesByKey ? gameEventFeaturesByKey[patternKey] : null;
+  if (ge) {
+    const iconKeys = (Array.isArray(ge.icon_keys) && ge.icon_keys.length)
+      ? ge.icon_keys
+      : (ge.icon_key ? [ge.icon_key] : []);
+    const iconUrls = iconKeys.map((k) => getUnitIcon(k)).filter(Boolean);
+    return (
+      <span key={`${key}-wrap`} className="workflow-pattern-with-count">
+        <span className="workflow-pattern-pill workflow-pattern-pill-strong" title={ge.label}>
+          {iconUrls.map((url, i) => (
+            <img key={`${patternKey}-i${i}`} src={url} alt="" className="workflow-pattern-icon" />
+          ))}
+          <span>{ge.label}</span>
+        </span>
+        <span className="workflow-pattern-count">×{entry.count}</span>
+      </span>
+    );
+  }
+  const pattern = { event_type: patternKey };
   const def = lookupDefinitionForPattern(registry, pattern);
   const rendered = def ? renderAggregatePillText(def) : null;
   if (!rendered) {
     return (
-      <span key={`${key}-fallback`} className="workflow-pattern-pill" title={entry.pattern_name}>
-        {entry.pattern_name} <span className="workflow-pattern-count">×{entry.count}</span>
+      <span key={`${key}-fallback`} className="workflow-pattern-pill" title={patternKey}>
+        {patternKey} <span className="workflow-pattern-count">×{entry.count}</span>
       </span>
     );
   }
@@ -1291,14 +1451,14 @@ const renderAggregatePatternEntry = (entry, key, registry) => {
   );
 };
 
-const renderMatchupPatternSection = (title, entries, keyPrefix, registry) => {
+const renderMatchupPatternSection = (title, entries, keyPrefix, registry, gameEventFeaturesByKey) => {
   const list = Array.isArray(entries) ? entries : [];
   if (list.length === 0) return null;
   return (
     <div className="workflow-player-matchup-section">
       <div className="workflow-player-matchup-section-title">{title}</div>
       <div className="workflow-pattern-pills workflow-pattern-pills-compact">
-        {list.map((entry, idx) => renderAggregatePatternEntry(entry, `${keyPrefix}-${idx}`, registry))}
+        {list.map((entry, idx) => renderAggregatePatternEntry(entry, `${keyPrefix}-${idx}`, registry, gameEventFeaturesByKey))}
       </div>
     </div>
   );
@@ -1496,6 +1656,14 @@ function App() {
   const markerRegistryState = useMarkerRegistry();
   const markerRegistry = markerRegistryState.markers;
   const markerDefinitions = markerRegistryState;
+  // Game-event features (drop subtypes, mind_control, rushes, proxies) keyed
+  // by their event_type — used by aggregate pill renderers to surface
+  // multi-icon pills for subtypes that aren't in the marker registry.
+  const mainPlayerGameEventFeaturesByKey = useMemo(() => {
+    const out = {};
+    (markerRegistryState?.game_event_features || []).forEach((f) => { if (f?.key) out[f.key] = f; });
+    return out;
+  }, [markerRegistryState?.game_event_features]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showGlobalReplayFilter, setShowGlobalReplayFilter] = useState(false);
@@ -3674,6 +3842,49 @@ function App() {
     if (!point) return null;
     return { icon, point };
   }, [selectedMainGameEvent, mainEventMapBounds]);
+  // Alliance overlay: for late_alliance events, render one 🤝 emoji per pair
+  // of allied players at the midpoint between their bases, plus a pair of
+  // bidirectional arrows running base↔🤝 in each player's color. The pair is
+  // skipped entirely when either player has no owned base at event time (per
+  // the spec — alliance is between active footprints, not absent ones).
+  const selectedMainGameAllianceOverlay = useMemo(() => {
+    if (normalizeEventType(selectedMainGameEvent?.type) !== 'late_alliance') return null;
+    if (!mainEventMapBounds) return null;
+    const teams = Array.isArray(selectedMainGameEvent?.alliance_teams) ? selectedMainGameEvent.alliance_teams : [];
+    if (teams.length === 0) return null;
+    const ownership = Array.isArray(selectedMainGameEvent?.ownership) ? selectedMainGameEvent.ownership : [];
+    const anchorForPlayer = (playerID) => {
+      const owned = ownership.filter((entry) => Number(entry?.owner?.player_id || 0) === playerID && entry?.base?.center);
+      if (owned.length === 0) return null;
+      const preferred = owned.find((entry) => String(entry?.base?.kind || '').toLowerCase() === 'starting') || owned[0];
+      const point = mapPointToPercent(preferred?.base?.center, mainEventMapBounds);
+      if (!point) return null;
+      return { point, base: preferred.base };
+    };
+    const pairs = [];
+    const consumedBases = [];
+    for (const team of teams) {
+      if (!Array.isArray(team) || team.length < 2) continue;
+      for (let i = 0; i < team.length; i += 1) {
+        for (let j = i + 1; j < team.length; j += 1) {
+          const a = team[i];
+          const b = team[j];
+          const aAnchor = anchorForPlayer(Number(a?.player_id || 0));
+          const bAnchor = anchorForPlayer(Number(b?.player_id || 0));
+          if (!aAnchor || !bAnchor) continue;
+          pairs.push({
+            key: `${Number(a?.player_id || 0)}-${Number(b?.player_id || 0)}`,
+            a: { from: aAnchor.point, color: playerColorToCss(a?.color) },
+            b: { from: bAnchor.point, color: playerColorToCss(b?.color) },
+            mid: { x: (aAnchor.point.x + bAnchor.point.x) / 2, y: (aAnchor.point.y + bAnchor.point.y) / 2 },
+          });
+          consumedBases.push(aAnchor.base, bAnchor.base);
+        }
+      }
+    }
+    if (pairs.length === 0) return null;
+    return { pairs, consumedBases };
+  }, [selectedMainGameEvent, mainEventMapBounds]);
   // Trained-units overlay (issue #122 BONUS): paint a small chip with each
   // player's army composition (top 4 unit types + "+N" pill) on top of the
   // player's largest owned polygon at the moment of the selected event.
@@ -3808,6 +4019,12 @@ function App() {
       }
       if (bestEntry && bestDist < 8) claimBase(bestEntry.base);
     }
+    // Alliance overlay: every base anchoring a 🤝 arrow is off-limits so
+    // the player's trained-units chip moves to a different owned base
+    // (preserving production info when one exists, hiding when it doesn't).
+    if (selectedMainGameAllianceOverlay?.consumedBases) {
+      for (const b of selectedMainGameAllianceOverlay.consumedBases) claimBase(b);
+    }
 
     const isOffLimits = (base) => {
       if (!base) return true;
@@ -3854,6 +4071,12 @@ function App() {
       const ARROW_AVOID_PCT = 9;
       const arrowFrom = selectedMainGameArrow?.from || null;
       const arrowTo = selectedMainGameArrow?.to || null;
+      // Alliance overlay segments base→midpoint per pair — chips should also
+      // stay clear of these so 🤝 + arrows aren't covered by production icons.
+      const allianceSegments = (selectedMainGameAllianceOverlay?.pairs || []).flatMap((pair) => ([
+        [pair.a.from, pair.mid],
+        [pair.b.from, pair.mid],
+      ]));
       let anchorBase = null;
       let point = null;
       for (const b of ranked) {
@@ -3866,6 +4089,11 @@ function App() {
           const d = distanceToSegment(pct, arrowFrom, arrowTo);
           if (d < ARROW_AVOID_PCT) continue;
         }
+        let tooClose = false;
+        for (const [from, to] of allianceSegments) {
+          if (distanceToSegment(pct, from, to) < ARROW_AVOID_PCT) { tooClose = true; break; }
+        }
+        if (tooClose) continue;
         anchorBase = b;
         point = pct;
         break;
@@ -3887,6 +4115,7 @@ function App() {
     mainEventMapBounds,
     selectedMainGameTrainedUnitsByPlayer,
     selectedMainGameArrow,
+    selectedMainGameAllianceOverlay,
   ]);
 
   const mainPlayerInsights = [
@@ -4570,17 +4799,21 @@ function App() {
                         <td className="workflow-games-list-map">{formatMapNameWithKind(game.map_name, game.map_kind)}</td>
                         <td className="workflow-games-list-duration">{formatDuration(game.duration_seconds)}</td>
                         <td className="workflow-games-list-featuring">
-                          {(game.featuring || []).length === 0 ? (
-                            <span className="workflow-empty-inline">-</span>
-                          ) : (
-                            <div className="workflow-pattern-pills">
-                              {(game.featuring || []).map((pill) => (
-                                <span key={`${game.replay_id}-${pill}`} className="workflow-pattern-pill workflow-feature-pill">
-                                  <span>{pill}</span>
-                                </span>
-                              ))}
-                            </div>
-                          )}
+                          {(() => {
+                            const featuring = elideGenericDropLabels(game.featuring || []);
+                            if (featuring.length === 0) {
+                              return <span className="workflow-empty-inline">-</span>;
+                            }
+                            return (
+                              <div className="workflow-pattern-pills">
+                                {featuring.map((pill) => (
+                                  <span key={`${game.replay_id}-${pill}`} className="workflow-pattern-pill workflow-feature-pill">
+                                    <span>{pill}</span>
+                                  </span>
+                                ))}
+                              </div>
+                            );
+                          })()}
                         </td>
                       </tr>
                     ))}
@@ -5435,6 +5668,19 @@ function App() {
                                       >
                                         <polygon points="0 0, 5 2.5, 0 5" fill={selectedMainGameArrow?.color || 'currentColor'} />
                                       </marker>
+                                      {/* Marker that inherits the line's stroke color via SVG2 context-stroke,
+                                          and auto-flips at markerStart via auto-start-reverse. Used by alliance
+                                          overlay arrows so each pair side is colorized to its player. */}
+                                      <marker
+                                        id="workflow-event-arrowhead-context"
+                                        markerWidth="5"
+                                        markerHeight="5"
+                                        refX="4.5"
+                                        refY="2.5"
+                                        orient="auto-start-reverse"
+                                      >
+                                        <polygon points="0 0, 5 2.5, 0 5" fill="context-stroke" />
+                                      </marker>
                                     </defs>
                                     {selectedMainGameOwnershipPolygons.map((overlay) => (
                                       <polygon
@@ -5456,6 +5702,51 @@ function App() {
                                         markerEnd="url(#workflow-event-arrowhead)"
                                       />
                                     ) : null}
+                                  </svg>
+                                ) : null}
+                                {selectedMainGameAllianceOverlay ? (
+                                  <svg
+                                    className="workflow-event-map-overlay workflow-event-map-overlay-alliance"
+                                    viewBox="0 0 100 100"
+                                    preserveAspectRatio="none"
+                                    aria-hidden="true"
+                                  >
+                                    <defs>
+                                      <marker
+                                        id="workflow-event-arrowhead-alliance"
+                                        markerWidth="5"
+                                        markerHeight="5"
+                                        refX="4.5"
+                                        refY="2.5"
+                                        orient="auto-start-reverse"
+                                      >
+                                        <polygon points="0 0, 5 2.5, 0 5" fill="context-stroke" />
+                                      </marker>
+                                    </defs>
+                                    {selectedMainGameAllianceOverlay.pairs.flatMap((pair) => ([
+                                      <line
+                                        key={`alliance-${selectedMainGameEventKeyResolved}-${pair.key}-a`}
+                                        x1={pair.a.from.x}
+                                        y1={pair.a.from.y}
+                                        x2={pair.mid.x}
+                                        y2={pair.mid.y}
+                                        className="workflow-event-map-alliance-line"
+                                        style={{ stroke: pair.a.color }}
+                                        markerStart="url(#workflow-event-arrowhead-alliance)"
+                                        markerEnd="url(#workflow-event-arrowhead-alliance)"
+                                      />,
+                                      <line
+                                        key={`alliance-${selectedMainGameEventKeyResolved}-${pair.key}-b`}
+                                        x1={pair.b.from.x}
+                                        y1={pair.b.from.y}
+                                        x2={pair.mid.x}
+                                        y2={pair.mid.y}
+                                        className="workflow-event-map-alliance-line"
+                                        style={{ stroke: pair.b.color }}
+                                        markerStart="url(#workflow-event-arrowhead-alliance)"
+                                        markerEnd="url(#workflow-event-arrowhead-alliance)"
+                                      />,
+                                    ]))}
                                   </svg>
                                 ) : null}
                                 {selectedMainGameTrainedUnitsAnchors.map((entry) => {
@@ -5547,6 +5838,18 @@ function App() {
                                     </span>
                                   </div>
                                 ) : null}
+                                {selectedMainGameAllianceOverlay
+                                  ? selectedMainGameAllianceOverlay.pairs.map((pair) => (
+                                    <div
+                                      key={`alliance-emoji-${selectedMainGameEventKeyResolved}-${pair.key}`}
+                                      className="workflow-event-map-flag-overlay workflow-event-map-alliance-handshake"
+                                      style={{ left: `${pair.mid.x}%`, top: `${pair.mid.y}%` }}
+                                      title="Alliance formed"
+                                    >
+                                      <span role="img" aria-label="Alliance">🤝</span>
+                                    </div>
+                                  ))
+                                  : null}
                                 {selectedMainGameExpansionOverlay ? (
                                   <img
                                     key={`expansion-${selectedMainGameEventKeyResolved}`}
@@ -6283,8 +6586,8 @@ function App() {
                                         <span><strong>{(Number(card.avg_eapm) || 0).toFixed(0)}</strong> EAPM</span>
                                       </span>
                                     </div>
-                                    {renderMatchupPatternSection('Top build orders', card.top_build_orders, `bo-${card.key}`, markerRegistry)}
-                                    {renderMatchupPatternSection('Top markers', card.top_markers, `mk-${card.key}`, markerRegistry)}
+                                    {renderMatchupPatternSection('Top build orders', card.top_build_orders, `bo-${card.key}`, markerRegistry, mainPlayerGameEventFeaturesByKey)}
+                                    {renderMatchupPatternSection('Top markers', card.top_markers, `mk-${card.key}`, markerRegistry, mainPlayerGameEventFeaturesByKey)}
                                   </div>
                                 );
                               })}

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -3480,6 +3480,24 @@ body {
   stroke-width: 0.45;
 }
 
+.workflow-event-map-alliance-line {
+  stroke-width: 0.45;
+  stroke-linecap: round;
+}
+
+.workflow-event-map-overlay-alliance {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.workflow-event-map-alliance-handshake {
+  z-index: 2;
+}
+
 .workflow-event-map-swords {
   font-size: 3.6px;
   text-anchor: middle;

--- a/internal/models/worker_units.go
+++ b/internal/models/worker_units.go
@@ -1,0 +1,16 @@
+package models
+
+var workerUnits = map[string]struct{}{
+	GeneralUnitSCV:   {},
+	GeneralUnitProbe: {},
+	GeneralUnitDrone: {},
+}
+
+// IsWorker reports whether a unit type is a worker (SCV/Probe/Drone). The
+// drop classifier excludes workers because workers trained inside the drop
+// window are typically unrelated to the unload — and including them dilutes
+// the dt_drop / reaver_drop subtype routing.
+func IsWorker(name string) bool {
+	_, ok := workerUnits[name]
+	return ok
+}

--- a/internal/parser/alliance_events.go
+++ b/internal/parser/alliance_events.go
@@ -54,23 +54,25 @@ func BuildAllianceDerivedEvents(players []*models.Player, ar AllianceResult) []w
 	}
 
 	// late_alliance — per topology-changing snapshot after sec=600.
+	// Payload carries only the pairs that are NEW vs the immediately
+	// preceding snapshot (a re-affirmation of pre-existing alliances would
+	// otherwise be re-listed every time a single new pair forms — confusing
+	// at read-time). If no pairs are new for a transition, the event has no
+	// narrative value and is skipped.
 	for _, snap := range ar.LateAllianceTransitions {
-		issuer, primaryAlly := pickAllianceIssuerAndAlly(snap.Teams)
+		prevTeams := previousSnapshotTeams(ar.Snapshots, snap.Sec)
+		newPairs := pairsAdded(prevTeams, snap.Teams)
+		if len(newPairs) == 0 {
+			continue
+		}
+		issuer, primaryAlly := newPairs[0][0], newPairs[0][1]
 		event := worldstate.ReplayEvent{
-			EventType: "late_alliance",
-			Second:    snap.Sec,
+			EventType:            "late_alliance",
+			Second:               snap.Sec,
+			SourceReplayPlayerID: &issuer,
+			TargetReplayPlayerID: &primaryAlly,
 		}
-		if issuer != 0 {
-			i := issuer
-			event.SourceReplayPlayerID = &i
-		}
-		if primaryAlly != 0 {
-			a := primaryAlly
-			event.TargetReplayPlayerID = &a
-		}
-		// Payload carries all team groupings so the frontend can render the
-		// full picture if it wants ("X is now allied with Y, Z").
-		if payload, ok := marshalAllianceTopology(snap.Teams, pidToName); ok {
+		if payload, ok := marshalAllianceTopology(pairsToTeams(newPairs), pidToName); ok {
 			payloadCopy := payload
 			event.Payload = &payloadCopy
 		}
@@ -91,6 +93,71 @@ func BuildAllianceDerivedEvents(players []*models.Player, ar AllianceResult) []w
 	}
 
 	return events
+}
+
+// previousSnapshotTeams returns the team topology that was in effect
+// immediately before the snapshot at `sec`. Returns nil if there's no
+// earlier snapshot (treat as all-solos before any topology was observed).
+func previousSnapshotTeams(snapshots []AllianceSnapshot, sec int) [][]byte {
+	var prev [][]byte
+	for _, snap := range snapshots {
+		if snap.Sec >= sec {
+			break
+		}
+		prev = snap.Teams
+	}
+	return prev
+}
+
+// pairsAdded returns the alliance pairs (sorted [a, b] with a < b) that
+// appear in `curr` but not in `prev`. A pair is an unordered (a, b) where
+// a and b are in the same team grouping. Order is by min-pid for stability.
+func pairsAdded(prev, curr [][]byte) [][2]byte {
+	prevSet := pairsOf(prev)
+	currSet := pairsOf(curr)
+	out := make([][2]byte, 0)
+	for p := range currSet {
+		if _, ok := prevSet[p]; ok {
+			continue
+		}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i][0] != out[j][0] {
+			return out[i][0] < out[j][0]
+		}
+		return out[i][1] < out[j][1]
+	})
+	return out
+}
+
+func pairsOf(teams [][]byte) map[[2]byte]struct{} {
+	out := map[[2]byte]struct{}{}
+	for _, team := range teams {
+		if len(team) < 2 {
+			continue
+		}
+		for i := 0; i < len(team); i++ {
+			for j := i + 1; j < len(team); j++ {
+				a, b := team[i], team[j]
+				if a > b {
+					a, b = b, a
+				}
+				out[[2]byte{a, b}] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// pairsToTeams reshapes a list of pairs into the [][]byte team layout used
+// by marshalAllianceTopology — each pair becomes its own 2-element "team".
+func pairsToTeams(pairs [][2]byte) [][]byte {
+	out := make([][]byte, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, []byte{p[0], p[1]})
+	}
+	return out
 }
 
 // pickAllianceIssuerAndAlly picks a representative (issuer, ally) pair

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -9,7 +9,7 @@ import (
 
 // AlgorithmVersion is the current version of the pattern detection algorithm
 // Increment this when the algorithm changes to trigger re-detection
-const AlgorithmVersion = 24
+const AlgorithmVersion = 25
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/worldstate/drops_events.go
+++ b/internal/patterns/worldstate/drops_events.go
@@ -103,15 +103,18 @@ func (e *Engine) emitDropEvents(ownership []PolyOwnership, clusters []DropCluste
 		_ = matchedCand // reserved for future use (kept for symmetry with Recall)
 
 		// Build participating-units list. Epicenter window around the
-		// cluster's mid-second. We include workers (SCV/Probe/Drone) since
-		// transports legitimately carry them (SCV repair drops, Probe build
-		// drops, Drone expand drops). Flyers are filtered — they can't be
-		// loaded into a transport.
+		// cluster's mid-second. Workers (SCV/Probe/Drone) are excluded
+		// because workers trained inside the drop window are typically
+		// unrelated to the unload — keeping them in dilutes the dt_drop /
+		// reaver_drop subtype routing (a DT drop that coincides with a
+		// worker train would otherwise route to plain "drop"). Flyers are
+		// filtered for the original reason: they can't be loaded into a
+		// transport.
 		mid := (cl.FirstSec + cl.LastSec) / 2
 		rawUnits := e.buildOrTrainUnitsInWindow(cl.PID, mid)
 		dropUnits := make([]string, 0, len(rawUnits))
 		for _, u := range rawUnits {
-			if models.IsFlyingUnit(u) {
+			if models.IsFlyingUnit(u) || models.IsWorker(u) {
 				continue
 			}
 			dropUnits = append(dropUnits, u)
@@ -257,9 +260,9 @@ func (e *Engine) inferDropTargetByPostActivity(cl DropCluster) (int, bool) {
 
 // buildOrTrainUnitsInWindow returns distinct unit-build names produced by the
 // player in [mid - past, mid + future]. Unlike buildUnitsInEpicenterWindow it
-// includes workers (SCV/Probe/Drone) since transports legitimately carry
-// them, and walks the enriched stream directly rather than the attacker-only
-// attackUnitsByPID buffer.
+// walks the enriched stream directly rather than the attacker-only
+// attackUnitsByPID buffer (drops aren't necessarily flagged as attacks). The
+// caller is expected to filter out workers/flyers as needed.
 func (e *Engine) buildOrTrainUnitsInWindow(pid byte, mid int) []string {
 	epicenter := mid - attackUnitsEpicenterOffsetSec
 	lo := epicenter - attackUnitsPastSec


### PR DESCRIPTION
## Summary

Fixes everything called out in #133 plus the follow-ups that surfaced during review.

**Alliance events**
- Skip emit when the snapshot has no team of ≥2 (no bare "Alliance" rows).
- Payload carries only NEW pairs vs the previous snapshot — a single new alliance no longer reads as "all five pairs re-formed".
- Game-events row renders "X and Y form an alliance" with colorized name spans.
- Map overlay: handshake 🤝 emoji at the midpoint between the two players' bases, with double-arrowed lines in each player's color. Pair is skipped if either player has no owned base. Trained-units chips treat alliance anchor bases as off-limits and segment-avoid the new arrows so they relocate to the player's other owned bases.

**DT / Reaver drops**
- Workers (SCV/Probe/Drone) excluded from drop classification & display — DT-shuttle drops that coincide with worker training now route to `dt_drop`.
- New `models.IsWorker` helper next to `IsFlyingUnit`.
- Event description reads "DT drops on …" / "Reaver drops on …".
- Game-detail main featuring strip and per-player pills surface a multi-icon "DT Drop" pill matching the games-list filter UI.
- FE-wide elision pass drops the generic "Drop" pill whenever a more-specific drop pill is present (game-detail strip, per-player pills, games-list Featuring column).
- Player summary per-matchup / by-format "Top markers" now lists `dt_drop` / `reaver_drop` / `cliff_drop` alongside the generic `made_drops` marker.

**Algorithm bump**
- AlgorithmVersion 24 → 25 since alliance event emission, drop subtype classification, and dropUnits content all changed on the ingest side. Re-ingestion is required to refresh historical replays.

## Some images of the improvements

<img width="1333" height="697" alt="Screenshot 2026-05-17 at 19 11 00" src="https://github.com/user-attachments/assets/d1bde6e6-3d82-4d14-a581-69ec2192e74f" />
<img width="685" height="686" alt="Screenshot 2026-05-17 at 19 10 32" src="https://github.com/user-attachments/assets/f16a74fb-4807-4110-81b7-1b9d8dec0b81" />
<img width="1388" height="800" alt="Screenshot 2026-05-17 at 19 10 16" src="https://github.com/user-attachments/assets/934bdae4-b405-4cc9-b2a4-f3b8096845aa" />
<img width="1322" height="551" alt="Screenshot 2026-05-17 at 19 10 00" src="https://github.com/user-attachments/assets/41407bfc-be0e-4acf-bb8d-af038e681162" />


## Test plan
- [x] `go test ./...` — 263 passed.
- [x] Re-ingested `id40_234435_bgh.rep`: the three `vico.firebat` shuttles at 7:59 / 8:17 / 8:50 now emit as `dt_drop` with `["Dark Templar"]` (probe filtered). The 19:54 alliance event row reads "pirraptazzzzz and vico.firebat form an alliance" and the minimap shows a single 🤝 with two colored arrows between their bases.
- [x] vico.firebat's Player → Summary card now lists both "DT Drop ×1" (multi-icon) and "Made drops ×1" under Top markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
