### PR TITLE
feat: Build-order coverage overhaul + dashboard pill UX

### DIFF
--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -22,6 +22,9 @@ import {
   useMarkerRegistry,
   renderPillText,
   pillClassName,
+  pillEventTypeClass,
+  isBuildOrderEventType,
+  isOpenerEventType,
   lookupDefinitionForPattern,
   renderAggregatePillText,
 } from './lib/markerRegistry';
@@ -828,8 +831,13 @@ const renderFeaturingPill = (pill, keyPrefix) => {
     ? pill.iconKeys
     : (pill.iconKey ? [pill.iconKey] : []);
   const iconUrls = iconKeys.map((k) => getUnitIcon(k)).filter(Boolean);
+  // Build-order pills get the teal opener accent + a "BUILD ORDER" legend on
+  // the top border, so they read as the opening across every surface.
+  const isBO = isBuildOrderEventType(pill.key);
+  const variantClass = isBO ? 'workflow-pattern-pill-bo workflow-pill-legended' : 'workflow-pattern-pill-strong';
   return (
-    <span key={`${keyPrefix}-${pill.key}`} className="workflow-pattern-pill workflow-pattern-pill-strong workflow-summary-feature-pill">
+    <span key={`${keyPrefix}-${pill.key}`} className={`workflow-pattern-pill ${variantClass} workflow-summary-feature-pill`}>
+      {isBO ? <span className="workflow-pill-legend">Build Order</span> : null}
       {iconUrls.map((url, i) => (
         <img key={`${pill.key}-i${i}`} src={url} alt="" className="workflow-pattern-icon" />
       ))}
@@ -1382,13 +1390,16 @@ const shouldHidePatternFromSummaryPills = (pattern, trustGameEventsForDrops) => 
 
 const filterSummaryPillPatterns = (patterns, trustGameEventsForDrops = false) => {
   const filtered = (patterns || []).filter((pattern) => !shouldHidePatternFromSummaryPills(pattern, trustGameEventsForDrops));
-  // Stable-sort by detected_second so pills read chronologically (BO first,
-  // then mid-game markers like SK Terran / Mech Transition). Patterns
-  // without a detected_second (e.g. unit-composition rollups) sort to the
-  // end. Hotkey markers carry an end-of-replay second already, so they
-  // naturally land after timed markers.
+  // The opening build order always leads the row (it's the headline signal and
+  // now has a guaranteed pill). After that, pills read chronologically by
+  // detected_second — mid-game markers like SK Terran / Mech Transition, then
+  // hotkey/absence markers which carry an end-of-replay second. Patterns
+  // without a detected_second sort to the end. Stable tiebreak via index.
   const indexed = filtered.map((pattern, idx) => ({ pattern, idx }));
   indexed.sort((a, b) => {
+    const aBO = isBuildOrderEventType(a.pattern?.event_type) ? 0 : 1;
+    const bBO = isBuildOrderEventType(b.pattern?.event_type) ? 0 : 1;
+    if (aBO !== bBO) return aBO - bBO;
     const ta = Number.isFinite(a.pattern?.detected_second) ? a.pattern.detected_second : Number.POSITIVE_INFINITY;
     const tb = Number.isFinite(b.pattern?.detected_second) ? b.pattern.detected_second : Number.POSITIVE_INFINITY;
     if (ta !== tb) return ta - tb;
@@ -1442,7 +1453,7 @@ const renderAggregatePatternEntry = (entry, key, registry, gameEventFeaturesByKe
   }
   return (
     <span key={`${key}-wrap`} className="workflow-pattern-with-count">
-      <span className={pillClassName(rendered.style)} title={rendered.title || undefined}>
+      <span className={`${pillClassName(rendered.style)} ${pillEventTypeClass(patternKey)}`.trim()} title={rendered.title || undefined}>
         {rendered.icon ? <img src={rendered.icon} alt="" className="workflow-pattern-icon" /> : null}
         {rendered.label ? <span>{rendered.label}</span> : null}
       </span>
@@ -1464,19 +1475,55 @@ const renderMatchupPatternSection = (title, entries, keyPrefix, registry, gameEv
   );
 };
 
+// renderHotkeyGroups lays out the hotkey group numbers space-separated (no
+// commas) beside the keyboard glyph. With more than 3 groups it wraps onto two
+// rows — first row gets max(3, ceil(n/2)), so e.g. 4→"1 2 3"/"4",
+// 6→"1 2 3"/"4 5 6", 7→"1 2 3 4"/"5 6 7" — with the glyph vertically centered.
+const renderHotkeyGroups = (label) => {
+  const nums = String(label || '').split(',').map((s) => s.trim()).filter(Boolean);
+  let rows;
+  if (nums.length > 3) {
+    const r1 = Math.max(3, Math.ceil(nums.length / 2));
+    rows = [nums.slice(0, r1), nums.slice(r1)];
+  } else {
+    rows = [nums];
+  }
+  return (
+    <>
+      <span className="workflow-hotkey-emoji" aria-label="hotkeys">⌨️</span>
+      <span className="workflow-hotkey-nums">
+        {rows.map((r, i) => <span key={i}>{r.join(' ')}</span>)}
+      </span>
+    </>
+  );
+};
+
 const renderPatternPill = (pattern, keyPrefix, team, registry) => {
   if (!registry) return null;
   const def = lookupDefinitionForPattern(registry, pattern);
   if (!def) return null;
   const rendered = renderPillText(def, PILL_SURFACES.summaryPlayer, pattern);
   if (!rendered) return null;
-  const className = pillClassName(rendered.style);
+  // Opener pills (a build order, or the "opener unresolved" N/A) carry a small
+  // "BUILD ORDER" legend on their top border instead of an inline prefix — the
+  // legend + accent colour identify the pill type.
+  const isOpener = isOpenerEventType(pattern?.event_type);
+  const isHotkeys = pattern?.event_type === 'used_hotkey_groups';
+  // A top-border legend names the pill type (opener / hotkeys); composition
+  // pills get theirs in CompositionPill.
+  const legendText = isOpener ? 'Build Order' : (isHotkeys ? 'Hotkeys' : null);
+  const className = `${pillClassName(rendered.style)} ${pillEventTypeClass(pattern?.event_type)} ${legendText ? 'workflow-pill-legended' : ''}`.trim();
   const key = `${keyPrefix}-${team ? `team-${team}-` : ''}${pattern?.event_type || ''}-${pattern?.detected_second ?? ''}`;
   return (
     <span key={key} className={className} title={rendered.title || undefined}>
+      {legendText ? <span className="workflow-pill-legend">{legendText}</span> : null}
       {team !== undefined ? <span className="team-dot" style={{ backgroundColor: getTeamColor(team) }}></span> : null}
-      {rendered.icon ? <img src={rendered.icon} alt="" className="workflow-pattern-icon" /> : null}
-      {rendered.label ? <span>{rendered.label}</span> : null}
+      {isHotkeys ? renderHotkeyGroups(rendered.label) : (
+        <>
+          {rendered.icon ? <img src={rendered.icon} alt="" className="workflow-pattern-icon" /> : null}
+          {rendered.label ? <span>{rendered.label}</span> : null}
+        </>
+      )}
     </span>
   );
 };
@@ -5490,47 +5537,54 @@ function App() {
                         ) : null}
                       </div>
                     </div>
-                    <div className="workflow-player-rows" style={{ '--workflow-player-name-width': `${mainPlayerNameWidthCh}ch` }}>
+                    <div className="workflow-player-table" style={{ '--workflow-player-name-width': `${mainPlayerNameWidthCh}ch` }}>
+                      <div className="wpt-head">Name</div>
+                      <div className="wpt-head">APM</div>
+                      <div className="wpt-head">Featuring</div>
+                      <div className="wpt-head">Unit composition %</div>
                       {(mainGame.players || []).map((player) => {
                         const raceIcon = getRaceIcon(player.race);
                         const gameSummaryParts = playerGameSummarySignalParts(player, mainGame?.game_events);
                         const trustGameEventsForDrops = Array.isArray(mainGame?.game_events) && mainGame.game_events.length > 0;
+                        const patterns = filterSummaryPillPatterns(player.detected_patterns, trustGameEventsForDrops);
+                        // BO/opener pill always leads, then game-event signal pills
+                        // (Drop / Bunker rush / Proxy …), then the remaining markers.
+                        const boPatterns = patterns.filter((p) => isOpenerEventType(p?.event_type));
+                        const restPatterns = patterns.filter((p) => !isOpenerEventType(p?.event_type));
+                        const playerPhases = Array.isArray(mainGame?.unit_composition_markers)
+                          ? mainGame.unit_composition_markers.filter((m) => m.player_id === player.player_id)
+                          : [];
                         return (
-                          <div key={player.player_id} className="workflow-player-row" style={{ borderLeft: `3px solid ${getTeamColor(player.team)}` }}>
-                            <div className="workflow-player-line">
-                              <div className="workflow-player-name workflow-player-name-block">
-                                {raceIcon ? <img src={raceIcon} alt={player.race || 'race'} className="unit-icon-inline workflow-summary-race-icon" /> : null}
-                                {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
-                                <button
-                                  type="button"
-                                  className="workflow-player-name-link"
-                                  title="Analyze player"
-                                  style={gamePlayerNameStyle(player)}
-                                  onClick={() => openMainPlayer(player.player_key)}
-                                >
-                                  {player.name}
-                                </button>
-                              </div>
-                              <div className="workflow-player-actions">
-                                <span className="workflow-player-apm"><strong>APM</strong> {player.apm}</span>
-                              </div>
-                              <div className="workflow-pattern-pills">
-                                {gameSummaryParts.positive.map(renderGameSummarySignalPill)}
-                                {filterSummaryPillPatterns(player.detected_patterns, trustGameEventsForDrops).map((pattern, idx) => renderPatternPill(pattern, `player-${player.player_id}-${idx}`, undefined, markerRegistry))}
-                              </div>
-                              {/* Per-player attacker-composition phase pills.
-                                  Source: mainGame.unit_composition_markers filtered to this player. */}
-                              {Array.isArray(mainGame?.unit_composition_markers) ? (() => {
-                                const playerPhases = mainGame.unit_composition_markers.filter((m) => m.player_id === player.player_id);
-                                if (playerPhases.length === 0) return null;
-                                return (
-                                  <div className="workflow-pattern-pills">
-                                    <CompositionPhasesRow phases={playerPhases} maxCasters={4} />
-                                  </div>
-                                );
-                              })() : null}
+                          <React.Fragment key={player.player_id}>
+                            <div className="wpt-cell wpt-name" style={{ borderLeftColor: getTeamColor(player.team) }}>
+                              {raceIcon ? <img src={raceIcon} alt={player.race || 'race'} className="unit-icon-inline workflow-summary-race-icon" /> : null}
+                              {player.is_winner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+                              <button
+                                type="button"
+                                className="workflow-player-name-link"
+                                title="Analyze player"
+                                style={gamePlayerNameStyle(player)}
+                                onClick={() => openMainPlayer(player.player_key)}
+                              >
+                                {player.name}
+                              </button>
                             </div>
-                          </div>
+                            <div className="wpt-cell wpt-apm">{player.apm}</div>
+                            <div className="wpt-cell wpt-featuring">
+                              <div className="workflow-pattern-pills">
+                                {boPatterns.map((pattern, idx) => renderPatternPill(pattern, `player-${player.player_id}-bo-${idx}`, undefined, markerRegistry))}
+                                {gameSummaryParts.positive.map(renderGameSummarySignalPill)}
+                                {restPatterns.map((pattern, idx) => renderPatternPill(pattern, `player-${player.player_id}-${idx}`, undefined, markerRegistry))}
+                              </div>
+                            </div>
+                            <div className="wpt-cell wpt-comp">
+                              {playerPhases.length > 0 ? (
+                                <div className="workflow-pattern-pills">
+                                  <CompositionPhasesRow phases={playerPhases} maxCasters={4} />
+                                </div>
+                              ) : null}
+                            </div>
+                          </React.Fragment>
                         );
                       })}
                     </div>

--- a/internal/dashboard/frontend/src/lib/compositionPill.jsx
+++ b/internal/dashboard/frontend/src/lib/compositionPill.jsx
@@ -165,8 +165,8 @@ export const CompositionPill = ({ phase, units, casters, maxCasters, slotCount }
   const tooltip = tooltipParts.join('\n');
 
   return (
-    <span className="workflow-pattern-pill workflow-pattern-pill-strong workflow-composition-pill" title={tooltip}>
-      <span className="workflow-composition-pill-phase">{formatPhaseLabel(phase)}</span>
+    <span className="workflow-pattern-pill workflow-pattern-pill-strong workflow-composition-pill workflow-pill-legended" title={tooltip}>
+      <span className="workflow-pill-legend">{formatPhaseLabel(phase)} Composition</span>
       <span className="workflow-composition-pill-units">
         {slots.map((name, idx) => {
           const icon = getUnitIcon(name);

--- a/internal/dashboard/frontend/src/lib/markerRegistry.js
+++ b/internal/dashboard/frontend/src/lib/markerRegistry.js
@@ -171,6 +171,30 @@ export const pillClassName = (style) => {
   }
 };
 
+// isBuildOrderEventType reports whether an event_type (== marker FeatureKey)
+// belongs to an opening build order. All initial-BO FeatureKeys are prefixed
+// "bo_" (including the residual "bo_*_other" catch-alls); the "opener_unresolved"
+// N/A marker is deliberately NOT one — it keeps its plain absence styling.
+export const isBuildOrderEventType = (eventType) =>
+  typeof eventType === 'string' && eventType.startsWith('bo_');
+
+// isOpenerEventType is the "fills the opener slot" predicate: a real build
+// order OR the "opener unresolved" (N/A) marker. Used for ordering (the opener
+// always leads the row) and for the "BUILD ORDER" legend.
+export const isOpenerEventType = (eventType) =>
+  isBuildOrderEventType(eventType) || eventType === 'opener_unresolved';
+
+// pillEventTypeClass returns an extra CSS class that distinguishes a pill by
+// what it represents (independent of its backend PillStyle): build orders, the
+// unresolved-opener N/A pill, and the "used hotkeys" pill each get their own
+// minimal treatment. Returns '' for everything else.
+export const pillEventTypeClass = (eventType) => {
+  if (isBuildOrderEventType(eventType)) return 'workflow-pattern-pill-bo';
+  if (eventType === 'opener_unresolved') return 'workflow-pattern-pill-na';
+  if (eventType === 'used_hotkey_groups') return 'workflow-pattern-pill-keys';
+  return '';
+};
+
 // useMarkerRegistry fetches /api/custom/markers/definitions once on mount and
 // exposes the full payload to consumers: markers keyed by FeatureKey, plus the
 // ordered featuring key list and the game-event-only feature metadata used by

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -2438,37 +2438,62 @@ body {
   gap: 12px;
 }
 
-.workflow-player-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+/* Per-player summary rendered as a compact table: aligned columns
+   (Name | APM | Featuring | Unit composition %), a header row, and no
+   black gaps between rows — just thin dividers. Tight column gap to
+   maximise content width. */
+.workflow-player-table {
+  display: grid;
+  grid-template-columns: max-content max-content minmax(0, 1.3fr) minmax(0, 1fr);
+  column-gap: 8px;
+  row-gap: 0;
+  align-items: stretch;
 }
 
-.workflow-player-row {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.wpt-head {
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 700;
+  padding: 2px 2px 6px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.16);
+  align-self: end;
+}
+/* Align the Name header with the name cells (which have a 3px team bar +
+   8px padding). */
+.wpt-head:first-child {
+  padding-left: 11px;
 }
 
-.workflow-player-name {
-  font-size: 0.98rem;
-  display: inline-flex;
+.wpt-cell {
+  display: flex;
   align-items: center;
-  gap: 6px;
-  width: var(--workflow-player-name-width, 15ch);
-  min-width: var(--workflow-player-name-width, 15ch);
-  max-width: var(--workflow-player-name-width, 15ch);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  min-width: 0;
+  padding: 5px 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-.workflow-player-name-block {
-  flex: 0 1 auto;
+.wpt-name {
+  gap: 6px;
+  font-size: 0.98rem;
+  font-weight: 700;
+  border-left: 3px solid transparent;
+  padding-left: 8px;
+  white-space: nowrap;
+}
+
+.wpt-apm {
+  justify-content: flex-start;
+  color: rgba(255, 255, 255, 0.85);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+}
+
+.wpt-featuring .workflow-pattern-pills,
+.wpt-comp .workflow-pattern-pills {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .workflow-player-name-link {
@@ -2758,7 +2783,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border-radius: 999px;
+  border-radius: 9px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.08);
   min-height: 48px;
@@ -2973,6 +2998,85 @@ body {
   border-color: rgba(100, 150, 255, 0.65);
   background: rgba(100, 150, 255, 0.2);
   color: #e6efff;
+}
+
+/* Build-order pill: the opening of the game and the leading per-player pill.
+   Identified by a teal tint + the "BUILD ORDER" legend on its top border
+   (see .workflow-pill-legend) — no left-accent bar needed. */
+.workflow-pattern-pill-bo {
+  border-color: rgba(125, 211, 192, 0.55);
+  background: rgba(125, 211, 192, 0.12);
+  font-weight: 600;
+}
+
+/* Opener-unresolved (N/A) pill: occupies the opener slot but signals "no
+   build order" — muted red, same "BUILD ORDER" legend treatment. */
+.workflow-pattern-pill-na {
+  border-color: rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.12);
+  color: #fecaca;
+}
+
+/* "BUILD ORDER" legend sitting centered on the pill's top border, fieldset-
+   legend style. The background matches the dark surface to "cut" the border.
+   Only pills tagged .workflow-pill-legended reserve the top space for it. */
+.workflow-pill-legended {
+  position: relative;
+  overflow: visible;
+  margin-top: 9px;
+}
+.workflow-pill-legend {
+  position: absolute;
+  top: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0 6px;
+  font-size: 8px;
+  line-height: 1;
+  letter-spacing: 0.1em;
+  font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+  background: #0f1115;
+  color: rgba(125, 211, 192, 0.95);
+  pointer-events: none;
+}
+/* N/A legend tinted red to match its pill. */
+.workflow-pattern-pill-na .workflow-pill-legend {
+  color: rgba(252, 165, 165, 0.95);
+}
+/* Composition pills are blue ("strong"); tint their legend to match. */
+.workflow-composition-pill .workflow-pill-legend {
+  color: rgba(150, 185, 255, 0.95);
+}
+/* Hotkeys legend tinted slate to match the keys pill. */
+.workflow-pattern-pill-keys .workflow-pill-legend {
+  color: rgba(203, 213, 225, 0.95);
+}
+
+/* "Used hotkeys" pill: minimal keyboard treatment — the ⌨️ glyph carries the
+   meaning, tabular numerals keep the group list tidy. */
+.workflow-pattern-pill-keys {
+  border-color: rgba(148, 163, 184, 0.4);
+  background: rgba(148, 163, 184, 0.12);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.03em;
+}
+/* The keyboard glyph rendered at 2× the pill text size. */
+.workflow-hotkey-emoji {
+  font-size: 2em;
+  line-height: 1;
+  vertical-align: middle;
+}
+/* Group numbers beside the glyph: space-separated, up to two stacked rows
+   (the glyph stays vertically centered across them via the pill's align-items). */
+.workflow-hotkey-nums {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.12em;
 }
 
 .workflow-pattern-icon {

--- a/internal/dashboard/unit_composition.go
+++ b/internal/dashboard/unit_composition.go
@@ -52,13 +52,13 @@ var compositionCasters = map[string]struct{}{
 // produced in meaningful numbers (4-12 Carriers, 2-6 Reavers) and read
 // as primary army composition, so they belong in the slot strip on the
 // left where the proportional fill reflects their actual share.
+// Dark Templar, Guardian and Devourer are NOT here: they're real army units
+// (and DT in particular is not a spellcaster), so they belong in the unit
+// histogram on the left, not the caster/notable strip on the right.
 var compositionSignatureNonCasters = map[string]struct{}{
-	models.GeneralUnitDarkTemplar:    {},
 	models.GeneralUnitBattlecruiser:  {},
 	models.GeneralUnitDropship:       {},
 	models.GeneralUnitNuclearMissile: {},
-	models.GeneralUnitGuardian:       {},
-	models.GeneralUnitDevourer:       {},
 }
 
 // compositionExcluded: workers + supply. Don't appear anywhere.

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -9,7 +9,11 @@ import (
 
 // AlgorithmVersion is the current version of the pattern detection algorithm
 // Increment this when the algorithm changes to trigger re-detection
-const AlgorithmVersion = 25
+//
+// 26: build-order overhaul — Zerg 5/6/7/8/10/11 Pool rungs, loosened FFE &
+// 1 Rax FE timings, widened Protoss expand/core matchups, Bunker Rush, per-race
+// residual "… (Other)" catch-alls, and the "Opener unresolved" N/A marker.
+const AlgorithmVersion = 26
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -1,6 +1,7 @@
 package markers
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/marianogappa/screpdb/internal/models"
@@ -15,6 +16,91 @@ func secAfter(anchor int, addends ...float64) int {
 		total += a
 	}
 	return int(math.Round(total))
+}
+
+// zergPoolBO builds one rung of the pool-first ladder. Supply at Pool = 4
+// starting Drones + N Drone morphs, so the rule keys off the exact morph count
+// (the early-game spam filter makes the surviving Drone stream supply-faithful
+// — see the 4/9/12 Pool comments). Each rung uses a distinct exact count, so
+// the rungs are mutually exclusive by construction. Hatchery / Evolution
+// Chamber must not precede the Pool (else it's a hatch-first opener).
+// poolSec is the progamer-ideal Pool placement second for the UI golden
+// compare; zerglings pop one Pool build-time later.
+func zergPoolBO(supply, poolSec int) Marker {
+	drones := supply - 4
+	label := fmt.Sprintf("%d Pool", supply)
+	return Marker{
+		Name:        label,
+		PatternName: "Build Order: " + label,
+		FeatureKey:  fmt.Sprintf("bo_%d_pool", supply),
+		Race:        RaceZerg,
+		Kind:        KindInitialBuildOrder,
+		Rule: All(
+			ProduceCountBeforeBuild(subjDrone, subjSpawningPool, drones),
+			Not(BuildBefore(subjHatchery, subjSpawningPool)),
+			Not(BuildBefore(subjEvolutionChamber, subjSpawningPool)),
+		),
+		RuleDeadline: 180,
+		Expert: []ExpertEvent{
+			{
+				Key:          "Spawning Pool",
+				Match:        MatchBuild(subjSpawningPool),
+				TargetSecond: poolSec,
+				Tolerance:    Sym(5),
+			},
+			{
+				Key:          "First Zerglings",
+				Match:        MatchFirstProduce(subjZergling),
+				TargetSecond: secAfter(poolSec, models.BuildTimeSpawningPool),
+				Tolerance:    Sym(4),
+			},
+		},
+		SummaryPlayer: &Pill{Label: label, IconKey: "spawningpool"},
+		GamesList:     &Pill{Label: label, IconKey: "spawningpool"},
+	}
+}
+
+// zergHatchBO builds one rung of the hatch-first ladder. Supply at the
+// expansion Hatchery = 4 starting Drones + N Drone morphs (the first
+// Build(Hatchery) is the expansion — the starting Hatchery isn't a command).
+// Keyed on the exact morph count, so rungs are mutually exclusive. A Pool /
+// Evolution Chamber before the Hatchery makes it a Pool-tech opening, not
+// hatch-first. The lower rungs (4–8 Hatch) need no Overlord gate — a Hatchery
+// costs 300 minerals, so a Drone morphing or not before it is the whole signal,
+// and the build can't be faked (the spam filter keeps the morph stream
+// supply-faithful). hatchSec is the progamer-ideal Hatchery second.
+func zergHatchBO(supply, hatchSec int) Marker {
+	drones := supply - 4
+	label := fmt.Sprintf("%d Hatch", supply)
+	return Marker{
+		Name:        label,
+		PatternName: "Build Order: " + label,
+		FeatureKey:  fmt.Sprintf("bo_%d_hatch", supply),
+		Race:        RaceZerg,
+		Kind:        KindInitialBuildOrder,
+		Rule: All(
+			ProduceCountBeforeBuild(subjDrone, subjHatchery, drones),
+			Not(BuildBefore(subjSpawningPool, subjHatchery)),
+			Not(BuildBefore(subjEvolutionChamber, subjHatchery)),
+		),
+		RuleDeadline: 180,
+		Expert: []ExpertEvent{
+			{
+				Key:          "Hatchery",
+				Match:        MatchBuild(subjHatchery),
+				TargetSecond: hatchSec,
+				Tolerance:    Sym(6),
+			},
+			{
+				Key:          "Spawning Pool",
+				Match:        MatchBuild(subjSpawningPool),
+				TargetSecond: hatchSec + 30,
+				Tolerance:    Asym(6, 12),
+			},
+		},
+		SummaryPlayer: &Pill{Label: label, IconKey: "hatchery"},
+		GamesList:     &Pill{Label: label, IconKey: "hatchery"},
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -86,6 +172,141 @@ var defaultTol = Sym(5)
 // All orders in a stable, UI-facing order. Defined as a func so initialization
 // order doesn't trip on cross-file references.
 func allMarkers() []Marker {
+	// -------------------------------------------------------------------
+	// Shared opener rules. Each named Protoss / Terran opener's Rule is
+	// declared once here and referenced both by its BO entry below and by
+	// the per-race residual "… (Other)" catch-all, which is defined as the
+	// EXACT complement Not(Any(named…)). Keeping a single source of truth
+	// means the residual can never drift out of sync with the named set, and
+	// the FuzzInitialBOsMutualExclusion test guarantees the named rules stay
+	// pairwise disjoint. Drone-count-keyed Zerg rungs don't need this — their
+	// exact counts are disjoint by construction — so their residual uses the
+	// ProduceCountAtLeastBeforeBuild primitive directly.
+	// -------------------------------------------------------------------
+
+	// Protoss.
+	pRule1GateCore := All(
+		BuildBefore(subjGateway, subjCyberneticsCore),
+		FirstBuildBefore(subjCyberneticsCore, 180),
+		Not(NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore})),
+		BuildBefore(subjCyberneticsCore, subjNexus),
+	)
+	pRule2Gate := All(
+		NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore, subjNexus, subjForge}),
+		CountBuildsBefore(subjGateway, 2, 180),
+	)
+	pRuleNexusFirst := All(
+		BuildBefore(subjNexus, subjGateway),
+		BuildBefore(subjNexus, subjForge),
+		FirstBuildBefore(subjNexus, 200),
+	)
+	// Gate Expand: single Gateway then Nexus. The Nexus-before-Cyber guard is
+	// what keeps it disjoint from 1 Gate Core once both run in PvT/PvP
+	// (1 Gate Core is Cyber-before-Nexus). Nexus window loosened 200→220.
+	pRuleGateExpand := All(
+		BuildBefore(subjGateway, subjForge),
+		BuildBefore(subjGateway, subjNexus),
+		FirstBuildBefore(subjNexus, 220),
+		Not(NthBuildBeforeAll(subjGateway, 2, []string{subjNexus})),
+		Not(BuildBefore(subjCyberneticsCore, subjNexus)),
+	)
+	// Forge Expand (FFE): Forge window loosened 100→140 and Nexus 200→260 —
+	// the corpus shows progamer FFEs with Forge up to ~140s and Nexus up to
+	// ~260s that the legacy bounds missed.
+	pRuleForgeExpand := All(
+		FirstBuildBefore(subjForge, 140),
+		BuildBefore(subjForge, subjGateway),
+		BuildBefore(subjForge, subjNexus),
+		FirstBuildBefore(subjNexus, 260),
+		BuildBefore(subjNexus, subjGateway),
+	)
+	// 1 Gate (no expa): a single-Gateway opener that doesn't rush Cyber
+	// (1 Gate Core), doesn't go 2 Gate, and never expands early — a slow /
+	// contain Gateway. "no expa" is baked in (no Nexus by 300s); a Gateway
+	// build that DOES expand is Gate Expand instead.
+	pRule1GateNoExpa := All(
+		FirstBuildExists(subjGateway),
+		Not(FirstBuildExists(subjForge)),
+		Not(FirstBuildBefore(subjNexus, 300)),
+		Not(FirstBuildBefore(subjCyberneticsCore, 180)),
+		Not(NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore, subjNexus, subjForge})),
+	)
+	// Forge Cannon (no expa): a Forge + Photon Cannon defensive opening with no
+	// early expansion (and not a Cyber-rush). NOTE: whether the Cannons are
+	// defensive (own base) or a proxy Cannon Rush is a spatial distinction the
+	// separate cannon_rush marker already makes; this opener keys on the build
+	// sequence only.
+	pRuleForgeCannonNoExpa := All(
+		FirstBuildExists(subjForge),
+		FirstBuildExists(subjPhotonCannon),
+		Not(FirstBuildBefore(subjNexus, 300)),
+		Not(FirstBuildBefore(subjCyberneticsCore, 180)),
+		Not(NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore, subjNexus, subjForge})),
+	)
+	pNamed := Any(pRule1GateCore, pRule2Gate, pRuleNexusFirst, pRuleGateExpand, pRuleForgeExpand, pRule1GateNoExpa, pRuleForgeCannonNoExpa)
+
+	// Terran.
+	tRule1Rax1Fac := All(
+		BuildBefore(subjRefinery, subjFactory),
+		FirstBuildBefore(subjFactory, 240),
+		Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjFactory})),
+		Not(BuildBefore(subjCommandCenter, subjBarracks)),
+		BuildBefore(subjRefinery, subjCommandCenter),
+		BuildBefore(subjFactory, subjCommandCenter),
+		// A defensive Bunker is fine here — Bunker Rush is now separated by
+		// expansion/tech absence (no CC, no Factory), not by Bunker timing.
+	)
+	tRuleCCFirst := All(
+		BuildBefore(subjCommandCenter, subjBarracks),
+		FirstBuildBefore(subjCommandCenter, 200),
+	)
+	// 1 Rax FE: 1 Barracks then CC (CC before Factory, CC<270). Gas-first
+	// expands land here, and so do defensive Bunkers — Bunker Rush is now
+	// separated by "no expansion" (below), not by Bunker timing. Disjoint
+	// from 1 Rax 1 Fac (which is Factory-before-CC).
+	tRule1RaxFE := All(
+		BuildBefore(subjBarracks, subjCommandCenter),
+		Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjCommandCenter})),
+		BuildBefore(subjCommandCenter, subjFactory),
+		FirstBuildBefore(subjCommandCenter, 270),
+	)
+	// 2 Rax CC: two Barracks before the expansion CC (a safer, pressure-first
+	// FE). Disjoint from 1 Rax FE (one Rax before CC) and from BBS (the Depot
+	// precedes the 2nd Rax here, so it isn't the no-Depot BBS topology).
+	tRule2RaxCC := All(
+		NthBuildBeforeAll(subjBarracks, 2, []string{subjCommandCenter}),
+		Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjSupplyDepot})),
+		BuildBefore(subjCommandCenter, subjFactory),
+		FirstBuildBefore(subjCommandCenter, 300),
+	)
+	tRuleBBS := All(
+		NthBuildBeforeAll(subjBarracks, 2, []string{
+			subjSupplyDepot, subjRefinery, subjCommandCenter,
+			subjFactory, subjStarport, subjAcademy,
+			subjEngineeringBay, subjBunker,
+		}),
+		CountBuildsBefore(subjBarracks, 2, 120),
+		FirstBuildBefore(subjBarracks, 100),
+	)
+	// Bunker Rush: an all-in — an early Bunker (≤240s) with NO expansion (no
+	// CC by 270s) and NO Factory tech (none by 240s). Defined by commitment to
+	// one base + the Bunker, not by Bunker-vs-gas timing, so it's disjoint from
+	// 1 Rax FE (has a CC) and 1 Rax 1 Fac (has a Factory). NOTE: a true
+	// proxy/forward Bunker would also require the Bunker to sit on the enemy's
+	// base/natural — that spatial check (reusing the worldstate the cannon_rush
+	// marker uses) is a follow-up; this rule keys on the all-in topology only.
+	tRuleBunkerRush := All(
+		FirstBuildBefore(subjBunker, 240),
+		BuildBefore(subjBarracks, subjBunker),
+		Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjBunker})),
+		// No expansion in the opener window — using 300s (matching 2 Rax CC's
+		// CC bound) so a 2-Rax build that expands at 270–300 is 2 Rax CC, not
+		// a Bunker Rush.
+		Not(FirstBuildBefore(subjCommandCenter, 300)),
+		Not(FirstBuildBefore(subjFactory, 240)),
+	)
+	tNamed := Any(tRule1Rax1Fac, tRuleCCFirst, tRule1RaxFE, tRule2RaxCC, tRuleBBS, tRuleBunkerRush)
+
 	return []Marker{
 		// Pool-first BOs are keyed off exact pre-Pool Drone-morph and
 		// Overlord-morph counts. The early-game spam filter (internal/
@@ -126,6 +347,14 @@ func allMarkers() []Marker {
 			SummaryPlayer: &Pill{Label: "4 Pool", IconKey: "spawningpool"},
 			GamesList:     &Pill{Label: "4 Pool", IconKey: "spawningpool"},
 		},
+		// 5–8 Pool: the lower rungs of the ladder. Keyed purely on the exact
+		// pre-Pool Drone-morph count (1/2/3/4 → supply 5/6/7/8); no Overlord
+		// gate needed (supply <9 needs no Overlord, and the exact Drone count
+		// alone keeps each rung disjoint from every other pool BO).
+		zergPoolBO(5, 45),
+		zergPoolBO(6, 52),
+		zergPoolBO(7, 60),
+		zergPoolBO(8, 67),
 		{
 			Name:        "9 Pool",
 			PatternName: "Build Order: 9 Pool",
@@ -229,6 +458,12 @@ func allMarkers() []Marker {
 			SummaryPlayer: &Pill{Label: "12 Pool", IconKey: "spawningpool"},
 			GamesList:     &Pill{Label: "12 Pool", IconKey: "spawningpool"},
 		},
+		// 10–11 Pool: between 9 and 12. Supply 10/11 forces an Overlord first
+		// (cap 9), but the exact Drone-morph count (6/7) already makes these
+		// disjoint from every other rung, so no explicit Overlord gate is
+		// needed — keeping them parallel to the 5–8 rungs.
+		zergPoolBO(10, 92),
+		zergPoolBO(11, 98),
 		{
 			Name:        "9 Pool into Hatchery",
 			PatternName: "Build Order: 9 Pool into Hatchery",
@@ -236,8 +471,11 @@ func allMarkers() []Marker {
 			Race:        RaceZerg,
 			Kind:        KindInitialBuildOrder,
 			Rule: All(
-				// Same prefix as 9 Pool...
-				ProduceBeforeBuild(subjDrone, subjSpawningPool),
+				// Same supply as 9 Pool (exactly 5 Drone morphs, no Overlord
+				// yet). Keyed on the exact count — not a loose "≥1 Drone" — so
+				// it stays disjoint from the 5–8/10–11 Pool rungs (only the
+				// 5-Drone stream can match here).
+				ProduceCountBeforeBuild(subjDrone, subjSpawningPool, 5),
 				NoProduceBeforeBuild(subjOverlord, subjSpawningPool),
 				FirstBuildAtOrAfter(subjSpawningPool, 70),
 				FirstBuildBefore(subjSpawningPool, 120),
@@ -268,6 +506,15 @@ func allMarkers() []Marker {
 			SummaryPlayer: &Pill{Label: "9 Pool → Hatch", IconKey: "hatchery"},
 			GamesList:     &Pill{Label: "9 Pool → Hatch", IconKey: "hatchery"},
 		},
+		// 4–8 Hatch: the fast hatch-first ladder below 9 Hatch. A Hatchery
+		// costs 300 minerals, so a player placing one at supply 4–8 genuinely
+		// waited that long with that few Drones — it's a real (greedy/fast)
+		// expansion, not noise. Keyed on exact pre-Hatch Drone count (0–4).
+		zergHatchBO(4, 40),
+		zergHatchBO(5, 50),
+		zergHatchBO(6, 58),
+		zergHatchBO(7, 66),
+		zergHatchBO(8, 70),
 		{
 			Name:        "9 Hatch",
 			PatternName: "Build Order: 9 Hatch",
@@ -419,19 +666,10 @@ func allMarkers() []Marker {
 			PatternName: "Build Order: 1 Gate Core",
 			FeatureKey:  "bo_1_gate_core",
 			Race:        RaceProtoss,
-			Matchup:     []string{"PvP", "PvT"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				// 1 Gate before Cyber Core (canonical).
-				BuildBefore(subjGateway, subjCyberneticsCore),
-				// Cyber Core within window — distinguishes from "Gateway
-				// only" or 2-Gate (where Cyber is delayed past 180s).
-				FirstBuildBefore(subjCyberneticsCore, 180),
-				// vs 2 Gate: Cyber arrives before any 2nd Gateway.
-				Not(NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore})),
-				// vs Nexus First: Cyber before Nexus.
-				BuildBefore(subjCyberneticsCore, subjNexus),
-			),
+			// Extended to PvZ: the Gate→Cyber→Stargate (Corsair / Sair-DT)
+			// opener is a standard PvZ build that previously fell through.
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRule1GateCore,
 			RuleDeadline: 180,
 			Expert: []ExpertEvent{
 				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(4)},
@@ -446,16 +684,12 @@ func allMarkers() []Marker {
 			// 2 Gate: ~11% of PvP, ~4% of PvZ in the dataset (rarer in PvT).
 			// Pylon, Gateway, Gateway, Pylon. Pressure / Zealot rush. Both
 			// Gateways must precede Cyber Core, Nexus, and Forge.
-			Name:        "2 Gate",
-			PatternName: "Build Order: 2 Gate",
-			FeatureKey:  "bo_2_gate",
-			Race:        RaceProtoss,
-			Matchup:     []string{"PvP", "PvT", "PvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				NthBuildBeforeAll(subjGateway, 2, []string{subjCyberneticsCore, subjNexus, subjForge}),
-				CountBuildsBefore(subjGateway, 2, 180),
-			),
+			Name:         "2 Gate",
+			PatternName:  "Build Order: 2 Gate",
+			FeatureKey:   "bo_2_gate",
+			Race:         RaceProtoss,
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRule2Gate,
 			RuleDeadline: 180,
 			Expert: []ExpertEvent{
 				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(4)},
@@ -478,17 +712,12 @@ func allMarkers() []Marker {
 			// Pioneered by Bisu (NeoSair-style greedy expand). Pylon, Nexus,
 			// Gateway. Loosened upper bound from the legacy 150s rule because
 			// the data shows Nexus placement up to ~170s in PvT.
-			Name:        "Nexus First",
-			PatternName: "Build Order: Nexus First",
-			FeatureKey:  "bo_nexus_first",
-			Race:        RaceProtoss,
-			Matchup:     []string{"PvP", "PvT", "PvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				BuildBefore(subjNexus, subjGateway),
-				BuildBefore(subjNexus, subjForge),
-				FirstBuildBefore(subjNexus, 200),
-			),
+			Name:         "Nexus First",
+			PatternName:  "Build Order: Nexus First",
+			FeatureKey:   "bo_nexus_first",
+			Race:         RaceProtoss,
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRuleNexusFirst,
 			RuleDeadline: 200,
 			Expert: []ExpertEvent{
 				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(4)},
@@ -506,18 +735,11 @@ func allMarkers() []Marker {
 			PatternName: "Build Order: Gate Expand",
 			FeatureKey:  "bo_gate_expand",
 			Race:        RaceProtoss,
-			Matchup:     []string{"PvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				// Gateway before Forge AND Nexus.
-				BuildBefore(subjGateway, subjForge),
-				BuildBefore(subjGateway, subjNexus),
-				// Nexus built within window.
-				FirstBuildBefore(subjNexus, 200),
-				// Mutex with 2 Gate: only ONE Gateway before Nexus.
-				Not(NthBuildBeforeAll(subjGateway, 2, []string{subjNexus})),
-			),
-			RuleDeadline: 200,
+			// Extended beyond PvZ: the Gate→Nexus expand (e.g. Gate→Nexus→Cyber)
+			// is common in PvT/PvP and previously had no opener.
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRuleGateExpand,
+			RuleDeadline: 220,
 			Expert: []ExpertEvent{
 				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(4)},
 				{Key: "Gateway", Match: MatchBuild(subjGateway), TargetSecond: 88, Tolerance: Sym(10)},
@@ -536,16 +758,11 @@ func allMarkers() []Marker {
 			PatternName: "Build Order: Forge Expand",
 			FeatureKey:  "bo_forge_expa",
 			Race:        RaceProtoss,
-			Matchup:     []string{"PvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				FirstBuildBefore(subjForge, 100),
-				BuildBefore(subjForge, subjGateway),
-				BuildBefore(subjForge, subjNexus),
-				FirstBuildBefore(subjNexus, 200),
-				BuildBefore(subjNexus, subjGateway),
-			),
-			RuleDeadline: 200,
+			// Extended beyond PvZ for the rare FFE-style opener in other
+			// matchups; the topology (Forge→Nexus→Gate) is matchup-agnostic.
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRuleForgeExpand,
+			RuleDeadline: 260,
 			Expert: []ExpertEvent{
 				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(4)},
 				{Key: "Forge", Match: MatchBuild(subjForge), TargetSecond: 86, Tolerance: Sym(8)},
@@ -554,6 +771,41 @@ func allMarkers() []Marker {
 			},
 			SummaryPlayer: &Pill{Label: "FFE", IconKey: "forge"},
 			GamesList:     &Pill{Label: "FFE", IconKey: "forge"},
+		},
+		{
+			// Forge Cannon (no expa): defensive Forge + Cannon, no early
+			// expansion. Cannon icon. (Proxy vs in-base cannons → cannon_rush
+			// marker.)
+			Name:         "Forge Cannon (no expa)",
+			PatternName:  "Build Order: Forge Cannon (no expa)",
+			FeatureKey:   "bo_forge_cannon_no_expa",
+			Race:         RaceProtoss,
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRuleForgeCannonNoExpa,
+			RuleDeadline: 320,
+			Expert: []ExpertEvent{
+				{Key: "Forge", Match: MatchBuild(subjForge), TargetSecond: 90, Tolerance: Sym(20)},
+				{Key: "Photon Cannon", Match: MatchBuild(subjPhotonCannon), TargetSecond: 130, Tolerance: Sym(30)},
+			},
+			SummaryPlayer: &Pill{Label: "Forge Cannon (no expa)", IconKey: "photoncannon"},
+			GamesList:     &Pill{Label: "Forge Cannon (no expa)", IconKey: "photoncannon"},
+		},
+		{
+			// 1 Gate (no expa): slow / contain single Gateway, no fast Cyber,
+			// no expansion.
+			Name:         "1 Gate (no expa)",
+			PatternName:  "Build Order: 1 Gate (no expa)",
+			FeatureKey:   "bo_1_gate_no_expa",
+			Race:         RaceProtoss,
+			Kind:         KindInitialBuildOrder,
+			Rule:         pRule1GateNoExpa,
+			RuleDeadline: 320,
+			Expert: []ExpertEvent{
+				{Key: "Pylon", Match: MatchBuild(subjPylon), TargetSecond: 48, Tolerance: Sym(6)},
+				{Key: "Gateway", Match: MatchBuild(subjGateway), TargetSecond: 88, Tolerance: Sym(15)},
+			},
+			SummaryPlayer: &Pill{Label: "1 Gate (no expa)", IconKey: "gateway"},
+			GamesList:     &Pill{Label: "1 Gate (no expa)", IconKey: "gateway"},
 		},
 
 		// -------------------------------------------------------------------
@@ -578,24 +830,12 @@ func allMarkers() []Marker {
 			// Depot, Rax, Refinery, Depot, Factory. Foundation for 1-1-1,
 			// 2-Fac Vulture, SK Terran. Refinery precedes Factory and CC
 			// (gas-before-CC discriminates from Rax-CC).
-			Name:        "1 Rax 1 Fac",
-			PatternName: "Build Order: 1 Rax 1 Fac",
-			FeatureKey:  "bo_1_rax_1_fac",
-			Race:        RaceTerran,
-			Matchup:     []string{"TvT", "PvT", "TvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				// Refinery built before Factory (gas before tech).
-				BuildBefore(subjRefinery, subjFactory),
-				FirstBuildBefore(subjFactory, 240),
-				// ≤1 Rax before Factory (else it's 2-Rax style).
-				Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjFactory})),
-				// Not CC-first: Barracks must precede CC if CC happens.
-				Not(BuildBefore(subjCommandCenter, subjBarracks)),
-				// Mutex with Rax-CC: gas before CC, factory before CC.
-				BuildBefore(subjRefinery, subjCommandCenter),
-				BuildBefore(subjFactory, subjCommandCenter),
-			),
+			Name:         "1 Rax 1 Fac",
+			PatternName:  "Build Order: 1 Rax 1 Fac",
+			FeatureKey:   "bo_1_rax_1_fac",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRule1Rax1Fac,
 			RuleDeadline: 240,
 			Expert: []ExpertEvent{
 				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 60, Tolerance: Sym(8)},
@@ -612,16 +852,12 @@ func allMarkers() []Marker {
 			// is true CC-first; the latter falls under Rax-CC). True CC
 			// First is Depot, CC, Rax. Risky vs Protoss without map help;
 			// canonical for greedy macro vs Z.
-			Name:        "CC First",
-			PatternName: "Build Order: CC First",
-			FeatureKey:  "bo_cc_first",
-			Race:        RaceTerran,
-			Matchup:     []string{"TvT", "PvT", "TvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				BuildBefore(subjCommandCenter, subjBarracks),
-				FirstBuildBefore(subjCommandCenter, 200),
-			),
+			Name:         "CC First",
+			PatternName:  "Build Order: CC First",
+			FeatureKey:   "bo_cc_first",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRuleCCFirst,
 			RuleDeadline: 200,
 			Expert: []ExpertEvent{
 				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 62, Tolerance: Sym(8)},
@@ -637,22 +873,13 @@ func allMarkers() []Marker {
 			// Factory. The 2nd Rax — when present — typically arrives
 			// AFTER the CC (e.g. D-B-D-C-B), which is why a separate
 			// "2-Rax CC" BO would over-fragment the data.
-			Name:        "1 Rax FE",
-			PatternName: "Build Order: 1 Rax FE",
-			FeatureKey:  "bo_rax_cc",
-			Race:        RaceTerran,
-			Matchup:     []string{"TvT", "PvT", "TvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				BuildBefore(subjBarracks, subjCommandCenter),
-				// 1 Rax before CC (else it's a 2-Rax variant).
-				Not(NthBuildBeforeAll(subjBarracks, 2, []string{subjCommandCenter})),
-				// CC before any gas / tech.
-				BuildBefore(subjCommandCenter, subjFactory),
-				BuildBefore(subjCommandCenter, subjRefinery),
-				FirstBuildBefore(subjCommandCenter, 220),
-			),
-			RuleDeadline: 220,
+			Name:         "1 Rax FE",
+			PatternName:  "Build Order: 1 Rax FE",
+			FeatureKey:   "bo_rax_cc",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRule1RaxFE,
+			RuleDeadline: 270,
 			Expert: []ExpertEvent{
 				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 60, Tolerance: Sym(8)},
 				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 88, Tolerance: Sym(10)},
@@ -663,34 +890,36 @@ func allMarkers() []Marker {
 			GamesList:     &Pill{Label: "1 Rax FE", IconKey: "commandcenter"},
 		},
 		{
+			// 2 Rax CC: two Barracks before the expansion CC — a safer,
+			// pressure-first FE. Depot precedes the 2nd Rax (not BBS), and
+			// 2 Rax precede the CC (not 1 Rax FE).
+			Name:         "2 Rax CC",
+			PatternName:  "Build Order: 2 Rax CC",
+			FeatureKey:   "bo_2_rax_cc",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRule2RaxCC,
+			RuleDeadline: 300,
+			Expert: []ExpertEvent{
+				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 60, Tolerance: Sym(8)},
+				{Key: "1st Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 88, Tolerance: Sym(10)},
+				{Key: "2nd Barracks", Match: MatchNthBuild(subjBarracks, 2), TargetSecond: 120, Tolerance: Sym(15)},
+				{Key: "Command Center", Match: MatchBuild(subjCommandCenter), TargetSecond: 200, Tolerance: Sym(25)},
+			},
+			SummaryPlayer: &Pill{Label: "2 Rax CC", IconKey: "commandcenter"},
+			GamesList:     &Pill{Label: "2 Rax CC", IconKey: "commandcenter"},
+		},
+		{
 			// BBS: confirmed in the dataset (e.g. SST_JumJaJungJi opens
 			// BBS in many TvZs: Rax @58s, Rax @79s, Depot @100s, Bunker
 			// @157s). All-in 2-Rax before any other Terran building. Rare
 			// in modern pro play but a recognizable signature.
-			Name:        "BBS",
-			PatternName: "Build Order: BBS",
-			FeatureKey:  "bo_bbs",
-			Race:        RaceTerran,
-			Matchup:     []string{"TvT", "PvT", "TvZ"},
-			Kind:        KindInitialBuildOrder,
-			Rule: All(
-				// 2 Barracks before any other Terran building. The "all
-				// other buildings" guard is what locks BBS topology: no
-				// Depot, no Refinery, no CC, no Factory until both Rax
-				// are down. (Mutex with Rax-CC, which permits a CC after
-				// the 1st Rax.)
-				NthBuildBeforeAll(subjBarracks, 2, []string{
-					subjSupplyDepot, subjRefinery, subjCommandCenter,
-					subjFactory, subjStarport, subjAcademy,
-					subjEngineeringBay, subjBunker,
-				}),
-				// 2nd Rax built before 120s — disambiguates from a slow
-				// "delayed 2nd Rax" stream (where the player simply skips
-				// production for a long time then drops a 2nd Rax).
-				CountBuildsBefore(subjBarracks, 2, 120),
-				// First Rax built before 100s — BBS pivot timings.
-				FirstBuildBefore(subjBarracks, 100),
-			),
+			Name:         "BBS",
+			PatternName:  "Build Order: BBS",
+			FeatureKey:   "bo_bbs",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRuleBBS,
 			RuleDeadline: 120,
 			Expert: []ExpertEvent{
 				{Key: "1st Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 60, Tolerance: Sym(8)},
@@ -699,6 +928,141 @@ func allMarkers() []Marker {
 			},
 			SummaryPlayer: &Pill{Label: "BBS", IconKey: "barracks"},
 			GamesList:     &Pill{Label: "BBS", IconKey: "barracks"},
+		},
+		{
+			// Bunker Rush: an all-in — early Bunker (≤240s) with no expansion
+			// (no CC by 270s) and no Factory tech (none by 240s). Separated
+			// from 1 Rax FE (has a CC) and 1 Rax 1 Fac (has a Factory) by that
+			// commitment, so defensive Bunkers in macro builds no longer land
+			// here. (Spatial "Bunker on enemy base" is a follow-up refinement.)
+			Name:         "Bunker Rush",
+			PatternName:  "Build Order: Bunker Rush",
+			FeatureKey:   "bo_bunker_rush",
+			Race:         RaceTerran,
+			Kind:         KindInitialBuildOrder,
+			Rule:         tRuleBunkerRush,
+			RuleDeadline: 300,
+			Expert: []ExpertEvent{
+				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 60, Tolerance: Sym(10)},
+				{Key: "Bunker", Match: MatchBuild(subjBunker), TargetSecond: 130, Tolerance: Sym(20)},
+			},
+			SummaryPlayer: &Pill{Label: "Bunker Rush", IconKey: "bunker"},
+			GamesList:     &Pill{Label: "Bunker Rush", IconKey: "bunker"},
+		},
+
+		// -------------------------------------------------------------------
+		// Residual "… (Other)" catch-alls (one per race). Each is the EXACT
+		// complement of its race's named openers, gated on the player having
+		// actually placed a defining opener building — so every classifiable
+		// player-replay lands on exactly one initial BO (a named one or its
+		// race's residual). Players who never place a defining building are
+		// left to the "Opener unresolved" marker below. Mutual exclusion with
+		// the named openers is guaranteed by construction (Not(Any(named))).
+		// -------------------------------------------------------------------
+		{
+			// Zerg residual: the greedy tail of the Drone ladder — a Pool or
+			// expansion Hatchery placed at supply ≥13 (≥9 Drone morphs), which
+			// no exact rung claims. Pool-first vs hatch-first guards keep the
+			// two arms disjoint from each other and from the named rungs.
+			Name:        "Pool/Hatch (Other)",
+			PatternName: "Build Order: Pool/Hatch (Other)",
+			FeatureKey:  "bo_zerg_other",
+			Race:        RaceZerg,
+			Kind:        KindInitialBuildOrder,
+			Rule: Any(
+				// Pool-first greedy tail: supply ≥13 (≥9 Drone morphs).
+				All(
+					FirstBuildExists(subjSpawningPool),
+					ProduceCountAtLeastBeforeBuild(subjDrone, subjSpawningPool, 9),
+					Not(BuildBefore(subjHatchery, subjSpawningPool)),
+					Not(BuildBefore(subjEvolutionChamber, subjSpawningPool)),
+				),
+				// Hatch-first greedy tail: supply ≥13 (≥9 Drone morphs). The
+				// low tail (supply 4–8) is now covered by the named 4–8 Hatch
+				// rungs.
+				All(
+					FirstBuildExists(subjHatchery),
+					ProduceCountAtLeastBeforeBuild(subjDrone, subjHatchery, 9),
+					Not(BuildBefore(subjSpawningPool, subjHatchery)),
+					Not(BuildBefore(subjEvolutionChamber, subjHatchery)),
+				),
+			),
+			RuleDeadline:  240,
+			SummaryPlayer: &Pill{Label: "Other", IconKey: "spawningpool"},
+			GamesList:     &Pill{Label: "Other", IconKey: "spawningpool"},
+		},
+		{
+			// Protoss residual: a Gateway / Nexus / Forge opener that matches
+			// none of the five named Protoss builds.
+			Name:        "Gateway (Other)",
+			PatternName: "Build Order: Gateway (Other)",
+			FeatureKey:  "bo_protoss_other",
+			Race:        RaceProtoss,
+			Kind:        KindInitialBuildOrder,
+			Rule: All(
+				Any(
+					FirstBuildExists(subjGateway),
+					FirstBuildExists(subjNexus),
+					FirstBuildExists(subjForge),
+				),
+				Not(pNamed),
+			),
+			RuleDeadline:  320,
+			SummaryPlayer: &Pill{Label: "Other", IconKey: "gateway"},
+			GamesList:     &Pill{Label: "Other", IconKey: "gateway"},
+		},
+		{
+			// 1 Rax Bio: a Barracks opener that matches none of the named
+			// Terran builds — the Dep-Rax-Gas bio path (Academy/Marine-Medic,
+			// no early expansion or Factory), plus short games that only got a
+			// Barracks down. Defined as the complement of the named openers,
+			// so it stays mutually exclusive with them.
+			Name:        "1 Rax Bio",
+			PatternName: "Build Order: 1 Rax Bio",
+			FeatureKey:  "bo_1_rax_bio",
+			Race:        RaceTerran,
+			Kind:        KindInitialBuildOrder,
+			Rule: All(
+				Any(
+					FirstBuildExists(subjBarracks),
+					FirstBuildExists(subjCommandCenter),
+					FirstBuildExists(subjFactory),
+				),
+				Not(tNamed),
+			),
+			RuleDeadline:  300,
+			SummaryPlayer: &Pill{Label: "1 Rax Bio", IconKey: "marine"},
+			GamesList:     &Pill{Label: "1 Rax Bio", IconKey: "marine"},
+		},
+		{
+			// Opener unresolved (N/A): the player never placed a defining
+			// opener building — Pool/Hatchery (Z), Gateway/Forge/Nexus (P), or
+			// Barracks/CC/Factory (T). Almost always a <2-minute abort / instant
+			// leave / dodge where no build order ever happened. Race-agnostic
+			// (no Race gate) so one entry covers all three; disjoint from every
+			// initial BO, which all require a defining building. Stored so the
+			// dashboard can render "—" and coverage can be reported over
+			// classifiable players only, instead of counting these as misses.
+			Name:        "Opener unresolved",
+			PatternName: "Opener unresolved",
+			FeatureKey:  "opener_unresolved",
+			Kind:        KindMarker,
+			Rule: Not(Any(
+				FirstBuildExists(subjSpawningPool),
+				FirstBuildExists(subjHatchery),
+				FirstBuildExists(subjGateway),
+				FirstBuildExists(subjForge),
+				FirstBuildExists(subjNexus),
+				FirstBuildExists(subjBarracks),
+				FirstBuildExists(subjCommandCenter),
+				FirstBuildExists(subjFactory),
+			)),
+			RuleDeadline: endOfReplaySentinel,
+			SummaryPlayer: &Pill{
+				Label: "🚫 Opener unresolved",
+				Style: PillStyleNegative,
+				Title: "No opening build order resolved (game too short / left early).",
+			},
 		},
 
 		// -------------------------------------------------------------------
@@ -713,11 +1077,11 @@ func allMarkers() []Marker {
 			// no Academy ever (Academy means SK / bio path). Replaces the
 			// older "Quick factory" marker which fired too eagerly on
 			// 1-Fac TvP openers that immediately go bio anyway.
-			Name:         "Mech",
-			PatternName:  "Mech",
-			FeatureKey:   "mech",
-			Kind:         KindMarker,
-			Race:         RaceTerran,
+			Name:        "Mech",
+			PatternName: "Mech",
+			FeatureKey:  "mech",
+			Kind:        KindMarker,
+			Race:        RaceTerran,
 			Rule: All(
 				CountBuildsBefore(subjFactory, 2, 390),
 				Not(FirstBuildExists(subjAcademy)),
@@ -800,27 +1164,27 @@ func allMarkers() []Marker {
 			// completion gap (median + p25/p75 from the cwal-dl 1v1 TvZ
 			// corpus), surfaced on the Mutalisk Timing tab — see
 			// populateMutaliskTimingForGameDetail.
-			Name:         "Mutalisk timing",
-			PatternName:  "Mutalisk timing",
-			FeatureKey:   "mutalisk_timing",
-			Kind:         KindMarker,
-			Race:         RaceZerg,
-			Matchup:      []string{"TvZ"},
-			Custom:       func() CustomEvaluator { return &mutaTimingEvaluator{} },
-			RuleDeadline: endOfReplaySentinel,
+			Name:          "Mutalisk timing",
+			PatternName:   "Mutalisk timing",
+			FeatureKey:    "mutalisk_timing",
+			Kind:          KindMarker,
+			Race:          RaceZerg,
+			Matchup:       []string{"TvZ"},
+			Custom:        func() CustomEvaluator { return &mutaTimingEvaluator{} },
+			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{Label: "Mutalisk timing {timestamp}", IconKey: "mutalisk"},
 			SummaryReplay: &Pill{Label: "Mutalisk timing {timestamp}", IconKey: "mutalisk"},
 			GamesList:     &Pill{Label: "Mutalisk timing {timestamp}", IconKey: "mutalisk"},
 		},
 		{
-			Name:         "Turret timing",
-			PatternName:  "Turret timing",
-			FeatureKey:   "turret_timing",
-			Kind:         KindMarker,
-			Race:         RaceTerran,
-			Matchup:      []string{"TvZ"},
-			Custom:       func() CustomEvaluator { return &turretTimingEvaluator{} },
-			RuleDeadline: endOfReplaySentinel,
+			Name:          "Turret timing",
+			PatternName:   "Turret timing",
+			FeatureKey:    "turret_timing",
+			Kind:          KindMarker,
+			Race:          RaceTerran,
+			Matchup:       []string{"TvZ"},
+			Custom:        func() CustomEvaluator { return &turretTimingEvaluator{} },
+			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{Label: "Turret timing {timestamp}", IconKey: "missileturret"},
 			SummaryReplay: &Pill{Label: "Turret timing {timestamp}", IconKey: "missileturret"},
 			GamesList:     &Pill{Label: "Turret timing {timestamp}", IconKey: "missileturret"},
@@ -842,24 +1206,24 @@ func allMarkers() []Marker {
 			GamesList:     &Pill{Label: "Cliff drop", IconKey: "dropship"},
 		},
 		{
-			Name:         "Carriers",
-			PatternName:  "Carriers",
-			FeatureKey:   "carriers",
-			Kind:         KindMarker,
-			Race:         RaceProtoss,
-			Rule:         FirstProduceExists(subjCarrier),
-			RuleDeadline: endOfReplaySentinel,
+			Name:          "Carriers",
+			PatternName:   "Carriers",
+			FeatureKey:    "carriers",
+			Kind:          KindMarker,
+			Race:          RaceProtoss,
+			Rule:          FirstProduceExists(subjCarrier),
+			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{IconKey: "carrier", Style: PillStyleStrong, Title: "Carriers"},
 			GamesList:     &Pill{IconKey: "carrier", Style: PillStyleStrong, Title: "Carriers"},
 		},
 		{
-			Name:         "Battlecruisers",
-			PatternName:  "Battlecruisers",
-			FeatureKey:   "battlecruisers",
-			Kind:         KindMarker,
-			Race:         RaceTerran,
-			Rule:         FirstProduceExists(subjBattlecruiser),
-			RuleDeadline: endOfReplaySentinel,
+			Name:          "Battlecruisers",
+			PatternName:   "Battlecruisers",
+			FeatureKey:    "battlecruisers",
+			Kind:          KindMarker,
+			Race:          RaceTerran,
+			Rule:          FirstProduceExists(subjBattlecruiser),
+			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{IconKey: "battlecruiser", Style: PillStyleStrong, Title: "Battlecruisers"},
 			GamesList:     &Pill{IconKey: "battlecruiser", Style: PillStyleStrong, Title: "Battlecruisers"},
 		},
@@ -869,14 +1233,14 @@ func allMarkers() []Marker {
 			// 10-Scout count almost never happens outside Money games.
 			// MapKind gate keeps the chip / pill noise-free on standard
 			// games even if a player accidentally produces a few Scouts.
-			Name:         "10+ Scouts",
-			PatternName:  "10+ Scouts",
-			FeatureKey:   "ten_plus_scouts",
-			Kind:         KindMarker,
-			Race:         RaceProtoss,
-			MapKind:      []string{"Money"},
-			Rule:         ProduceCountAtLeast(subjScout, 10),
-			RuleDeadline: endOfReplaySentinel,
+			Name:          "10+ Scouts",
+			PatternName:   "10+ Scouts",
+			FeatureKey:    "ten_plus_scouts",
+			Kind:          KindMarker,
+			Race:          RaceProtoss,
+			MapKind:       []string{"Money"},
+			Rule:          ProduceCountAtLeast(subjScout, 10),
+			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{Label: "10+ Scouts", IconKey: "scout", Style: PillStyleStrong, Title: "10+ Scouts"},
 			GamesList:     &Pill{Label: "10+ Scouts", IconKey: "scout", Style: PillStyleStrong, Title: "10+ Scouts"},
 		},
@@ -1049,7 +1413,10 @@ func allMarkers() []Marker {
 			Custom:       newUsedHotkeyGroupsEvaluator,
 			RuleDeadline: endOfReplaySentinel,
 			SummaryPlayer: &Pill{
-				Label:   "Hotkeys {subject}",
+				// The keyboard emoji (enlarged) and a "HOTKEYS" top-border
+				// legend are added by the frontend; the stored label is just
+				// the group list.
+				Label:   "{subject}",
 				Subject: PayloadFieldSubject("groups"),
 			},
 		},

--- a/internal/patterns/markers/definitions_test.go
+++ b/internal/patterns/markers/definitions_test.go
@@ -1,6 +1,10 @@
 package markers
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/marianogappa/screpdb/internal/cmdenrich"
+)
 
 // Each test builds a minimal stream exercising one BO's broad definition,
 // then asserts both positive (should match) and a close-by negative case.
@@ -143,9 +147,11 @@ func TestBO_12Pool(t *testing.T) {
 
 func TestBO_9PoolIntoHatchery(t *testing.T) {
 	bo := findBO(t, "9 Pool into Hatchery")
-	// Positive: drones, pool, then hatch within 60s of pool.
+	// Positive: exactly 5 drone morphs (= supply 9), pool, then hatch within
+	// 60s of pool. The exact 5-Drone count is what separates this from the
+	// 5–8/10–11 Pool rungs that share the "pool then fast hatch" topology.
 	b := factsBuilder()
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 5; i++ {
 		b.P(subjDrone, 5+i*3)
 	}
 	pos := b.B(subjSpawningPool, 73).B(subjHatchery, 118).list()
@@ -154,12 +160,22 @@ func TestBO_9PoolIntoHatchery(t *testing.T) {
 	}
 	// Negative: hatch built too late after pool.
 	b = factsBuilder()
-	for i := 0; i < 9; i++ {
+	for i := 0; i < 5; i++ {
 		b.P(subjDrone, 5+i*3)
 	}
 	neg := b.B(subjSpawningPool, 73).B(subjHatchery, 200).list()
 	if bo.Matches(neg) {
 		t.Fatalf("9 pool → hatch should fail hatch@200 after pool@73 (gap > 60)")
+	}
+	// Negative: 7-Pool topology (3 drones) that also takes a fast hatch must
+	// NOT match here — it belongs to "7 Pool".
+	b = factsBuilder()
+	for i := 0; i < 3; i++ {
+		b.P(subjDrone, 5+i*3)
+	}
+	neg2 := b.B(subjSpawningPool, 73).B(subjHatchery, 110).list()
+	if bo.Matches(neg2) {
+		t.Fatalf("9 pool → hatch should NOT match a 3-drone (7 Pool) stream")
 	}
 }
 
@@ -415,12 +431,14 @@ func TestBO_RaxCC(t *testing.T) {
 	if !bo.Matches(pos) {
 		t.Fatalf("1 Rax FE should match Rax → CC → Refinery sequence")
 	}
-	// Negative: Refinery before CC.
-	neg := factsBuilder().
+	// Positive: gas-first expand (Rax, Refinery, CC). The gas-before-CC guard
+	// was intentionally dropped so this gas-first FE lands here; it stays
+	// disjoint from 1 Rax 1 Fac (which is Factory-before-CC).
+	posGas := factsBuilder().
 		B(subjSupplyDepot, 60).B(subjBarracks, 88).
 		B(subjRefinery, 115).B(subjCommandCenter, 180).list()
-	if bo.Matches(neg) {
-		t.Fatalf("1 Rax FE should fail when Refinery precedes CC")
+	if !bo.Matches(posGas) {
+		t.Fatalf("1 Rax FE should match a gas-first expand (Rax → Refinery → CC)")
 	}
 	// Negative: 2 Rax before CC.
 	neg2 := factsBuilder().
@@ -458,6 +476,209 @@ func TestBO_BBS(t *testing.T) {
 	neg3 := factsBuilder().B(subjBarracks, 60).list()
 	if bo.Matches(neg3) {
 		t.Fatalf("BBS should fail with a single Barracks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// New ladder rungs / openers / residuals
+// ---------------------------------------------------------------------------
+
+// zergPool builds a stream of n drone morphs then a Pool.
+func zergPoolStream(drones, poolSec int) []cmdenrich.EnrichedCommand {
+	b := factsBuilder()
+	for i := 0; i < drones; i++ {
+		b.P(subjDrone, 5+i*3)
+	}
+	return b.B(subjSpawningPool, poolSec).list()
+}
+
+func TestBO_PoolLadder_5to11(t *testing.T) {
+	// supply → expected BO name. Supply = 4 + drone morphs before Pool.
+	cases := map[int]string{5: "5 Pool", 6: "6 Pool", 7: "7 Pool", 8: "8 Pool", 10: "10 Pool", 11: "11 Pool"}
+	for supply, name := range cases {
+		bo := findBO(t, name)
+		drones := supply - 4
+		if !bo.Matches(zergPoolStream(drones, 50+drones*6)) {
+			t.Fatalf("%s should match exactly %d drones before Pool", name, drones)
+		}
+		// One extra drone is the next rung up, not this one.
+		if bo.Matches(zergPoolStream(drones+1, 50+drones*6)) {
+			t.Fatalf("%s should NOT match with %d drones", name, drones+1)
+		}
+		// A Hatchery before the Pool makes it hatch-first, not a pool BO.
+		hatchFirst := factsBuilder()
+		for i := 0; i < drones; i++ {
+			hatchFirst.P(subjDrone, 5+i*3)
+		}
+		neg := hatchFirst.B(subjHatchery, 40).B(subjSpawningPool, 80).list()
+		if bo.Matches(neg) {
+			t.Fatalf("%s should fail when a Hatchery precedes the Pool", name)
+		}
+	}
+}
+
+func TestBO_HatchLadder_4to8(t *testing.T) {
+	cases := map[int]string{4: "4 Hatch", 5: "5 Hatch", 6: "6 Hatch", 7: "7 Hatch", 8: "8 Hatch"}
+	for supply, name := range cases {
+		bo := findBO(t, name)
+		drones := supply - 4
+		b := factsBuilder()
+		for i := 0; i < drones; i++ {
+			b.P(subjDrone, 5+i*3)
+		}
+		pos := b.B(subjHatchery, 50+drones*8).list()
+		if !bo.Matches(pos) {
+			t.Fatalf("%s should match exactly %d drones before the Hatchery", name, drones)
+		}
+		// A Pool before the Hatchery makes it pool-first, not hatch-first.
+		b2 := factsBuilder()
+		for i := 0; i < drones; i++ {
+			b2.P(subjDrone, 5+i*3)
+		}
+		neg := b2.B(subjSpawningPool, 40).B(subjHatchery, 80).list()
+		if bo.Matches(neg) {
+			t.Fatalf("%s should fail when a Pool precedes the Hatchery", name)
+		}
+	}
+}
+
+func TestBO_2RaxCC(t *testing.T) {
+	bo := findBO(t, "2 Rax CC")
+	// Positive: Depot, Rax, Rax, CC (2 rax before CC, depot first).
+	pos := factsBuilder().B(subjSupplyDepot, 55).B(subjBarracks, 80).B(subjBarracks, 110).B(subjCommandCenter, 180).list()
+	if !bo.Matches(pos) {
+		t.Fatalf("2 Rax CC should match Depot → 2 Rax → CC")
+	}
+	// Negative: only 1 Rax before CC — that's 1 Rax FE.
+	neg := factsBuilder().B(subjSupplyDepot, 55).B(subjBarracks, 80).B(subjCommandCenter, 180).list()
+	if bo.Matches(neg) {
+		t.Fatalf("2 Rax CC should fail with only 1 Rax before CC")
+	}
+	// Negative: 2 Rax before the Depot — that's BBS.
+	neg2 := factsBuilder().B(subjBarracks, 55).B(subjBarracks, 75).B(subjSupplyDepot, 95).B(subjCommandCenter, 180).list()
+	if bo.Matches(neg2) {
+		t.Fatalf("2 Rax CC should fail with 2 Rax before the Depot (that's BBS)")
+	}
+}
+
+func TestBO_ProtossNoExpa(t *testing.T) {
+	gate := findBO(t, "1 Gate (no expa)")
+	// Positive: lone Gateway, no fast Cyber, no expansion.
+	if !gate.Matches(factsBuilder().B(subjPylon, 48).B(subjGateway, 90).list()) {
+		t.Fatalf("1 Gate (no expa) should match a lone Gateway with no expand/cyber")
+	}
+	// Negative: expands (Nexus) — that's Gate Expand.
+	if gate.Matches(factsBuilder().B(subjGateway, 90).B(subjNexus, 180).list()) {
+		t.Fatalf("1 Gate (no expa) should fail when the player expands")
+	}
+	fc := findBO(t, "Forge Cannon (no expa)")
+	// Positive: Forge + Cannon, no expansion.
+	if !fc.Matches(factsBuilder().B(subjForge, 90).B(subjPhotonCannon, 130).list()) {
+		t.Fatalf("Forge Cannon (no expa) should match Forge + Cannon with no expand")
+	}
+	// Negative: Forge then Nexus is FFE, not this.
+	if fc.Matches(factsBuilder().B(subjForge, 90).B(subjPhotonCannon, 130).B(subjNexus, 200).list()) {
+		t.Fatalf("Forge Cannon (no expa) should fail when the player expands (FFE)")
+	}
+}
+
+func TestBO_BunkerRush(t *testing.T) {
+	bo := findBO(t, "Bunker Rush")
+	// Positive: Rax → Bunker, all-in (no CC, no Factory). A defensive gas is
+	// now fine — the build is defined by the absence of an expansion/tech.
+	pos := factsBuilder().B(subjBarracks, 55).B(subjSupplyDepot, 90).B(subjBunker, 130).list()
+	if !bo.Matches(pos) {
+		t.Fatalf("Bunker Rush should match Rax → Bunker all-in (no CC, no Factory)")
+	}
+	posGas := factsBuilder().B(subjBarracks, 55).B(subjRefinery, 100).B(subjBunker, 140).list()
+	if !bo.Matches(posGas) {
+		t.Fatalf("Bunker Rush should still match when a defensive gas precedes the Bunker")
+	}
+	// Negative: expands (CC) — that's 1 Rax FE, not an all-in.
+	negCC := factsBuilder().B(subjBarracks, 55).B(subjBunker, 130).B(subjCommandCenter, 200).list()
+	if bo.Matches(negCC) {
+		t.Fatalf("Bunker Rush should fail when the player expands (CC)")
+	}
+	// Negative: techs to Factory — that's 1 Rax 1 Fac / 1-1-1.
+	negFac := factsBuilder().B(subjBarracks, 55).B(subjBunker, 130).B(subjRefinery, 140).B(subjFactory, 200).list()
+	if bo.Matches(negFac) {
+		t.Fatalf("Bunker Rush should fail when the player techs to a Factory")
+	}
+	// Negative: 2 Rax before the bunker — that's BBS.
+	neg2 := factsBuilder().B(subjBarracks, 55).B(subjBarracks, 80).B(subjBunker, 130).list()
+	if bo.Matches(neg2) {
+		t.Fatalf("Bunker Rush should fail with 2 Barracks before the Bunker (that's BBS)")
+	}
+}
+
+func TestBO_GateExpand_NonPvZ(t *testing.T) {
+	bo := findBO(t, "Gate Expand")
+	// Positive: Gateway → Nexus → Cyber (the PvT/PvP 1-Gate expand).
+	pos := factsBuilder().B(subjGateway, 80).B(subjNexus, 160).B(subjCyberneticsCore, 185).list()
+	if !bo.Matches(pos) {
+		t.Fatalf("Gate Expand should match Gateway → Nexus → Cyber")
+	}
+	// Negative: Cyber before Nexus — that's 1 Gate Core, not an expand.
+	neg := factsBuilder().B(subjGateway, 80).B(subjCyberneticsCore, 130).B(subjNexus, 180).list()
+	if bo.Matches(neg) {
+		t.Fatalf("Gate Expand should fail when Cyber precedes Nexus")
+	}
+}
+
+func TestBO_ForgeExpand_Loosened(t *testing.T) {
+	bo := findBO(t, "Forge Expand")
+	// Positive: slower FFE — Forge@130 (was rejected by the old <100 bound),
+	// Nexus@240 (was rejected by the old <200 bound).
+	pos := factsBuilder().B(subjForge, 130).B(subjNexus, 240).B(subjGateway, 260).list()
+	if !bo.Matches(pos) {
+		t.Fatalf("Forge Expand should match a slow FFE (Forge@130, Nexus@240)")
+	}
+}
+
+func TestBO_Residuals_Complement(t *testing.T) {
+	// Zerg residual: greedy Pool at supply ≥13 (≥9 drones), no named rung.
+	zerg := findBO(t, "Pool/Hatch (Other)")
+	if !zerg.Matches(zergPoolStream(9, 140)) {
+		t.Fatalf("Zerg residual should match a 9-drone (supply 13) Pool")
+	}
+	if zerg.Matches(zergPoolStream(5, 73)) {
+		t.Fatalf("Zerg residual should NOT match a named rung (9 Pool)")
+	}
+	// Protoss residual: a leftover Gateway+Forge opener (no Cannon, no
+	// expansion) that matches none of the named builds — not 1 Gate (no expa)
+	// (which excludes a Forge), not Forge Cannon (no Cannon), not FFE (no Nexus).
+	prot := findBO(t, "Gateway (Other)")
+	if !prot.Matches(factsBuilder().B(subjGateway, 70).B(subjForge, 120).list()) {
+		t.Fatalf("Protoss residual should match a leftover Gateway+Forge opener")
+	}
+	if prot.Matches(factsBuilder().B(subjGateway, 70).B(subjCyberneticsCore, 138).list()) {
+		t.Fatalf("Protoss residual should NOT match a 1 Gate Core")
+	}
+	// A lone slow Gateway is now its own named build, not the residual.
+	if prot.Matches(factsBuilder().B(subjGateway, 70).B(subjCyberneticsCore, 200).list()) {
+		t.Fatalf("Protoss residual should NOT match a lone slow Gateway (that's 1 Gate (no expa))")
+	}
+	// Terran "1 Rax Bio" residual: a Barracks opener matching no named build
+	// (bio: Rax → gas → academy, no expansion, no factory).
+	terr := findBO(t, "1 Rax Bio")
+	if !terr.Matches(factsBuilder().B(subjSupplyDepot, 60).B(subjBarracks, 88).B(subjRefinery, 120).B(subjAcademy, 160).list()) {
+		t.Fatalf("1 Rax Bio should match a bio opener with no expansion/factory")
+	}
+}
+
+func TestMarker_OpenerUnresolved(t *testing.T) {
+	m := findBO(t, "Opener unresolved")
+	// Positive: no defining building ever placed (only workers/supply).
+	if !m.Matches(factsBuilder().P(subjDrone, 10).P(subjDrone, 20).list()) {
+		t.Fatalf("Opener unresolved should match when no defining building is placed")
+	}
+	// Negative: a Pool (Zerg defining building) was placed.
+	if m.Matches(factsBuilder().B(subjSpawningPool, 40).list()) {
+		t.Fatalf("Opener unresolved should NOT match once a Pool is placed")
+	}
+	// Negative: a Gateway (Protoss defining building) was placed.
+	if m.Matches(factsBuilder().B(subjGateway, 70).list()) {
+		t.Fatalf("Opener unresolved should NOT match once a Gateway is placed")
 	}
 }
 

--- a/internal/patterns/markers/dsl.go
+++ b/internal/patterns/markers/dsl.go
@@ -570,6 +570,55 @@ func (s *produceCountBeforeBuildState) Observe(f cmdenrich.EnrichedCommand) {
 func (s *produceCountBeforeBuildState) Decision(int) TriState { return s.done }
 func (s *produceCountBeforeBuildState) Finalize() TriState    { return s.finalizeDefaultRejected() }
 
+// ProduceCountAtLeastBeforeBuild matches if AT LEAST n Produce(unit) facts
+// arrive strictly before the first Build(refSubject). Like
+// ProduceCountBeforeBuild but with a >= threshold instead of an exact count —
+// used by the residual "Other Pool / Other Hatch" catch-alls, which claim the
+// greedy tail of the drone ladder (supply >= 13) that the exact rungs don't.
+//
+// Matches as soon as the n-th Produce(unit) arrives before refSubject; rejects
+// on observing refSubject with fewer than n produced.
+func ProduceCountAtLeastBeforeBuild(unit, refSubject string, n int) Predicate {
+	return func() PredicateState {
+		return &produceCountAtLeastBeforeBuildState{unit: unit, ref: refSubject, want: n}
+	}
+}
+
+type produceCountAtLeastBeforeBuildState struct {
+	commitState
+	unit, ref string
+	want      int
+	count     int
+}
+
+func (s *produceCountAtLeastBeforeBuildState) Observe(f cmdenrich.EnrichedCommand) {
+	if s.done != Pending {
+		return
+	}
+	switch f.Kind {
+	case cmdenrich.KindMakeUnit:
+		if f.Subject == s.unit {
+			s.count++
+			if s.count >= s.want {
+				s.done = Matched
+			}
+		}
+	case cmdenrich.KindMakeBuilding:
+		if f.Subject == s.ref {
+			// First ref build with too few produced so far — can never reach
+			// the threshold "before the first ref build".
+			if s.count < s.want {
+				s.done = Rejected
+			} else {
+				s.done = Matched
+			}
+		}
+	}
+}
+
+func (s *produceCountAtLeastBeforeBuildState) Decision(int) TriState { return s.done }
+func (s *produceCountAtLeastBeforeBuildState) Finalize() TriState    { return s.finalizeDefaultRejected() }
+
 // CountBuildsBefore matches if at least n Build(subject) facts happen with
 // second strictly less than maxSecond.
 func CountBuildsBefore(subject string, n, maxSecond int) Predicate {

--- a/internal/patterns/markers/mutex_test.go
+++ b/internal/patterns/markers/mutex_test.go
@@ -133,14 +133,23 @@ func formatFactsForError(facts []cmdenrich.EnrichedCommand) string {
 func FuzzInitialBOsMutualExclusion(f *testing.F) {
 	// Seed corpus: a mix of typical pool-first / hatch-first / protoss /
 	// terran timings.
-	f.Add([]byte{0, 0, 10, 0, 1, 85, 0, 0, 110, 0})                  // Zerg early Pool
+	f.Add([]byte{0, 0, 10, 0, 1, 85, 0, 0, 110, 0})                    // Zerg early Pool
 	f.Add([]byte{0, 3, 5, 0, 3, 15, 0, 3, 27, 0, 0, 73, 0, 5, 123, 0}) // Zerg 9 Pool
-	f.Add([]byte{1, 0, 48, 0, 2, 86, 0, 3, 116, 0, 4, 138, 0})       // Protoss 1 Gate Core
-	f.Add([]byte{1, 0, 48, 0, 0, 130, 0, 2, 175, 0})                 // Protoss Nexus First
-	f.Add([]byte{1, 1, 48, 0, 5, 86, 0, 6, 130, 0, 0, 152, 0})       // Protoss FFE
-	f.Add([]byte{2, 1, 60, 0, 2, 88, 0, 3, 115, 0, 4, 165, 0})       // Terran 1 Rax 1 Fac
-	f.Add([]byte{2, 1, 62, 0, 0, 145, 0, 2, 165, 0})                 // Terran CC First
-	f.Add([]byte{2, 2, 60, 0, 2, 80, 0, 1, 100, 0})                  // Terran BBS
+	f.Add([]byte{1, 0, 48, 0, 2, 86, 0, 3, 116, 0, 4, 138, 0})         // Protoss 1 Gate Core
+	f.Add([]byte{1, 0, 48, 0, 0, 130, 0, 2, 175, 0})                   // Protoss Nexus First
+	f.Add([]byte{1, 1, 48, 0, 5, 86, 0, 6, 130, 0, 0, 152, 0})         // Protoss FFE
+	f.Add([]byte{2, 1, 60, 0, 2, 88, 0, 3, 115, 0, 4, 165, 0})         // Terran 1 Rax 1 Fac
+	f.Add([]byte{2, 1, 62, 0, 0, 145, 0, 2, 165, 0})                   // Terran CC First
+	f.Add([]byte{2, 2, 60, 0, 2, 80, 0, 1, 100, 0})                    // Terran BBS
+	// New openers (subject indices: zerg pool=0 hatch=1 drone=3 overlord=4;
+	// protoss nexus=0 gateway=2; terran depot=1 rax=2 bunker=8).
+	f.Add([]byte{0, 3, 30, 0, 3, 33, 0, 3, 36, 0, 0, 60, 0})                                         // Zerg 7 Pool (3 drones)
+	f.Add([]byte{0, 4, 20, 0, 3, 30, 0, 3, 33, 0, 3, 36, 0, 3, 39, 0, 3, 42, 0, 3, 45, 0, 0, 92, 0}) // Zerg 10 Pool (overlord + 6 drones)
+	f.Add([]byte{1, 2, 80, 0, 0, 160, 0})                                                            // Protoss Gate Expand (gate→nexus)
+	f.Add([]byte{2, 2, 55, 0, 1, 90, 0, 8, 130, 0})                                                  // Terran Bunker Rush (rax→depot→bunker)
+	// Regression: rax→bunker→rax→CC@276 once both-matched Bunker Rush + 2 Rax CC
+	// (real 6-player Money game). CC second = 20 + 1*256 = 276.
+	f.Add([]byte{2, 1, 55, 0, 2, 80, 0, 8, 130, 0, 2, 180, 0, 0, 20, 1})
 
 	f.Fuzz(func(t *testing.T, data []byte) {
 		if len(data) < 1 {

--- a/internal/patterns/markers/testdata/fuzz/FuzzInitialBOsMutualExclusion/456f4719aa30b539
+++ b/internal/patterns/markers/testdata/fuzz/FuzzInitialBOsMutualExclusion/456f4719aa30b539
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2YX28028020")

--- a/internal/patterns/markers/testdata/fuzz/FuzzInitialBOsMutualExclusion/4c0c1a1a650a6942
+++ b/internal/patterns/markers/testdata/fuzz/FuzzInitialBOsMutualExclusion/4c0c1a1a650a6942
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2Y02Z01")

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -170,6 +170,11 @@
       },
       {
         "replay_player_id": 1,
+        "pattern_name": "Build Order: Gateway (Other)",
+        "value": "150"
+      },
+      {
+        "replay_player_id": 1,
         "pattern_name": "Used Hotkey Groups",
         "value": "{\"groups\":[1,2,3,4]}"
       }
@@ -191,6 +196,11 @@
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
         "value": "{\"switches_per_minute\":8.544303797468354}"
+      },
+      {
+        "replay_player_id": 1,
+        "pattern_name": "Build Order: 4 Hatch",
+        "value": "{\"expert_actuals\":[{\"second\":74,\"found\":true},{\"second\":109,\"found\":true}]}"
       },
       {
         "replay_player_id": 1,
@@ -298,10 +308,26 @@
     ]
   },
   "empty_short.rep": {
-    "detections": []
+    "detections": [
+      {
+        "replay_player_id": 0,
+        "pattern_name": "Opener unresolved",
+        "value": "1"
+      },
+      {
+        "replay_player_id": 1,
+        "pattern_name": "Opener unresolved",
+        "value": "1"
+      }
+    ]
   },
   "never_upgraded.rep": {
     "detections": [
+      {
+        "replay_player_id": 0,
+        "pattern_name": "Opener unresolved",
+        "value": "831"
+      },
       {
         "replay_player_id": 1,
         "pattern_name": "Build Order: 11 Hatch",

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -83,9 +83,13 @@ func TestSQLiteStorage_IngestionAndQueries(t *testing.T) {
 	// all marker detections live in replay_events with event_kind='marker' alongside
 	// narrative game_events — the single count here is their sum.
 	expectedCounts := map[string]int64{
-		"replays":       4,
-		"players":       14,
-		"replay_events": 201,
+		"replays": 4,
+		"players": 14,
+		// Every classifiable player now lands on an opener (named BO or a
+		// per-race residual) regardless of team format — the opener rules are
+		// no longer matchup-gated — so the BGH team-game players in this set
+		// each gain an opener marker too.
+		"replay_events": 209,
 	}
 	actualCounts, err := collectCounts(store, keys(expectedCounts))
 	if err != nil {

--- a/internal/testdata/replays/golden.json
+++ b/internal/testdata/replays/golden.json
@@ -24,7 +24,7 @@
       "commands": 8973,
       "patterns": {
         "replay": 2,
-        "player": 7
+        "player": 8
       }
     },
     {
@@ -33,7 +33,7 @@
       "commands": 13965,
       "patterns": {
         "replay": 2,
-        "player": 31
+        "player": 38
       }
     }
   ]


### PR DESCRIPTION
## Why

Build-order (BO) detection was reliable but under-covered: only ~60% of player-replays got a BO, coverage was uneven across races/matchups, and the Zerg pool ladder had holes (4 & 9 existed; 5/6/7/8/10/11 did not). Goal: classify essentially every *playable* player-replay while keeping BOs mutually exclusive.

Grounded in fresh ingests of the cwal-dl progamer corpus (~2.8k replays) plus a held-out cross-validation corpus.

## Results

- **1v1 playable coverage** (≥3 min): Protoss ~98% / Terran ~98% / Zerg ~97% (was ~86/89/81).
- **All player-replays accounted** (BO or N/A) across every team format: **~99%**.
- **Mutual exclusion holds on every 1v1 matchup** — `FuzzInitialBOsMutualExclusion` passes (regression seeds added). One known degenerate edge: a race-changed player on a 6-player Money game can get 2 BOs.

## Detection changes (`internal/patterns/markers`)

- **Zerg**: pool ladder `5/6/7/8/10/11 Pool` + hatch-first ladder `4/5/6/7/8 Hatch`, keyed on exact pre-build Drone-morph counts (spam-reduced stream).
- **Protoss**: loosened FFE timing; widened expand/core openers to all matchups; added `1 Gate Expand`, `Forge Cannon (no expa)`, `1 Gate (no expa)`.
- **Terran**: defensive Bunkers fold into `1 Rax FE`; `Bunker Rush` redefined as an all-in (no CC / no Factory); added `2 Rax CC`; residual relabeled `1 Rax Bio`.
- Per-race **residual catch-alls** (exact complement of the named openers) + a race-agnostic **`Opener unresolved`** (N/A) marker for players who never place a defining building.
- **Matchup gates removed** from openers so team/FFA players are classified too.
- New `ProduceCountAtLeastBeforeBuild` DSL primitive; **`AlgorithmVersion` → 26** (triggers re-detection of existing DBs on next ingest).

## Dashboard changes (`internal/dashboard`)

- Per-player summary is now a **table** (Name / APM / Featuring / Unit composition %) with a header row, thin dividers, tighter columns.
- Pill type shown via a **top-border legend** (BUILD ORDER / HOTKEYS / EARLY-MID-LATE COMPOSITION); the BO pill leads each row; squarer 9px pills.
- **🚫 Opener unresolved** pill for N/A players; hotkeys show an enlarged ⌨️ + space-separated groups wrapped onto two rows.
- **Fix**: Guardian / Devourer / Dark Templar no longer shown in the spellcaster strip (they're army units → unit histogram).

## Testing

- `go test ./...` — 279 pass (new per-BO unit tests; markers/parser/storage goldens regenerated).
- `FuzzInitialBOsMutualExclusion` green (90s).
- Verified coverage + mutex on the full corpus and a held-out cross-validation corpus; UI verified in the browser.

## Known follow-ups (not in this PR)

- Pre-existing game-detail `sql: no rows` error on winner-less/leaver games blocks the detail view (and thus the N/A pill) there.
- ~11 uncategorised Zerg drone-count edge cases; optional one-BO-per-player safety net for degenerate team games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
