### PR TITLE
feat: Generated, test-backed SPECIFICATION.md (closes #138)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: openapi-generate ui-build build release cross-binaries windows-syso clean-windows-syso
+.PHONY: openapi-generate spec-generate ui-build build release cross-binaries windows-syso clean-windows-syso
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 REL_LDFLAGS := -s -w -X github.com/marianogappa/screpdb/internal/buildinfo.Version=$(VERSION)
@@ -23,6 +23,11 @@ SYSO_VER_FLAGS := \
 openapi-generate:
 	go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest -config api/openapi/oapi-codegen.yaml api/openapi/dashboard.v1.yaml
 	go run ./internal/dashboard/tools/gen_openapi_bridge
+
+# Regenerate SPECIFICATION.md from the Go source of truth. Equivalent to
+# `go generate ./...` for the spec package; CI's `go test ./...` fails if stale.
+spec-generate:
+	go run ./internal/spec/tools/genspec
 
 ui-build:
 	cd internal/dashboard/frontend && npm ci && npm run build

--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ go build .
 
 - All UI functionality exposed as API: [OpenAPI schema available](api/openapi/dashboard.v1.yaml)
 
+## Specification — how the numbers are computed
+
+screpdb makes a lot of derived claims: "this is a **9 Pool**", "your Spawning
+Pool was 6s late", "a Zealot takes 25.2s". Skeptical? Audit them.
+
+[**SPECIFICATION.md**](SPECIFICATION.md) documents every golden value the app
+relies on — unit names, build times, expert timings, costs, tech-tree rules,
+detection thresholds, and more. It's:
+
+- **Generated** from the Go source of truth (`go generate ./...`), so it can't drift from the code.
+- **Test-backed** — CI fails if any value is wrong or the file is stale.
+
+In short: not aspirational docs that rot, but a provably-accurate description of
+what the app actually does.
+
 ## Running on Windows
 
 The Windows binaries are **not code-signed**. On first launch you will see one or more of the following — none of them mean the binary is malicious:

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,721 @@
+# screpdb specification
+
+> **Generated file — do not edit by hand.** Run `go generate ./...` to rebuild it,
+> then commit. CI fails if it's stale or if any value isn't test-backed.
+
+## Why this exists
+
+screpdb makes a lot of derived claims — "this is a **9 Pool**", "your Spawning
+Pool was 6s late", "a Zealot takes 25.2s". They all rest on **golden values**
+baked into the code.
+
+This document lets you audit them:
+
+- Every value is read straight from the constants the app runs on (the doc is generated *from* them).
+- Every value is checked by a test (`go test ./...`).
+
+So the doc can't drift from the code, and the code can't be silently wrong.
+
+Each section is a short intro plus a fixed-column table — readable by humans,
+parseable by machines. Keys are sorted, so diffs stay small.
+
+## Contents
+
+- [Unit & building names](#unit--building-names)
+- [Order → unit attribution](#order--unit-attribution)
+- [Build times](#build-times)
+- [Tech research](#tech-research)
+- [Upgrades](#upgrades)
+- [Worker & flying units](#worker--flying-units)
+- [Unit geometry](#unit-geometry)
+- [Building geometry](#building-geometry)
+- [Higher-level action types](#higherlevel-action-types)
+- [Replay enums](#replay-enums)
+- [Build orders & expert timings](#build-orders--expert-timings)
+- [Build-order rule deadlines](#buildorder-rule-deadlines)
+- [Absence-marker game-length thresholds](#absencemarker-gamelength-thresholds)
+- [Detection scalars & versioning](#detection-scalars--versioning)
+- [Early-game unit economics](#earlygame-unit-economics)
+- [Worker gather rates](#worker-gather-rates)
+- [Tech tree: producers](#tech-tree-producers)
+- [Tech tree: prerequisites](#tech-tree-prerequisites)
+- [Featuring strip order](#featuring-strip-order)
+- [Game-event featuring chips](#gameevent-featuring-chips)
+
+## Unit & building names
+
+The canonical names screpdb uses for every unit and building, grouped by race. Every name shown in the UI is one of these strings.
+
+| Race | Category | Names |
+| --- | --- | --- |
+| Terran | Units | Battlecruiser, Dropship, Firebat, Ghost, Goliath, Marine, Medic, SCV, Science Vessel, Siege Tank (Tank Mode), Siege Tank Turret (Tank Mode), Valkyrie, Vulture, Wraith |
+| Terran | Buildings | Academy, Armory, Barracks, Bunker, ComSat, Command Center, Control Tower, Covert Ops, Engineering Bay, Factory, Machine Shop, Missile Turret, Nuclear Silo, Physics Lab, Refinery, Science Facility, Starport, Supply Depot |
+| Zerg | Units | Defiler, Devourer, Drone, Guardian, Hydralisk, Infested Terran, Lurker, Mutalisk, Overlord, Queen, Scourge, Ultralisk, Zergling |
+| Zerg | Buildings | Creep Colony, Defiler Mound, Evolution Chamber, Extractor, Greater Spire, Hatchery, Hive, Hydralisk Den, Infested CC, Lair, Nydus Canal, Queens Nest, Spawning Pool, Spire, Spore Colony, Sunken Colony, Ultralisk Cavern |
+| Protoss | Units | Arbiter, Archon, Carrier, Corsair, Dark Archon, Dark Templar, Dragoon, High Templar, Observer, Probe, Reaver, Scout, Shuttle, Zealot |
+| Protoss | Buildings | Arbiter Tribunal, Assimilator, Citadel of Adun, Cybernetics Core, Fleet Beacon, Forge, Gateway, Nexus, Observatory, Photon Cannon, Pylon, Robotics Facility, Robotics Support Bay, Shield Battery, Stargate, Templar Archives |
+
+## Order → unit attribution
+
+Orders/actions that belong to exactly one unit type (e.g. `CastPsionicStorm` can only be a High Templar). screpdb uses this to attribute a command to the unit that issued it. Generic orders (Move, Attack, Hold) belong to many units and are omitted. `OrderName` and `ActionType` are separate namespaces.
+
+| Key | Namespace | Issued by | Race |
+| --- | --- | --- | --- |
+| ArchonWarp | OrderName | High Templar | Protoss |
+| Carrier | OrderName | Carrier | Protoss |
+| CarrierAttack | OrderName | Carrier | Protoss |
+| CarrierFight | OrderName | Carrier | Protoss |
+| CarrierHoldPosition | OrderName | Carrier | Protoss |
+| CarrierIgnore2 | OrderName | Carrier | Protoss |
+| CarrierMoveToAttack | OrderName | Carrier | Protoss |
+| CarrierStop | ActionType | Carrier | Protoss |
+| CarrierStop | OrderName | Carrier | Protoss |
+| CastConsume | OrderName | Defiler | Zerg |
+| CastDarkSwarm | OrderName | Defiler | Zerg |
+| CastDefensiveMatrix | OrderName | Science Vessel | Terran |
+| CastDisruptionWeb | OrderName | Corsair | Protoss |
+| CastEMPShockwave | OrderName | Science Vessel | Terran |
+| CastEnsnare | OrderName | Queen | Zerg |
+| CastFeedback | OrderName | Dark Archon | Protoss |
+| CastHallucination | OrderName | High Templar | Protoss |
+| CastInfestation | OrderName | Queen | Zerg |
+| CastIrradiate | OrderName | Science Vessel | Terran |
+| CastLockdown | OrderName | Ghost | Terran |
+| CastMaelstrom | OrderName | Dark Archon | Protoss |
+| CastMindControl | OrderName | Dark Archon | Protoss |
+| CastNuclearStrike | OrderName | Ghost | Terran |
+| CastOpticalFlare | OrderName | Medic | Terran |
+| CastParasite | OrderName | Queen | Zerg |
+| CastPlague | OrderName | Defiler | Zerg |
+| CastPsionicStorm | OrderName | High Templar | Protoss |
+| CastRecall | OrderName | Arbiter | Protoss |
+| CastRestoration | OrderName | Medic | Terran |
+| CastSpawnBroodlings | OrderName | Queen | Zerg |
+| CastStasisField | OrderName | Science Vessel | Terran |
+| CloakNearbyUnits | OrderName | Arbiter | Protoss |
+| CreateProtossBuilding | OrderName | Probe | Protoss |
+| DarkArchonMeld | OrderName | Dark Archon | Protoss |
+| DroneBuild | OrderName | Drone | Zerg |
+| DroneLand | OrderName | Drone | Zerg |
+| DroneLiftOff | OrderName | Drone | Zerg |
+| DroneStartBuild | OrderName | Drone | Zerg |
+| FireYamatoGun | OrderName | Battlecruiser | Terran |
+| GuardianAspect | OrderName | Mutalisk | Zerg |
+| Hallucination2 | OrderName | High Templar | Protoss |
+| HealMove | OrderName | Medic | Terran |
+| InfestingCommandCenter | OrderName | Queen | Zerg |
+| InitializeArbiter | OrderName | Arbiter | Protoss |
+| InterceptorAttack | OrderName | Carrier | Protoss |
+| InterceptorReturn | OrderName | Carrier | Protoss |
+| Medic | OrderName | Medic | Terran |
+| MedicHeal | OrderName | Medic | Terran |
+| MedicHealToIdle | OrderName | Medic | Terran |
+| MedicHoldPosition | OrderName | Medic | Terran |
+| MoveToFireYamatoGun | OrderName | Battlecruiser | Terran |
+| MoveToInfest | OrderName | Queen | Zerg |
+| MoveToRepair | OrderName | SCV | Terran |
+| NukeLaunch | OrderName | Ghost | Terran |
+| NukePaint | OrderName | Ghost | Terran |
+| NukeTrack | OrderName | Ghost | Terran |
+| NukeTrain | OrderName | Ghost | Terran |
+| NukeUnit | OrderName | Ghost | Terran |
+| NukeWait | OrderName | Ghost | Terran |
+| PlaceMine | OrderName | Vulture | Terran |
+| PlaceProtossBuilding | OrderName | Probe | Protoss |
+| QueenHoldPosition | OrderName | Queen | Zerg |
+| Reaver | OrderName | Reaver | Protoss |
+| ReaverAttack | OrderName | Reaver | Protoss |
+| ReaverFight | OrderName | Reaver | Protoss |
+| ReaverHoldPosition | OrderName | Reaver | Protoss |
+| ReaverMoveToAttack | OrderName | Reaver | Protoss |
+| ReaverStop | ActionType | Reaver | Protoss |
+| ReaverStop | OrderName | Reaver | Protoss |
+| Repair | OrderName | SCV | Terran |
+| ScarabAttack | OrderName | Reaver | Protoss |
+| Siege | ActionType | Siege Tank (Tank Mode) | Terran |
+| Sieging | OrderName | Siege Tank (Tank Mode) | Terran |
+| Unsiege | ActionType | Terran Siege Tank (Siege Mode) | Terran |
+| Unsieging | OrderName | Terran Siege Tank (Siege Mode) | Terran |
+| VultureMine | OrderName | Vulture | Terran |
+
+## Build times
+
+Build time in seconds at "Fastest" speed (every competitive replay uses it). Single source of truth for all timing logic — detection, expert timings, and the economy table all read these values. Zerglings are timed per pair (one egg makes two).
+
+| Unit / Building | Build time (s) |
+| --- | --- |
+| Academy | 50 |
+| Assimilator | 25 |
+| Barracks | 50 |
+| Bunker | 19 |
+| Command Center | 75 |
+| Creep Colony | 12 |
+| Cybernetics Core | 38 |
+| Drone | 12.6 |
+| Engineering Bay | 38 |
+| Evolution Chamber | 25 |
+| Extractor | 25 |
+| Factory | 50 |
+| Forge | 25 |
+| Gateway | 38 |
+| Hatchery | 75 |
+| Machine Shop | 25 |
+| Marine | 15 |
+| Missile Turret | 18.9 |
+| Mutalisk | 25 |
+| Nexus | 75 |
+| Overlord | 25 |
+| Photon Cannon | 31.5 |
+| Probe | 12.6 |
+| Pylon | 19 |
+| Refinery | 25 |
+| SCV | 12.6 |
+| Spawning Pool | 50 |
+| Spire | 75 |
+| Starport | 44 |
+| Sunken Colony | 12 |
+| Supply Depot | 25 |
+| Zealot | 25.2 |
+| Zergling | 18 |
+
+## Tech research
+
+One-shot researches that unlock an ability or morph (Stim Packs, Lurker Aspect, Psionic Storm, …): where each is researched, its cost, and its duration at "Fastest" speed. screpdb uses the duration to time when the ability becomes available.
+
+| Tech | Race | Researched at | Minerals | Gas | Duration (s) |
+| --- | --- | --- | --- | --- | --- |
+| Burrowing | Zerg | Hatchery | 100 | 100 | 80 |
+| Cloaking Field | Terran | Control Tower | 150 | 150 | 63 |
+| Consume | Zerg | Defiler Mound | 100 | 100 | 63 |
+| Disruption Web | Protoss | Fleet Beacon | 200 | 200 | 50 |
+| EMP Shockwave | Terran | Science Facility | 200 | 200 | 75.6 |
+| Ensnare | Zerg | Queens Nest | 100 | 100 | 50 |
+| Hallucination | Protoss | Templar Archives | 150 | 150 | 50.4 |
+| Irradiate | Terran | Science Facility | 200 | 200 | 50.4 |
+| Lockdown | Terran | Covert Ops | 200 | 200 | 63 |
+| Lurker Aspect | Zerg | Hydralisk Den | 200 | 200 | 75.6 |
+| Maelstrom | Protoss | Templar Archives | 100 | 100 | 63 |
+| Mind Control | Protoss | Templar Archives | 200 | 200 | 75.6 |
+| Optical Flare | Terran | Academy | 100 | 100 | 75.6 |
+| Personnel Cloaking | Terran | Covert Ops | 100 | 100 | 50 |
+| Plague | Zerg | Defiler Mound | 200 | 200 | 63 |
+| Psionic Storm | Protoss | Templar Archives | 200 | 200 | 75.6 |
+| Recall | Protoss | Arbiter Tribunal | 150 | 150 | 76 |
+| Restoration | Terran | Academy | 100 | 100 | 50.4 |
+| Spawn Broodlings | Zerg | Queens Nest | 100 | 100 | 50 |
+| Spider Mines | Terran | Machine Shop | 100 | 100 | 50.4 |
+| Stasis Field | Protoss | Arbiter Tribunal | 150 | 150 | 63 |
+| Stim Packs | Terran | Academy | 100 | 100 | 50.4 |
+| Tank Siege Mode | Terran | Machine Shop | 150 | 150 | 50.4 |
+| Yamato Gun | Terran | Physics Lab | 100 | 100 | 75.6 |
+
+## Upgrades
+
+Passive upgrades: where each is researched, its max level (1 one-shot, 3 tiered) and each level's cost. Level cells read `minerals / gas / seconds`; unused levels show an em dash. Used to time when an upgrade completes.
+
+| Upgrade | Race | Researched at | Max level | L1 (m/g/s) | L2 (m/g/s) | L3 (m/g/s) |
+| --- | --- | --- | --- | --- | --- | --- |
+| Adrenal Glands (Zergling Attack) | Zerg | Spawning Pool | 1 | 200 / 200 / 63 | — | — |
+| Anabolic Synthesis (Ultralisk Speed) | Zerg | Ultralisk Cavern | 1 | 200 / 200 / 83.79 | — | — |
+| Antennae (Overlord Sight) | Zerg | Lair | 1 | 150 / 150 / 83.79 | — | — |
+| Apial Sensors (Scout Sight) | Protoss | Fleet Beacon | 1 | 100 / 100 / 105 | — | — |
+| Apollo Reactor (Wraith Energy) | Terran | Control Tower | 1 | 200 / 200 / 105 | — | — |
+| Argus Jewel (Corsair Energy) | Protoss | Fleet Beacon | 1 | 100 / 100 / 105 | — | — |
+| Argus Talisman (Dark Archon Energy) | Protoss | Templar Archives | 1 | 150 / 150 / 105 | — | — |
+| Caduceus Reactor (Medic Energy) | Terran | Academy | 1 | 150 / 150 / 105 | — | — |
+| Carrier Capacity | Protoss | Fleet Beacon | 1 | 100 / 100 / 63 | — | — |
+| Charon Boosters (Goliath Range) | Terran | Machine Shop | 1 | 100 / 100 / 84 | — | — |
+| Chitinous Plating (Ultralisk Armor) | Zerg | Ultralisk Cavern | 1 | 150 / 150 / 83.79 | — | — |
+| Colossus Reactor (Battle Cruiser Energy) | Terran | Physics Lab | 1 | 150 / 150 / 105 | — | — |
+| Defiler Energy | Zerg | Defiler Mound | 1 | 150 / 150 / 104.58 | — | — |
+| Gamete Meiosis (Queen Energy) | Zerg | Queens Nest | 1 | 150 / 150 / 104.58 | — | — |
+| Gravitic Booster (Observer Speed) | Protoss | Observatory | 1 | 150 / 150 / 84 | — | — |
+| Gravitic Drive (Shuttle Speed) | Protoss | Robotics Support Bay | 1 | 200 / 200 / 105 | — | — |
+| Gravitic Thrusters (Scout Speed) | Protoss | Fleet Beacon | 1 | 200 / 200 / 105 | — | — |
+| Grooved Spines (Hydralisk Range) | Zerg | Hydralisk Den | 1 | 150 / 150 / 63 | — | — |
+| Ion Thrusters (Vulture Speed) | Terran | Machine Shop | 1 | 100 / 100 / 63 | — | — |
+| Khaydarin Amulet (Templar Energy) | Protoss | Templar Archives | 1 | 150 / 150 / 105 | — | — |
+| Khaydarin Core (Arbiter Energy) | Protoss | Arbiter Tribunal | 1 | 150 / 150 / 105 | — | — |
+| Leg Enhancement (Zealot Speed) | Protoss | Citadel of Adun | 1 | 150 / 150 / 84 | — | — |
+| Metabolic Boost (Zergling Speed) | Zerg | Spawning Pool | 1 | 100 / 100 / 63 | — | — |
+| Moebius Reactor (Ghost Energy) | Terran | Covert Ops | 1 | 150 / 150 / 105 | — | — |
+| Muscular Augments (Hydralisk Speed) | Zerg | Hydralisk Den | 1 | 150 / 150 / 63 | — | — |
+| Ocular Implants (Ghost Sight) | Terran | Covert Ops | 1 | 100 / 100 / 105 | — | — |
+| Pneumatized Carapace (Overlord Speed) | Zerg | Lair | 1 | 150 / 150 / 83.79 | — | — |
+| Protoss Air Armor | Protoss | Cybernetics Core | 3 | 150 / 150 / 167.58 | 225 / 225 / 180.18 | 300 / 300 / 192.78 |
+| Protoss Air Weapons | Protoss | Cybernetics Core | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Protoss Ground Armor | Protoss | Forge | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Protoss Ground Weapons | Protoss | Forge | 3 | 100 / 100 / 167.58 | 150 / 150 / 180.18 | 200 / 200 / 192.78 |
+| Protoss Plasma Shields | Protoss | Forge | 3 | 200 / 200 / 167.58 | 300 / 300 / 180.18 | 400 / 400 / 192.78 |
+| Reaver Capacity | Protoss | Robotics Support Bay | 1 | 200 / 200 / 105 | — | — |
+| Scarab Damage | Protoss | Robotics Support Bay | 1 | 200 / 200 / 105 | — | — |
+| Sensor Array (Observer Sight) | Protoss | Observatory | 1 | 150 / 150 / 84 | — | — |
+| Singularity Charge (Dragoon Range) | Protoss | Cybernetics Core | 1 | 150 / 150 / 105 | — | — |
+| Terran Infantry Armor | Terran | Engineering Bay | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Terran Infantry Weapons | Terran | Engineering Bay | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Terran Ship Plating | Terran | Armory | 3 | 150 / 150 / 167.58 | 225 / 225 / 180.18 | 300 / 300 / 192.78 |
+| Terran Ship Weapons | Terran | Armory | 3 | 100 / 100 / 167.58 | 150 / 150 / 180.18 | 200 / 200 / 192.78 |
+| Terran Vehicle Plating | Terran | Armory | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Terran Vehicle Weapons | Terran | Armory | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Titan Reactor (Science Vessel Energy) | Terran | Science Facility | 1 | 150 / 150 / 105 | — | — |
+| U-238 Shells (Marine Range) | Terran | Academy | 1 | 150 / 150 / 63 | — | — |
+| Ventral Sacs (Overlord Transport) | Zerg | Lair | 1 | 200 / 200 / 100.8 | — | — |
+| Zerg Carapace | Zerg | Evolution Chamber | 3 | 150 / 150 / 167.58 | 225 / 225 / 180.18 | 300 / 300 / 192.78 |
+| Zerg Flyer Attacks | Zerg | Spire | 3 | 100 / 100 / 167.58 | 175 / 175 / 180.18 | 250 / 250 / 192.78 |
+| Zerg Flyer Carapace | Zerg | Spire | 3 | 150 / 150 / 167.58 | 225 / 225 / 180.18 | 300 / 300 / 192.78 |
+| Zerg Melee Attacks | Zerg | Evolution Chamber | 3 | 100 / 100 / 167.58 | 150 / 150 / 180.18 | 200 / 200 / 192.78 |
+| Zerg Missile Attacks | Zerg | Evolution Chamber | 3 | 100 / 100 / 167.58 | 150 / 150 / 180.18 | 200 / 200 / 192.78 |
+
+## Worker & flying units
+
+Two unit sets the detectors special-case, both excluded from drop-composition estimates: workers, and flying units (can't be carried in a transport).
+
+| Category | Units |
+| --- | --- |
+| Workers | Drone, Probe, SCV |
+| Flying (non-transportable) | Arbiter, Battlecruiser, Carrier, Corsair, Devourer, Dropship, Guardian, Mutalisk, Mutalisk Cocoon, Observer, Overlord, Queen, Science Vessel, Scourge, Scout, Shuttle, Valkyrie, Wraith |
+
+## Unit geometry
+
+Pixel dimensions screpdb uses to draw unit overlays on the map.
+
+| Unit | Width (px) | Height (px) |
+| --- | --- | --- |
+| Arbiter | 44 | 44 |
+| Archon | 32 | 32 |
+| Battlecruiser | 75 | 59 |
+| Carrier | 64 | 64 |
+| Corsair | 36 | 32 |
+| Dark Archon | 32 | 32 |
+| Dark Templar | 24 | 26 |
+| Defiler | 27 | 25 |
+| Devourer | 44 | 44 |
+| Dragoon | 32 | 32 |
+| Drone | 23 | 23 |
+| Dropship | 49 | 37 |
+| Firebat | 23 | 22 |
+| Ghost | 15 | 22 |
+| Goliath | 32 | 32 |
+| Guardian | 44 | 44 |
+| High Templar | 24 | 24 |
+| Hydralisk | 21 | 23 |
+| Infested Terran | 17 | 20 |
+| Lurker | 32 | 32 |
+| Marine | 17 | 20 |
+| Medic | 17 | 20 |
+| Mutalisk | 44 | 44 |
+| Observer | 32 | 32 |
+| Overlord | 50 | 50 |
+| Probe | 23 | 23 |
+| Queen | 48 | 48 |
+| Reaver | 32 | 32 |
+| SCV | 23 | 23 |
+| Science Vessel | 65 | 50 |
+| Scourge | 24 | 24 |
+| Scout | 36 | 32 |
+| Shuttle | 40 | 32 |
+| Siege Tank (Tank Mode) | 32 | 32 |
+| Siege Tank Turret (Tank Mode) | 32 | 32 |
+| Ultralisk | 38 | 32 |
+| Valkyrie | 49 | 37 |
+| Vulture | 32 | 32 |
+| Wraith | 38 | 30 |
+| Zealot | 23 | 19 |
+| Zergling | 16 | 16 |
+
+## Building geometry
+
+Pixel dimensions for building overlays. `Box` is the placement footprint, `Real` is the visible sprite, and the gaps are the insets from box to sprite on each side.
+
+| Building | Box W | Box H | Real W | Real H | Gap T | Gap L | Gap R | Gap B |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Academy | 96 | 64 | 85 | 57 | 0 | 8 | 3 | 7 |
+| Arbiter Tribunal | 96 | 64 | 89 | 57 | 4 | 4 | 3 | 3 |
+| Armory | 96 | 64 | 96 | 55 | 0 | 0 | 0 | 9 |
+| Assimilator | 128 | 64 | 97 | 57 | 0 | 16 | 15 | 7 |
+| Barracks | 128 | 96 | 105 | 73 | 8 | 16 | 7 | 15 |
+| Bunker | 64 | 64 | 33 | 49 | 0 | 16 | 15 | 15 |
+| Citadel of Adun | 96 | 64 | 65 | 49 | 8 | 24 | 7 | 7 |
+| ComSat | 64 | 64 | 69 | 42 | 16 | -5 | 0 | 6 |
+| Command Center | 128 | 96 | 117 | 83 | 7 | 6 | 5 | 6 |
+| Control Tower | 64 | 64 | 76 | 47 | 8 | -15 | 3 | 9 |
+| Covert Ops | 64 | 64 | 76 | 47 | 8 | -15 | 3 | 9 |
+| Creep Colony | 64 | 64 | 48 | 48 | 8 | 8 | 8 | 8 |
+| Cybernetics Core | 96 | 64 | 81 | 49 | 8 | 8 | 7 | 7 |
+| Defiler Mound | 128 | 64 | 97 | 37 | 0 | 16 | 15 | 27 |
+| Engineering Bay | 128 | 96 | 97 | 61 | 16 | 16 | 15 | 19 |
+| Evolution Chamber | 96 | 64 | 77 | 53 | 0 | 4 | 15 | 11 |
+| Extractor | 128 | 64 | 128 | 64 | 0 | 0 | 0 | 0 |
+| Factory | 128 | 96 | 113 | 81 | 8 | 8 | 7 | 7 |
+| Fleet Beacon | 96 | 64 | 88 | 57 | 0 | 8 | 0 | 7 |
+| Forge | 96 | 64 | 73 | 45 | 8 | 12 | 11 | 11 |
+| Gateway | 128 | 96 | 97 | 73 | 16 | 16 | 15 | 7 |
+| Greater Spire | 64 | 64 | 57 | 57 | 0 | 4 | 3 | 7 |
+| Hatchery | 128 | 96 | 99 | 65 | 16 | 15 | 14 | 15 |
+| Hive | 128 | 96 | 99 | 65 | 16 | 15 | 14 | 15 |
+| Hydralisk Den | 96 | 64 | 81 | 57 | 0 | 8 | 7 | 7 |
+| Infested CC | 128 | 96 | 117 | 83 | 7 | 6 | 5 | 6 |
+| Lair | 128 | 96 | 99 | 65 | 16 | 15 | 14 | 15 |
+| Machine Shop | 64 | 64 | 71 | 49 | 8 | -7 | 0 | 7 |
+| Missile Turret | 64 | 64 | 33 | 49 | 0 | 16 | 15 | 15 |
+| Nexus | 128 | 96 | 113 | 79 | 9 | 8 | 7 | 8 |
+| Nuclear Silo | 64 | 64 | 69 | 42 | 16 | -5 | 0 | 6 |
+| Nydus Canal | 64 | 64 | 64 | 64 | 0 | 0 | 0 | 0 |
+| Observatory | 96 | 64 | 89 | 45 | 16 | 4 | 3 | 3 |
+| Photon Cannon | 64 | 64 | 41 | 33 | 16 | 12 | 11 | 15 |
+| Physics Lab | 64 | 64 | 76 | 47 | 8 | -15 | 3 | 9 |
+| Pylon | 64 | 64 | 33 | 33 | 20 | 16 | 15 | 11 |
+| Queens Nest | 96 | 64 | 71 | 57 | 4 | 10 | 15 | 3 |
+| Refinery | 128 | 64 | 113 | 64 | 0 | 8 | 7 | 0 |
+| Robotics Facility | 96 | 64 | 77 | 37 | 16 | 12 | 7 | 11 |
+| Robotics Support Bay | 96 | 64 | 65 | 53 | 0 | 16 | 15 | 11 |
+| Science Facility | 128 | 96 | 97 | 77 | 10 | 16 | 15 | 9 |
+| Shield Battery | 96 | 64 | 65 | 33 | 16 | 16 | 15 | 15 |
+| Spawning Pool | 96 | 64 | 77 | 47 | 4 | 12 | 7 | 13 |
+| Spire | 64 | 64 | 57 | 57 | 0 | 4 | 3 | 7 |
+| Spore Colony | 64 | 64 | 48 | 48 | 8 | 8 | 8 | 8 |
+| Stargate | 128 | 96 | 97 | 73 | 8 | 16 | 15 | 15 |
+| Starport | 128 | 96 | 97 | 79 | 8 | 16 | 15 | 9 |
+| Sunken Colony | 64 | 64 | 48 | 48 | 8 | 8 | 8 | 8 |
+| Supply Depot | 96 | 64 | 77 | 49 | 10 | 10 | 9 | 5 |
+| Templar Archives | 96 | 64 | 65 | 49 | 8 | 16 | 15 | 7 |
+| Ultralisk Cavern | 96 | 64 | 73 | 64 | 0 | 8 | 15 | 0 |
+
+## Higher-level action types
+
+screpdb collapses many raw commands into a few higher-level action types (train, build, morph). These are the exact string values it stores and matches on.
+
+| Action type | Value |
+| --- | --- |
+| Train | Train |
+| Build | Build |
+| Unit Morph | Unit Morph |
+
+## Replay enums
+
+Fixed value sets screpdb reads from a parsed replay. Races are screpdb's; speeds and colors come from the screp parser (`github.com/icza/screp/rep/repcore`); matchups are derived from race initials.
+
+| Enum | Values | Notes |
+| --- | --- | --- |
+| Races | Terran, Protoss, Zerg | Random resolves to the actual race at game start. |
+| Game speeds | Slowest, Slower, Slow, Normal, Fast, Faster, Fastest | Competitive replays are always played on Fastest. |
+| Player colors | Red, Blue, Teal, Purple, Orange, Brown, White, Yellow, Green, Pale Yellow, Tan, Aqua, Pale Green, Blueish Grey, Pale Yellow2, Cyan, Pink, Olive, Lime, Navy, Dark Aqua, Magenta, Grey, Black | The player's slot color as parsed from the replay. |
+| 1v1 matchups | PvP, PvT, PvZ, TvT, TvZ, ZvZ | Race initials sorted alphabetically; team/FFA games use the same scheme (e.g. PPvZZ). |
+| Start location (clock) | 1–12 | The o'clock position of the player's start location on the map. |
+
+## Build orders & expert timings
+
+The openings screpdb recognizes and each milestone's "progamer ideal" timing. The Build Orders tab marks a milestone on-time if it lands within the tolerance window around its target. Targets are seconds from game start ("Fastest" speed); tolerance is the accepted early/late deviation.
+
+| Build order | Race | Milestone | Target (s) | Tolerance (s) |
+| --- | --- | --- | --- | --- |
+| 1 Gate (no expa) | Protoss | Pylon | 48 | ±6 |
+| 1 Gate (no expa) | Protoss | Gateway | 88 | ±15 |
+| 1 Gate Core | Protoss | Pylon | 48 | ±4 |
+| 1 Gate Core | Protoss | Gateway | 86 | ±6 |
+| 1 Gate Core | Protoss | Assimilator | 116 | ±10 |
+| 1 Gate Core | Protoss | Cybernetics Core | 138 | ±10 |
+| 1 Rax 1 Fac | Terran | Supply Depot | 60 | ±8 |
+| 1 Rax 1 Fac | Terran | Barracks | 88 | ±8 |
+| 1 Rax 1 Fac | Terran | Refinery | 115 | ±12 |
+| 1 Rax 1 Fac | Terran | Factory | 165 | ±15 |
+| 1 Rax FE | Terran | Supply Depot | 60 | ±8 |
+| 1 Rax FE | Terran | Barracks | 88 | ±10 |
+| 1 Rax FE | Terran | Command Center | 180 | ±18 |
+| 1 Rax FE | Terran | Refinery | 195 | ±18 |
+| 10 Hatch | Zerg | Hatchery | 80 | ±5 |
+| 10 Hatch | Zerg | Spawning Pool | 110 | −3 / +10 |
+| 10 Pool | Zerg | Spawning Pool | 92 | ±5 |
+| 10 Pool | Zerg | First Zerglings | 142 | ±4 |
+| 11 Hatch | Zerg | Hatchery | 94 | ±5 |
+| 11 Hatch | Zerg | Spawning Pool | 116 | −3 / +10 |
+| 11 Pool | Zerg | Spawning Pool | 98 | ±5 |
+| 11 Pool | Zerg | First Zerglings | 148 | ±4 |
+| 12 Hatch | Zerg | Hatchery | 98 | ±5 |
+| 12 Hatch | Zerg | Spawning Pool | 116 | −3 / +10 |
+| 12 Pool | Zerg | Spawning Pool | 104 | ±5 |
+| 12 Pool | Zerg | First Zerglings | 154 | ±4 |
+| 2 Gate | Protoss | Pylon | 48 | ±4 |
+| 2 Gate | Protoss | 1st Gateway | 70 | ±6 |
+| 2 Gate | Protoss | 2nd Gateway | 86 | ±10 |
+| 2 Gate | Protoss | First Zealot | 108 | ±3 |
+| 2 Rax CC | Terran | Supply Depot | 60 | ±8 |
+| 2 Rax CC | Terran | 1st Barracks | 88 | ±10 |
+| 2 Rax CC | Terran | 2nd Barracks | 120 | ±15 |
+| 2 Rax CC | Terran | Command Center | 200 | ±25 |
+| 4 Hatch | Zerg | Hatchery | 40 | ±6 |
+| 4 Hatch | Zerg | Spawning Pool | 70 | −6 / +12 |
+| 4 Pool | Zerg | Spawning Pool | 33 | ±4 |
+| 4 Pool | Zerg | First Zerglings | 83 | ±3 |
+| 5 Hatch | Zerg | Hatchery | 50 | ±6 |
+| 5 Hatch | Zerg | Spawning Pool | 80 | −6 / +12 |
+| 5 Pool | Zerg | Spawning Pool | 45 | ±5 |
+| 5 Pool | Zerg | First Zerglings | 95 | ±4 |
+| 6 Hatch | Zerg | Hatchery | 58 | ±6 |
+| 6 Hatch | Zerg | Spawning Pool | 88 | −6 / +12 |
+| 6 Pool | Zerg | Spawning Pool | 52 | ±5 |
+| 6 Pool | Zerg | First Zerglings | 102 | ±4 |
+| 7 Hatch | Zerg | Hatchery | 66 | ±6 |
+| 7 Hatch | Zerg | Spawning Pool | 96 | −6 / +12 |
+| 7 Pool | Zerg | Spawning Pool | 60 | ±5 |
+| 7 Pool | Zerg | First Zerglings | 110 | ±4 |
+| 8 Hatch | Zerg | Hatchery | 70 | ±6 |
+| 8 Hatch | Zerg | Spawning Pool | 100 | −6 / +12 |
+| 8 Pool | Zerg | Spawning Pool | 67 | ±5 |
+| 8 Pool | Zerg | First Zerglings | 117 | ±4 |
+| 9 Hatch | Zerg | Hatchery | 73 | ±4 |
+| 9 Hatch | Zerg | Spawning Pool | 103 | −6 / +10 |
+| 9 Overpool | Zerg | Spawning Pool | 80 | ±5 |
+| 9 Overpool | Zerg | First Zerglings | 130 | ±4 |
+| 9 Pool | Zerg | Spawning Pool | 73 | ±4 |
+| 9 Pool | Zerg | First Zerglings | 123 | ±3 |
+| 9 Pool into Hatchery | Zerg | Spawning Pool | 73 | ±4 |
+| 9 Pool into Hatchery | Zerg | Hatchery | 118 | ±5 |
+| 9 Pool into Hatchery | Zerg | First Zerglings | 123 | ±3 |
+| BBS | Terran | 1st Barracks | 60 | ±8 |
+| BBS | Terran | 2nd Barracks | 80 | ±8 |
+| BBS | Terran | Supply Depot | 100 | ±10 |
+| Bunker Rush | Terran | Barracks | 60 | ±10 |
+| Bunker Rush | Terran | Bunker | 130 | ±20 |
+| CC First | Terran | Supply Depot | 62 | ±8 |
+| CC First | Terran | Command Center | 145 | ±20 |
+| CC First | Terran | Barracks | 165 | ±20 |
+| Forge Cannon (no expa) | Protoss | Forge | 90 | ±20 |
+| Forge Cannon (no expa) | Protoss | Photon Cannon | 130 | ±30 |
+| Forge Expand | Protoss | Pylon | 48 | ±4 |
+| Forge Expand | Protoss | Forge | 86 | ±8 |
+| Forge Expand | Protoss | Photon Cannon | 130 | ±20 |
+| Forge Expand | Protoss | Nexus | 152 | ±15 |
+| Gate Expand | Protoss | Pylon | 48 | ±4 |
+| Gate Expand | Protoss | Gateway | 88 | ±10 |
+| Gate Expand | Protoss | Nexus | 165 | ±15 |
+| Nexus First | Protoss | Pylon | 48 | ±4 |
+| Nexus First | Protoss | Nexus | 145 | ±20 |
+| Nexus First | Protoss | Gateway | 175 | ±20 |
+
+## Build-order rule deadlines
+
+Each opener's detector commits its decision once the replay passes this second — the last moment the rule could still flip. "End of replay" means it's decided only when the game ends.
+
+| Build order | Race | Rule deadline (s) |
+| --- | --- | --- |
+| 1 Gate (no expa) | Protoss | 320 |
+| 1 Gate Core | Protoss | 180 |
+| 1 Rax 1 Fac | Terran | 240 |
+| 1 Rax Bio | Terran | 300 |
+| 1 Rax FE | Terran | 270 |
+| 10 Hatch | Zerg | 180 |
+| 10 Pool | Zerg | 180 |
+| 11 Hatch | Zerg | 180 |
+| 11 Pool | Zerg | 180 |
+| 12 Hatch | Zerg | 180 |
+| 12 Pool | Zerg | 180 |
+| 2 Gate | Protoss | 180 |
+| 2 Rax CC | Terran | 300 |
+| 4 Hatch | Zerg | 180 |
+| 4 Pool | Zerg | 60 |
+| 5 Hatch | Zerg | 180 |
+| 5 Pool | Zerg | 180 |
+| 6 Hatch | Zerg | 180 |
+| 6 Pool | Zerg | 180 |
+| 7 Hatch | Zerg | 180 |
+| 7 Pool | Zerg | 180 |
+| 8 Hatch | Zerg | 180 |
+| 8 Pool | Zerg | 180 |
+| 9 Hatch | Zerg | 150 |
+| 9 Overpool | Zerg | 180 |
+| 9 Pool | Zerg | 180 |
+| 9 Pool into Hatchery | Zerg | 180 |
+| BBS | Terran | 120 |
+| Bunker Rush | Terran | 300 |
+| CC First | Terran | 200 |
+| Forge Cannon (no expa) | Protoss | 320 |
+| Forge Expand | Protoss | 260 |
+| Gate Expand | Protoss | 220 |
+| Gateway (Other) | Protoss | 320 |
+| Nexus First | Protoss | 200 |
+| Pool/Hatch (Other) | Zerg | 240 |
+
+## Absence-marker game-length thresholds
+
+"Never X" markers (e.g. *Never upgraded*) only fire on games long enough for the absence to mean something. The minimum length is matchup-specific — the 5th-percentile first-occurrence time across a large progamer 1v1 corpus. Outer race is the player's, inner is the opponent's.
+
+| Marker | Own race | Opp race | Min game length (s) |
+| --- | --- | --- | --- |
+| Never researched | Protoss | Protoss | 332 |
+| Never researched | Protoss | Terran | 496 |
+| Never researched | Protoss | Zerg | 396 |
+| Never researched | Terran | Protoss | 238 |
+| Never researched | Terran | Terran | 245 |
+| Never researched | Terran | Zerg | 252 |
+| Never researched | Zerg | Protoss | 339 |
+| Never researched | Zerg | Terran | 243 |
+| Never upgraded | Protoss | Protoss | 169 |
+| Never upgraded | Protoss | Terran | 163 |
+| Never upgraded | Protoss | Zerg | 237 |
+| Never upgraded | Terran | Protoss | 293 |
+| Never upgraded | Terran | Terran | 264 |
+| Never upgraded | Terran | Zerg | 233 |
+| Never upgraded | Zerg | Protoss | 128 |
+| Never upgraded | Zerg | Terran | 175 |
+| Never upgraded | Zerg | Zerg | 125 |
+
+## Detection scalars & versioning
+
+Standalone constants the detectors depend on — dedup windows, muta/turret burst thresholds, cliff-drop corner boxes, the viewport window, and the algorithm version (bump it to force re-detection).
+
+| Constant | Value | Meaning |
+| --- | --- | --- |
+| Algorithm version | 26 | Detection algorithm revision; incremented to trigger re-detection. |
+| Build dedup gap (s) | 3 | Repeat Build orders of the same building closer than this are one event. |
+| Build dedup max second (s) | 240 | Past this second, dedup stops and every Build is observed as-is. |
+| Mutalisk burst window (s) | 30 | Window within which the Mutalisk morphs must cluster. |
+| Mutalisk burst min count | 3 | Minimum Mutalisks in the window to count as a burst. |
+| Turret burst window (s) | 60 | Window within which the Missile Turrets must cluster. |
+| Turret burst min count | 3 | Minimum Missile Turrets in the window to count as a burst. |
+| Cliff-drop corner width (px) | 256 | Width of the corner box a drop must land in to count as a cliff drop. |
+| Cliff-drop corner height (px) | 128 | Height of that corner box. |
+| Viewport window start (s) | 420 | Second from which viewport-multitasking is measured. |
+| Viewport width (px) | 704 | Width of the screen viewport in map pixels. |
+| Viewport height (px) | 512 | Height of the screen viewport in map pixels. |
+
+## Early-game unit economics
+
+What producing each early-game unit/building costs and does to supply. Supply Δ is the cap increase from supply structures (Pylon/Depot/Overlord = +8); supply cost is what a unit consumes. Build times match the Build times section.
+
+| Subject | Minerals | Gas | Build time (s) | Supply Δ | Supply cost |
+| --- | --- | --- | --- | --- | --- |
+| Academy | 150 | 0 | 50 | 0 | 0 |
+| Assimilator | 100 | 0 | 25 | 0 | 0 |
+| Barracks | 150 | 0 | 50 | 0 | 0 |
+| Bunker | 100 | 0 | 19 | 0 | 0 |
+| Command Center | 400 | 0 | 75 | 0 | 0 |
+| Creep Colony | 75 | 0 | 12 | 0 | 0 |
+| Cybernetics Core | 200 | 0 | 38 | 0 | 0 |
+| Drone | 50 | 0 | 12.6 | 0 | 1 |
+| Engineering Bay | 125 | 0 | 38 | 0 | 0 |
+| Evolution Chamber | 75 | 0 | 25 | 0 | 0 |
+| Extractor | 50 | 0 | 25 | 0 | 0 |
+| Factory | 200 | 0 | 50 | 0 | 0 |
+| Forge | 150 | 0 | 25 | 0 | 0 |
+| Gateway | 150 | 0 | 38 | 0 | 0 |
+| Hatchery | 300 | 0 | 75 | 0 | 0 |
+| Machine Shop | 50 | 0 | 25 | 0 | 0 |
+| Marine | 50 | 0 | 15 | 0 | 1 |
+| Nexus | 400 | 0 | 75 | 0 | 0 |
+| Overlord | 100 | 0 | 25 | 8 | 0 |
+| Photon Cannon | 150 | 0 | 31.5 | 0 | 0 |
+| Probe | 50 | 0 | 12.6 | 0 | 1 |
+| Pylon | 100 | 0 | 19 | 8 | 0 |
+| Refinery | 100 | 0 | 25 | 0 | 0 |
+| SCV | 50 | 0 | 12.6 | 0 | 1 |
+| Spawning Pool | 200 | 0 | 50 | 0 | 0 |
+| Starport | 150 | 0 | 44 | 0 | 0 |
+| Sunken Colony | 50 | 0 | 12 | 0 | 0 |
+| Supply Depot | 100 | 0 | 25 | 8 | 0 |
+| Zealot | 100 | 0 | 25.2 | 0 | 2 |
+| Zergling | 50 | 0 | 18 | 0 | 2 |
+
+## Worker gather rates
+
+Mineral income per worker per minute at a near base, used in early-game economy math.
+
+| Worker | Minerals / min |
+| --- | --- |
+| Drone | 67.1 |
+| Probe | 68.1 |
+| SCV | 65 |
+
+## Tech tree: producers
+
+Which building produces each early-game unit. The engine won't run a Train order without its producer, so a surviving Train is strong evidence the producer existed — the spam filter relies on this.
+
+| Unit | Produced by |
+| --- | --- |
+| Drone | Hatchery |
+| Marine | Barracks |
+| Overlord | Hatchery |
+| Probe | Nexus |
+| SCV | Command Center |
+| Zealot | Gateway |
+| Zergling | Spawning Pool |
+
+## Tech tree: prerequisites
+
+Buildings that must already exist before another can be placed (beyond the producer) — e.g. a Photon Cannon needs a Pylon and a Forge.
+
+| Building | Requires |
+| --- | --- |
+| Academy | Barracks |
+| Assimilator | Nexus |
+| Bunker | Barracks |
+| Cybernetics Core | Pylon, Gateway |
+| Factory | Barracks |
+| Forge | Pylon |
+| Gateway | Pylon |
+| Machine Shop | Factory |
+| Photon Cannon | Pylon, Forge |
+| Starport | Factory |
+| Sunken Colony | Creep Colony, Spawning Pool |
+
+## Featuring strip order
+
+The fixed left-to-right order of chips in the games-list "Featuring" strip — a mix of marker keys and game-event keys. Every key resolves to a marker or a game-event feature (next section), enforced by a test.
+
+| # | Feature key |
+| --- | --- |
+| 1 | mech |
+| 2 | cannon_rush |
+| 3 | bunker_rush |
+| 4 | zergling_rush |
+| 5 | proxy_gate |
+| 6 | proxy_rax |
+| 7 | proxy_factory |
+| 8 | drop |
+| 9 | dt_drop |
+| 10 | reaver_drop |
+| 11 | mind_control |
+| 12 | threw_nukes |
+| 13 | made_recalls |
+| 14 | mech_transition |
+| 15 | one_one_one |
+| 16 | sk_terran |
+| 17 | bo_4_pool |
+| 18 | bo_9_pool |
+| 19 | bo_9_overpool |
+| 20 | bo_12_pool |
+| 21 | bo_9_pool_hatch |
+| 22 | bo_9_hatch |
+| 23 | bo_10_hatch |
+| 24 | bo_11_hatch |
+| 25 | bo_12_hatch |
+| 26 | bo_2_gate |
+| 27 | bo_1_gate_core |
+| 28 | bo_nexus_first |
+| 29 | bo_gate_expand |
+| 30 | bo_forge_expa |
+| 31 | bo_bbs |
+| 32 | bo_1_rax_1_fac |
+| 33 | bo_rax_cc |
+| 34 | bo_cc_first |
+| 35 | carriers |
+| 36 | battlecruisers |
+| 37 | ten_plus_scouts |
+| 38 | cliff_drop |
+
+## Game-event featuring chips
+
+Featuring chips for narrative game events that aren't markers (cannon rush, drop, mind control, …): each with a label and one or more unit icons.
+
+| Key | Label | Icons |
+| --- | --- | --- |
+| bunker_rush | Bunker rush | bunker |
+| cannon_rush | Cannon rush | photoncannon |
+| drop | Drop | shuttle |
+| dt_drop | DT Drop | shuttle, darktemplar |
+| mind_control | Mind control | darkarchon |
+| proxy_factory | Proxy factory | factory |
+| proxy_gate | Proxy gateway | gateway |
+| proxy_rax | Proxy barracks | barracks |
+| reaver_drop | Reaver Drop | shuttle, reaver |
+| zergling_rush | Zergling rush | zergling |

--- a/internal/cmdenrich/costs.go
+++ b/internal/cmdenrich/costs.go
@@ -1,6 +1,10 @@
 package cmdenrich
 
-import "github.com/marianogappa/screpdb/internal/models"
+import (
+	"sort"
+
+	"github.com/marianogappa/screpdb/internal/models"
+)
 
 // UnitEcon is the economic footprint of producing one instance of a Subject
 // (a Train, Build, or Morph). It is the canonical answer for: "what does it
@@ -19,45 +23,49 @@ type UnitEcon struct {
 
 // econTable is the source of truth for early-game economy. Extend as the
 // filter's coverage grows beyond Tier-1.
+//
+// BuildTimeS references the canonical models.BuildTime* consts so the build
+// times here can never drift from the build-order / expert-timing values in
+// internal/models/build_times.go (enforced by a cross-consistency test).
 var econTable = map[string]UnitEcon{
 	// Protoss
-	models.GeneralUnitPylon:           {Minerals: 100, BuildTimeS: 19, SupplyDelta: 8},
-	models.GeneralUnitGateway:         {Minerals: 150, BuildTimeS: 38},
-	models.GeneralUnitAssimilator:     {Minerals: 100, BuildTimeS: 25},
-	models.GeneralUnitNexus:           {Minerals: 400, BuildTimeS: 75},
-	models.GeneralUnitForge:           {Minerals: 150, BuildTimeS: 25},
-	models.GeneralUnitPhotonCannon:    {Minerals: 150, BuildTimeS: 31.5},
-	models.GeneralUnitCyberneticsCore: {Minerals: 200, BuildTimeS: 38},
-	models.GeneralUnitProbe:           {Minerals: 50, BuildTimeS: 12.6, SupplyCost: 1},
-	models.GeneralUnitZealot:          {Minerals: 100, BuildTimeS: 25, SupplyCost: 2},
+	models.GeneralUnitPylon:           {Minerals: 100, BuildTimeS: models.BuildTimePylon, SupplyDelta: 8},
+	models.GeneralUnitGateway:         {Minerals: 150, BuildTimeS: models.BuildTimeGateway},
+	models.GeneralUnitAssimilator:     {Minerals: 100, BuildTimeS: models.BuildTimeAssimilator},
+	models.GeneralUnitNexus:           {Minerals: 400, BuildTimeS: models.BuildTimeNexus},
+	models.GeneralUnitForge:           {Minerals: 150, BuildTimeS: models.BuildTimeForge},
+	models.GeneralUnitPhotonCannon:    {Minerals: 150, BuildTimeS: models.BuildTimePhotonCannon},
+	models.GeneralUnitCyberneticsCore: {Minerals: 200, BuildTimeS: models.BuildTimeCyberneticsCore},
+	models.GeneralUnitProbe:           {Minerals: 50, BuildTimeS: models.BuildTimeProbe, SupplyCost: 1},
+	models.GeneralUnitZealot:          {Minerals: 100, BuildTimeS: models.BuildTimeZealot, SupplyCost: 2},
 
 	// Terran
-	models.GeneralUnitSupplyDepot:    {Minerals: 100, BuildTimeS: 25, SupplyDelta: 8},
-	models.GeneralUnitBarracks:       {Minerals: 150, BuildTimeS: 50},
-	models.GeneralUnitRefinery:       {Minerals: 100, BuildTimeS: 25},
-	models.GeneralUnitCommandCenter:  {Minerals: 400, BuildTimeS: 75},
-	models.GeneralUnitEngineeringBay: {Minerals: 125, BuildTimeS: 38},
-	models.GeneralUnitFactory:        {Minerals: 200, BuildTimeS: 50},
-	models.GeneralUnitStarport:       {Minerals: 150, BuildTimeS: 44},
-	models.GeneralUnitMachineShop:    {Minerals: 50, BuildTimeS: 25},
-	models.GeneralUnitAcademy:        {Minerals: 150, BuildTimeS: 50},
-	models.GeneralUnitBunker:         {Minerals: 100, BuildTimeS: 19},
-	models.GeneralUnitSCV:            {Minerals: 50, BuildTimeS: 12.6, SupplyCost: 1},
-	models.GeneralUnitMarine:         {Minerals: 50, BuildTimeS: 15, SupplyCost: 1},
+	models.GeneralUnitSupplyDepot:    {Minerals: 100, BuildTimeS: models.BuildTimeSupplyDepot, SupplyDelta: 8},
+	models.GeneralUnitBarracks:       {Minerals: 150, BuildTimeS: models.BuildTimeBarracks},
+	models.GeneralUnitRefinery:       {Minerals: 100, BuildTimeS: models.BuildTimeRefinery},
+	models.GeneralUnitCommandCenter:  {Minerals: 400, BuildTimeS: models.BuildTimeCommandCenter},
+	models.GeneralUnitEngineeringBay: {Minerals: 125, BuildTimeS: models.BuildTimeEngineeringBay},
+	models.GeneralUnitFactory:        {Minerals: 200, BuildTimeS: models.BuildTimeFactory},
+	models.GeneralUnitStarport:       {Minerals: 150, BuildTimeS: models.BuildTimeStarport},
+	models.GeneralUnitMachineShop:    {Minerals: 50, BuildTimeS: models.BuildTimeMachineShop},
+	models.GeneralUnitAcademy:        {Minerals: 150, BuildTimeS: models.BuildTimeAcademy},
+	models.GeneralUnitBunker:         {Minerals: 100, BuildTimeS: models.BuildTimeBunker},
+	models.GeneralUnitSCV:            {Minerals: 50, BuildTimeS: models.BuildTimeSCV, SupplyCost: 1},
+	models.GeneralUnitMarine:         {Minerals: 50, BuildTimeS: models.BuildTimeMarine, SupplyCost: 1},
 
 	// Zerg
-	models.GeneralUnitOverlord:         {Minerals: 100, BuildTimeS: 25, SupplyDelta: 8},
-	models.GeneralUnitSpawningPool:     {Minerals: 200, BuildTimeS: 50},
-	models.GeneralUnitExtractor:        {Minerals: 50, BuildTimeS: 25},
-	models.GeneralUnitHatchery:         {Minerals: 300, BuildTimeS: 75},
-	models.GeneralUnitEvolutionChamber: {Minerals: 75, BuildTimeS: 25},
-	models.GeneralUnitCreepColony:      {Minerals: 75, BuildTimeS: 12},
-	models.GeneralUnitSunkenColony:     {Minerals: 50, BuildTimeS: 12},
-	models.GeneralUnitDrone:            {Minerals: 50, BuildTimeS: 12.6, SupplyCost: 1},
-	// Zerglings come in a pair from one Egg: 50m/17.1s yields 2 lings, 2 supply.
-	// We track them per-pair to match how the Train command appears in the replay
-	// (one Morph command per pair).
-	models.GeneralUnitZergling: {Minerals: 50, BuildTimeS: 17.1, SupplyCost: 2},
+	models.GeneralUnitOverlord:         {Minerals: 100, BuildTimeS: models.BuildTimeOverlord, SupplyDelta: 8},
+	models.GeneralUnitSpawningPool:     {Minerals: 200, BuildTimeS: models.BuildTimeSpawningPool},
+	models.GeneralUnitExtractor:        {Minerals: 50, BuildTimeS: models.BuildTimeExtractor},
+	models.GeneralUnitHatchery:         {Minerals: 300, BuildTimeS: models.BuildTimeHatchery},
+	models.GeneralUnitEvolutionChamber: {Minerals: 75, BuildTimeS: models.BuildTimeEvolutionChamber},
+	models.GeneralUnitCreepColony:      {Minerals: 75, BuildTimeS: models.BuildTimeCreepColony},
+	models.GeneralUnitSunkenColony:     {Minerals: 50, BuildTimeS: models.BuildTimeSunkenColony},
+	models.GeneralUnitDrone:            {Minerals: 50, BuildTimeS: models.BuildTimeDrone, SupplyCost: 1},
+	// Zerglings come in a pair from one Egg: 50m yields 2 lings, 2 supply. We
+	// track them per-pair to match how the Train command appears in the replay
+	// (one Morph command per pair); BuildTimeZergling is the per-pair morph time.
+	models.GeneralUnitZergling: {Minerals: 50, BuildTimeS: models.BuildTimeZergling, SupplyCost: 2},
 }
 
 // EconOf returns the economic footprint for a Subject. Returns (zero, false)
@@ -80,4 +88,38 @@ var gatherRates = map[string]float64{
 // Subject (SCV / Drone / Probe). Returns 0 for non-worker subjects.
 func GatherRatePerMinute(workerSubject string) float64 {
 	return gatherRates[workerSubject]
+}
+
+// EconEntry is one row of the early-game economy table (Subject + footprint).
+type EconEntry struct {
+	Subject string
+	Econ    UnitEcon
+}
+
+// AllEcon returns every early-game economy entry, sorted by Subject. Used by
+// the SPECIFICATION.md generator and cross-consistency tests.
+func AllEcon() []EconEntry {
+	out := make([]EconEntry, 0, len(econTable))
+	for subject, econ := range econTable {
+		out = append(out, EconEntry{Subject: subject, Econ: econ})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Subject < out[j].Subject })
+	return out
+}
+
+// GatherRateEntry is one row of the worker gather-rate table.
+type GatherRateEntry struct {
+	Worker         string
+	MineralsPerMin float64
+}
+
+// AllGatherRates returns the per-worker mineral gather rates, sorted by worker
+// name. Used by the SPECIFICATION.md generator and cross-consistency tests.
+func AllGatherRates() []GatherRateEntry {
+	out := make([]GatherRateEntry, 0, len(gatherRates))
+	for worker, rate := range gatherRates {
+		out = append(out, GatherRateEntry{Worker: worker, MineralsPerMin: rate})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Worker < out[j].Worker })
+	return out
 }

--- a/internal/cmdenrich/techtree.go
+++ b/internal/cmdenrich/techtree.go
@@ -1,6 +1,10 @@
 package cmdenrich
 
-import "github.com/marianogappa/screpdb/internal/models"
+import (
+	"sort"
+
+	"github.com/marianogappa/screpdb/internal/models"
+)
 
 // producerByUnit answers "what building produces this unit?" for the early-game
 // units the spam filter cares about. The StarCraft engine refuses to execute a
@@ -85,3 +89,40 @@ var supplyStructureSubjects = map[string]bool{
 // IsSupplyStructure reports whether the Subject increases supply cap on
 // completion.
 func IsSupplyStructure(subject string) bool { return supplyStructureSubjects[subject] }
+
+// ProducerEntry is one row of the producer table: a unit and the building that
+// produces it.
+type ProducerEntry struct {
+	Unit     string
+	Producer string
+}
+
+// AllProducers returns the unit → producer-building table, sorted by unit name.
+// Used by the SPECIFICATION.md generator and cross-consistency tests.
+func AllProducers() []ProducerEntry {
+	out := make([]ProducerEntry, 0, len(producerByUnit))
+	for unit, producer := range producerByUnit {
+		out = append(out, ProducerEntry{Unit: unit, Producer: producer})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Unit < out[j].Unit })
+	return out
+}
+
+// PrereqEntry is one row of the prerequisite table: a building and the buildings
+// that must already exist before it can be placed (the producer is implicit).
+type PrereqEntry struct {
+	Building string
+	Prereqs  []string
+}
+
+// AllPrereqs returns the building → prerequisites table, sorted by building
+// name (prerequisite lists preserve their declared order). Used by the
+// SPECIFICATION.md generator and cross-consistency tests.
+func AllPrereqs() []PrereqEntry {
+	out := make([]PrereqEntry, 0, len(prereqsByBuilding))
+	for building, prereqs := range prereqsByBuilding {
+		out = append(out, PrereqEntry{Building: building, Prereqs: prereqs})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Building < out[j].Building })
+	return out
+}

--- a/internal/dashboard/endpoint_custom_markers_definitions.go
+++ b/internal/dashboard/endpoint_custom_markers_definitions.go
@@ -112,6 +112,39 @@ var staticFeaturingOrder = []string{
 	"cliff_drop",
 }
 
+// GameEventFeatureSpec is the exported, package-stable view of one non-marker
+// "game event" featuring chip (cannon_rush, drop, …). Used by the
+// SPECIFICATION.md generator. IconKeys collapses the internal single/multi icon
+// fields into one ordered list.
+type GameEventFeatureSpec struct {
+	Key      string
+	Label    string
+	IconKeys []string
+}
+
+// AllGameEventFeatures returns the non-marker game-event featuring chips in
+// their declared order. Used by the SPECIFICATION.md generator.
+func AllGameEventFeatures() []GameEventFeatureSpec {
+	out := make([]GameEventFeatureSpec, 0, len(staticGameEventFeatures))
+	for _, f := range staticGameEventFeatures {
+		icons := f.IconKeys
+		if len(icons) == 0 && f.IconKey != "" {
+			icons = []string{f.IconKey}
+		}
+		out = append(out, GameEventFeatureSpec{Key: f.Key, Label: f.Label, IconKeys: icons})
+	}
+	return out
+}
+
+// FeaturingOrder returns the fixed display order of every featuring-strip chip
+// (a mix of marker FeatureKeys and game-event keys). Used by the
+// SPECIFICATION.md generator and cross-consistency tests.
+func FeaturingOrder() []string {
+	out := make([]string, len(staticFeaturingOrder))
+	copy(out, staticFeaturingOrder)
+	return out
+}
+
 // handlerMarkersDefinitions serves the per-marker Pill metadata plus ordering
 // and game-event feature metadata. Cached in-memory by the frontend; re-fetched
 // when the server's algorithm_version differs from the one the frontend last saw.

--- a/internal/iofacade/enforcement_test.go
+++ b/internal/iofacade/enforcement_test.go
@@ -141,11 +141,12 @@ func skipDir(root, dir string) bool {
 	}
 	switch rel {
 	case ".git", ".claude", "node_modules", "dist",
-		"internal/iofacade", // the filesystem facade implementation
-		"internal/netfacade", // the network facade implementation
-		"scripts", // dev-only debug scripts, not shipped
-		"internal/dashboard/frontend",         // React source, not Go
-		"internal/dashboard/tools":             // build-time codegen, not shipped
+		"internal/iofacade",           // the filesystem facade implementation
+		"internal/netfacade",          // the network facade implementation
+		"scripts",                     // dev-only debug scripts, not shipped
+		"internal/dashboard/frontend", // React source, not Go
+		"internal/dashboard/tools",    // build-time codegen, not shipped
+		"internal/spec/tools":         // SPECIFICATION.md codegen, not shipped
 		return true
 	}
 	base := filepath.Base(dir)
@@ -161,7 +162,8 @@ func skipFile(root, path string) bool {
 	}
 	rel = filepath.ToSlash(rel)
 	return strings.HasPrefix(rel, "scripts/") ||
-		strings.HasPrefix(rel, "internal/dashboard/tools/")
+		strings.HasPrefix(rel, "internal/dashboard/tools/") ||
+		strings.HasPrefix(rel, "internal/spec/tools/")
 }
 
 func defaultPkgName(importPath string) string {

--- a/internal/models/build_times.go
+++ b/internal/models/build_times.go
@@ -1,23 +1,124 @@
 package models
 
+import "sort"
+
 // Build times (seconds) at SC:BW "Fastest" game speed — the speed every
 // competitive replay is played on. These are the canonical in-game values
-// used by timing-based logic (e.g. build-order detection and expert timings).
+// used by timing-based logic (e.g. build-order detection and expert timings)
+// AND by the early-game economy table (internal/cmdenrich/costs.go), which
+// references these consts so the two can never drift apart.
 //
 // Values are float64 because some are fractional (e.g. Zealot 25.2s). Round
 // to int at the call site when combining with integer game seconds.
+//
+// Source: https://liquipedia.net/starcraft — Fastest game speed.
 const (
-	BuildTimeSpawningPool   float64 = 50
-	BuildTimeGateway        float64 = 38
-	BuildTimeZealot         float64 = 25.2
-	BuildTimeHatchery       float64 = 75
-	BuildTimeNexus          float64 = 75
-	BuildTimeForge          float64 = 25
-	BuildTimeOverlord       float64 = 25
-	BuildTimeDrone          float64 = 12.6
-	BuildTimeZergling       float64 = 18
-	BuildTimeSpire          float64 = 75
-	BuildTimeMutalisk       float64 = 25
-	BuildTimeMissileTurret  float64 = 18.9
+	// Zerg
+	BuildTimeSpawningPool     float64 = 50
+	BuildTimeHatchery         float64 = 75
+	BuildTimeExtractor        float64 = 25
+	BuildTimeEvolutionChamber float64 = 25
+	BuildTimeCreepColony      float64 = 12
+	BuildTimeSunkenColony     float64 = 12
+	BuildTimeSpire            float64 = 75
+	BuildTimeOverlord         float64 = 25
+	BuildTimeDrone            float64 = 12.6
+	// BuildTimeZergling is per Zergling-pair (one Egg morphs into two lings).
+	BuildTimeZergling float64 = 18
+	BuildTimeMutalisk float64 = 25
+
+	// Protoss
+	BuildTimeNexus           float64 = 75
+	BuildTimePylon           float64 = 19
+	BuildTimeGateway         float64 = 38
+	BuildTimeAssimilator     float64 = 25
+	BuildTimeForge           float64 = 25
+	BuildTimePhotonCannon    float64 = 31.5
+	BuildTimeCyberneticsCore float64 = 38
+	BuildTimeProbe           float64 = 12.6
+	BuildTimeZealot          float64 = 25.2
+
+	// Terran
+	BuildTimeCommandCenter  float64 = 75
+	BuildTimeSupplyDepot    float64 = 25
+	BuildTimeBarracks       float64 = 50
+	BuildTimeRefinery       float64 = 25
 	BuildTimeEngineeringBay float64 = 38
+	BuildTimeFactory        float64 = 50
+	BuildTimeStarport       float64 = 44
+	BuildTimeMachineShop    float64 = 25
+	BuildTimeAcademy        float64 = 50
+	BuildTimeBunker         float64 = 19
+	BuildTimeMissileTurret  float64 = 18.9
+	BuildTimeSCV            float64 = 12.6
+	BuildTimeMarine         float64 = 15
 )
+
+// buildTimes is the canonical name → build-time index over the BuildTime*
+// consts above. Keyed by the GeneralUnit* canonical name so callers and the
+// SPECIFICATION.md generator can look up by the same string the replay emits.
+var buildTimes = map[string]float64{
+	// Zerg
+	GeneralUnitSpawningPool:     BuildTimeSpawningPool,
+	GeneralUnitHatchery:         BuildTimeHatchery,
+	GeneralUnitExtractor:        BuildTimeExtractor,
+	GeneralUnitEvolutionChamber: BuildTimeEvolutionChamber,
+	GeneralUnitCreepColony:      BuildTimeCreepColony,
+	GeneralUnitSunkenColony:     BuildTimeSunkenColony,
+	GeneralUnitSpire:            BuildTimeSpire,
+	GeneralUnitOverlord:         BuildTimeOverlord,
+	GeneralUnitDrone:            BuildTimeDrone,
+	GeneralUnitZergling:         BuildTimeZergling,
+	GeneralUnitMutalisk:         BuildTimeMutalisk,
+
+	// Protoss
+	GeneralUnitNexus:           BuildTimeNexus,
+	GeneralUnitPylon:           BuildTimePylon,
+	GeneralUnitGateway:         BuildTimeGateway,
+	GeneralUnitAssimilator:     BuildTimeAssimilator,
+	GeneralUnitForge:           BuildTimeForge,
+	GeneralUnitPhotonCannon:    BuildTimePhotonCannon,
+	GeneralUnitCyberneticsCore: BuildTimeCyberneticsCore,
+	GeneralUnitProbe:           BuildTimeProbe,
+	GeneralUnitZealot:          BuildTimeZealot,
+
+	// Terran
+	GeneralUnitCommandCenter:  BuildTimeCommandCenter,
+	GeneralUnitSupplyDepot:    BuildTimeSupplyDepot,
+	GeneralUnitBarracks:       BuildTimeBarracks,
+	GeneralUnitRefinery:       BuildTimeRefinery,
+	GeneralUnitEngineeringBay: BuildTimeEngineeringBay,
+	GeneralUnitFactory:        BuildTimeFactory,
+	GeneralUnitStarport:       BuildTimeStarport,
+	GeneralUnitMachineShop:    BuildTimeMachineShop,
+	GeneralUnitAcademy:        BuildTimeAcademy,
+	GeneralUnitBunker:         BuildTimeBunker,
+	GeneralUnitMissileTurret:  BuildTimeMissileTurret,
+	GeneralUnitSCV:            BuildTimeSCV,
+	GeneralUnitMarine:         BuildTimeMarine,
+}
+
+// BuildTimeOf returns the canonical build time (seconds, Fastest speed) for a
+// unit/building by its canonical GeneralUnit* name. The bool is false for
+// names not in the table — callers should treat that as "unknown".
+func BuildTimeOf(name string) (float64, bool) {
+	t, ok := buildTimes[name]
+	return t, ok
+}
+
+// BuildTimeEntry is one row of the canonical build-time table.
+type BuildTimeEntry struct {
+	Name    string
+	Seconds float64
+}
+
+// AllBuildTimes returns every canonical build time, sorted by name. Used by the
+// SPECIFICATION.md generator and cross-consistency tests.
+func AllBuildTimes() []BuildTimeEntry {
+	out := make([]BuildTimeEntry, 0, len(buildTimes))
+	for name, sec := range buildTimes {
+		out = append(out, BuildTimeEntry{Name: name, Seconds: sec})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/models/spec_surface.go
+++ b/internal/models/spec_surface.go
@@ -1,0 +1,65 @@
+package models
+
+import "sort"
+
+// This file exposes deterministic, exported "spec surface" enumerators over the
+// private golden-value tables in this package (techTable, upgradeTable,
+// workerUnits, flyingUnits). They exist so the SPECIFICATION.md generator and
+// the cross-consistency tests can read the real values without the tables
+// having to be exported (the maps stay the single source of truth).
+
+// TechSpecEntry is one row of the tech-research table: the Tech* name plus its
+// static metadata.
+type TechSpecEntry struct {
+	Name string
+	Meta TechMeta
+}
+
+// AllTechMeta returns every researched tech with its metadata, sorted by name.
+func AllTechMeta() []TechSpecEntry {
+	out := make([]TechSpecEntry, 0, len(techTable))
+	for name, meta := range techTable {
+		out = append(out, TechSpecEntry{Name: name, Meta: meta})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// UpgradeSpecEntry is one row of the upgrade table: the Upgrade* name plus its
+// static metadata (including per-level costs/durations).
+type UpgradeSpecEntry struct {
+	Name string
+	Meta UpgradeMeta
+}
+
+// AllUpgradeMeta returns every upgrade with its metadata, sorted by name.
+func AllUpgradeMeta() []UpgradeSpecEntry {
+	out := make([]UpgradeSpecEntry, 0, len(upgradeTable))
+	for name, meta := range upgradeTable {
+		out = append(out, UpgradeSpecEntry{Name: name, Meta: meta})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// WorkerUnitNames returns the canonical worker unit names (SCV/Probe/Drone),
+// sorted.
+func WorkerUnitNames() []string {
+	out := make([]string, 0, len(workerUnits))
+	for name := range workerUnits {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FlyingUnitNames returns the canonical flying (non-transportable) unit names,
+// sorted.
+func FlyingUnitNames() []string {
+	out := make([]string, 0, len(flyingUnits))
+	for name := range flyingUnits {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/models/units_registry.go
+++ b/internal/models/units_registry.go
@@ -1,0 +1,57 @@
+package models
+
+import "sort"
+
+// unitGeometry / buildingGeometry are the registries over the Unit* / Building*
+// geometry vars declared in units.go. They exist so the SPECIFICATION.md
+// generator can enumerate every pixel box. A completeness guard test
+// (units_registry_test.go) parses units.go and fails if any Unit*/Building*
+// var is missing here, so the registries can't silently fall out of sync.
+var unitGeometry = []Unit{
+	UnitMarine, UnitGhost, UnitVulture, UnitGoliath, UnitSiegeTankTankMode,
+	UnitSiegeTankTurretTankMode, UnitSCV, UnitWraith, UnitScienceVessel,
+	UnitDropship, UnitBattlecruiser, UnitFirebat, UnitMedic, UnitValkyrie,
+	UnitZergling, UnitHydralisk, UnitUltralisk, UnitDrone, UnitOverlord,
+	UnitMutalisk, UnitGuardian, UnitQueen, UnitDefiler, UnitScourge,
+	UnitDevourer, UnitLurker, UnitInfestedTerran, UnitCorsair, UnitDarkTemplar,
+	UnitDarkArchon, UnitProbe, UnitZealot, UnitDragoon, UnitHighTemplar,
+	UnitArchon, UnitShuttle, UnitScout, UnitArbiter, UnitCarrier, UnitReaver,
+	UnitObserver,
+}
+
+var buildingGeometry = []Building{
+	BuildingCommandCenter, BuildingComSat, BuildingNuclearSilo,
+	BuildingSupplyDepot, BuildingRefinery, BuildingBarracks, BuildingAcademy,
+	BuildingFactory, BuildingStarport, BuildingControlTower,
+	BuildingScienceFacility, BuildingCovertOps, BuildingPhysicsLab,
+	BuildingMachineShop, BuildingEngineeringBay, BuildingArmory,
+	BuildingMissileTurret, BuildingBunker, BuildingInfestedCc, BuildingHatchery,
+	BuildingLair, BuildingHive, BuildingNydusCanal, BuildingHydraliskDen,
+	BuildingDefilerMound, BuildingGreaterSpire, BuildingQueensNest,
+	BuildingEvolutionChamber, BuildingUltraliskCavern, BuildingSpire,
+	BuildingSpawningPool, BuildingCreepColony, BuildingSporeColony,
+	BuildingSunkenColony, BuildingExtractor, BuildingNexus,
+	BuildingRoboticsFacility, BuildingPylon, BuildingAssimilator,
+	BuildingObservatory, BuildingGateway, BuildingPhotonCannon,
+	BuildingCitadelOfAdun, BuildingCyberneticsCore, BuildingTemplarArchives,
+	BuildingForge, BuildingStargate, BuildingFleetBeacon,
+	BuildingArbiterTribunal, BuildingRoboticsSupportBay, BuildingShieldBattery,
+}
+
+// AllUnitGeometry returns every unit pixel box, sorted by Name. Used by the
+// SPECIFICATION.md generator.
+func AllUnitGeometry() []Unit {
+	out := make([]Unit, len(unitGeometry))
+	copy(out, unitGeometry)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// AllBuildingGeometry returns every building pixel box, sorted by Name. Used by
+// the SPECIFICATION.md generator.
+func AllBuildingGeometry() []Building {
+	out := make([]Building, len(buildingGeometry))
+	copy(out, buildingGeometry)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/models/units_registry_test.go
+++ b/internal/models/units_registry_test.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestGeometryRegistryComplete guards against adding a Unit*/Building* geometry
+// var in units.go without also adding it to the registries in
+// units_registry.go (which the SPECIFICATION.md generator enumerates). It parses
+// units.go and counts every top-level `var X = Unit{...}` / `Building{...}`
+// declaration, then asserts those counts match the registry lengths. Because the
+// registries reference each var by identifier, a removed var won't compile and a
+// renamed var is caught here — so the registries can't silently fall out of sync.
+//
+// This is the one place the spec machinery relies on AST parsing: Go has no way
+// to enumerate package-level vars by type at runtime, so completeness can only
+// be proven by reading the source.
+func TestGeometryRegistryComplete(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve current file")
+	}
+	unitsPath := filepath.Join(filepath.Dir(thisFile), "units.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, unitsPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse units.go: %v", err)
+	}
+
+	unitVars, buildingVars := 0, 0
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, val := range vs.Values {
+				lit, ok := val.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				typeIdent, ok := lit.Type.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				switch typeIdent.Name {
+				case "Unit":
+					unitVars++
+				case "Building":
+					buildingVars++
+				}
+			}
+		}
+	}
+
+	if unitVars != len(unitGeometry) {
+		t.Errorf("units.go declares %d Unit vars but unitGeometry has %d; add the missing var(s) to units_registry.go", unitVars, len(unitGeometry))
+	}
+	if buildingVars != len(buildingGeometry) {
+		t.Errorf("units.go declares %d Building vars but buildingGeometry has %d; add the missing var(s) to units_registry.go", buildingVars, len(buildingGeometry))
+	}
+}

--- a/internal/patterns/markers/mutalisk_turret_timing.go
+++ b/internal/patterns/markers/mutalisk_turret_timing.go
@@ -21,27 +21,27 @@ import (
 // state required.
 
 const (
-	mutaBurstWindowSec   = 30
-	mutaBurstMinCount    = 3
-	turretBurstWindowSec = 60
-	turretBurstMinCount  = 3
+	MutaBurstWindowSec   = 30
+	MutaBurstMinCount    = 3
+	TurretBurstWindowSec = 60
+	TurretBurstMinCount  = 3
 )
 
 type mutaTurretSignals struct {
-	zergPID       byte
-	terranPID     byte
-	zergFound     bool
-	terranFound   bool
-	spireCmd      int
-	spireFound    bool
-	firstMutaCmd  int
-	firstMutaOK   bool
-	mutaBurst     int
-	ebayCmd       int
-	ebayFound     bool
+	zergPID        byte
+	terranPID      byte
+	zergFound      bool
+	terranFound    bool
+	spireCmd       int
+	spireFound     bool
+	firstMutaCmd   int
+	firstMutaOK    bool
+	mutaBurst      int
+	ebayCmd        int
+	ebayFound      bool
 	firstTurretCmd int
-	firstTurretOK bool
-	turretBurst   int
+	firstTurretOK  bool
+	turretBurst    int
 }
 
 // computeMutaTurretSignals walks the full enriched stream once, classifies the
@@ -108,7 +108,7 @@ func computeMutaTurretSignals(ctx CustomEvalContext) (mutaTurretSignals, bool) {
 		first := mutaTimes[0]
 		count := 0
 		for _, t := range mutaTimes {
-			if t-first > mutaBurstWindowSec {
+			if t-first > MutaBurstWindowSec {
 				break
 			}
 			count++
@@ -121,7 +121,7 @@ func computeMutaTurretSignals(ctx CustomEvalContext) (mutaTurretSignals, bool) {
 		first := turretTimes[0]
 		count := 0
 		for _, t := range turretTimes {
-			if t-first > turretBurstWindowSec {
+			if t-first > TurretBurstWindowSec {
 				break
 			}
 			count++
@@ -133,10 +133,10 @@ func computeMutaTurretSignals(ctx CustomEvalContext) (mutaTurretSignals, bool) {
 
 // bothBurstsMatch reports whether the cross-player condition holds.
 func (s mutaTurretSignals) bothBurstsMatch() bool {
-	if !s.firstMutaOK || s.mutaBurst < mutaBurstMinCount {
+	if !s.firstMutaOK || s.mutaBurst < MutaBurstMinCount {
 		return false
 	}
-	if !s.firstTurretOK || s.turretBurst < turretBurstMinCount {
+	if !s.firstTurretOK || s.turretBurst < TurretBurstMinCount {
 		return false
 	}
 	return true

--- a/internal/spec/consistency_test.go
+++ b/internal/spec/consistency_test.go
@@ -1,0 +1,78 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/marianogappa/screpdb/internal/cmdenrich"
+	"github.com/marianogappa/screpdb/internal/dashboard"
+	"github.com/marianogappa/screpdb/internal/models"
+	"github.com/marianogappa/screpdb/internal/patterns/markers"
+)
+
+// TestEconBuildTimesMatchCanonical is the headline cross-consistency check for
+// issue #138: the early-game economy table's build times must equal the
+// canonical models build times for every overlapping subject. This is what
+// makes "stored in two places" impossible — costs.go references the models
+// consts, and this test proves it.
+func TestEconBuildTimesMatchCanonical(t *testing.T) {
+	for _, e := range cmdenrich.AllEcon() {
+		canonical, ok := models.BuildTimeOf(e.Subject)
+		if !ok {
+			t.Errorf("econ subject %q has no canonical models build time", e.Subject)
+			continue
+		}
+		if e.Econ.BuildTimeS != canonical {
+			t.Errorf("econ build time for %q = %v, canonical models value = %v", e.Subject, e.Econ.BuildTimeS, canonical)
+		}
+	}
+}
+
+// TestFeaturingOrderResolves asserts every key in the dashboard featuring strip
+// resolves to either a registered marker (by FeatureKey) or a non-marker
+// game-event feature. A typo or a removed marker leaves a dangling chip — this
+// catches it.
+func TestFeaturingOrderResolves(t *testing.T) {
+	gameEventKeys := map[string]bool{}
+	for _, f := range dashboard.AllGameEventFeatures() {
+		gameEventKeys[f.Key] = true
+	}
+
+	for _, key := range dashboard.FeaturingOrder() {
+		if markers.ByFeatureKey(key) != nil {
+			continue
+		}
+		if gameEventKeys[key] {
+			continue
+		}
+		t.Errorf("featuring key %q resolves to neither a marker nor a game-event feature", key)
+	}
+}
+
+// TestGameEventFeaturesAreFeatured asserts every non-marker game-event feature
+// is actually placed in the featuring order (no orphan chips defined but never
+// shown).
+func TestGameEventFeaturesAreFeatured(t *testing.T) {
+	inOrder := map[string]bool{}
+	for _, key := range dashboard.FeaturingOrder() {
+		inOrder[key] = true
+	}
+	for _, f := range dashboard.AllGameEventFeatures() {
+		if !inOrder[f.Key] {
+			t.Errorf("game-event feature %q is defined but not in the featuring order", f.Key)
+		}
+	}
+}
+
+// TestOpenersHaveResolvableFeatureKeys asserts every initial-build-order marker
+// carries a FeatureKey that round-trips through the marker registry.
+func TestOpenersHaveResolvableFeatureKeys(t *testing.T) {
+	for _, m := range openers() {
+		if m.FeatureKey == "" {
+			t.Errorf("opener %q has empty FeatureKey", m.Name)
+			continue
+		}
+		if markers.ByFeatureKey(m.FeatureKey) == nil {
+			t.Errorf("opener %q FeatureKey %q does not resolve in the marker registry", m.Name, m.FeatureKey)
+		}
+	}
+}

--- a/internal/spec/coverage_test.go
+++ b/internal/spec/coverage_test.go
@@ -1,0 +1,56 @@
+package spec
+
+import "testing"
+
+// TestEverySectionHasRows asserts every registered section renders at least one
+// row. A golden table wired up with an empty enumerator (or none) fails here.
+func TestEverySectionHasRows(t *testing.T) {
+	secs := Sections()
+	if len(secs) == 0 {
+		t.Fatal("no sections registered")
+	}
+	for _, s := range secs {
+		rows := s.Rows()
+		if len(rows) == 0 {
+			t.Errorf("section %q (%s) rendered no rows", s.Key, s.Title)
+			continue
+		}
+		for i, row := range rows {
+			if len(row) != len(s.Columns) {
+				t.Errorf("section %q row %d has %d cells, want %d", s.Key, i, len(row), len(s.Columns))
+			}
+		}
+	}
+}
+
+// TestEverySectionVerifies runs each section's import-based Verify assertion.
+// This is the coverage guarantee: a section whose documented values are not
+// backed by a real assertion (or whose values are wrong) fails here, so no
+// golden table can be documented without being test-backed.
+func TestEverySectionVerifies(t *testing.T) {
+	for _, s := range Sections() {
+		if s.Verify == nil {
+			t.Errorf("section %q has no Verify assertion", s.Key)
+			continue
+		}
+		if err := s.Verify(); err != nil {
+			t.Errorf("section %q Verify failed: %v", s.Key, err)
+		}
+	}
+}
+
+// TestGenerateDeterministic asserts Generate is stable across calls (sorted keys
+// and rows), so committed diffs stay minimal and meaningful.
+func TestGenerateDeterministic(t *testing.T) {
+	a, err := Generate()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	b, err := Generate()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if string(a) != string(b) {
+		t.Fatal("Generate produced different output across calls")
+	}
+}

--- a/internal/spec/generate.go
+++ b/internal/spec/generate.go
@@ -1,0 +1,8 @@
+package spec
+
+// Regenerate SPECIFICATION.md (at the repo root) from the Go source of truth.
+// Run `go generate ./...` after changing any golden value, then commit the
+// result. The guard test (spec_guard_test.go) fails CI if the committed file is
+// stale.
+//
+//go:generate go run ./tools/genspec

--- a/internal/spec/sections_detection.go
+++ b/internal/spec/sections_detection.go
@@ -1,0 +1,432 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/marianogappa/screpdb/internal/cmdenrich"
+	"github.com/marianogappa/screpdb/internal/dashboard"
+	"github.com/marianogappa/screpdb/internal/models"
+	"github.com/marianogappa/screpdb/internal/patterns/core"
+	"github.com/marianogappa/screpdb/internal/patterns/markers"
+	"github.com/marianogappa/screpdb/internal/utils"
+)
+
+// endOfReplayThreshold mirrors markers.endOfReplaySentinel (private): rule
+// deadlines at or above this are "resolved only at end of replay".
+const endOfReplayThreshold = 7200 // 2 in-game hours; well past any real opener
+
+func tolerance(t markers.Tolerance) string {
+	if t.EarlySeconds == t.LateSeconds {
+		return fmt.Sprintf("±%d", t.EarlySeconds)
+	}
+	return fmt.Sprintf("−%d / +%d", t.EarlySeconds, t.LateSeconds)
+}
+
+func openers() []markers.Marker {
+	var out []markers.Marker
+	for _, m := range markers.Markers() {
+		if m.Kind == markers.KindInitialBuildOrder {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func init() {
+	registerBuildOrders()
+	registerBuildOrderDeadlines()
+	registerAbsenceThresholds()
+	registerDetectionScalars()
+	registerUnitEconomics()
+	registerGatherRates()
+	registerTechTreeProducers()
+	registerTechTreePrereqs()
+	registerFeaturingOrder()
+	registerGameEventFeatures()
+}
+
+func registerBuildOrders() {
+	Register(Section{
+		Key:   "20-build-orders",
+		Title: "Build orders & expert timings",
+		Intro: "The openings screpdb recognizes and each milestone's \"progamer ideal\" " +
+			"timing. The Build Orders tab marks a milestone on-time if it lands within " +
+			"the tolerance window around its target. Targets are seconds from game " +
+			"start (\"Fastest\" speed); tolerance is the accepted early/late deviation.",
+		Columns: []string{"Build order", "Race", "Milestone", "Target (s)", "Tolerance (s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, m := range openers() {
+				for _, e := range m.Expert {
+					rows = append(rows, []string{
+						m.Name, string(m.Race), e.Key,
+						strconv.Itoa(e.TargetSecond), tolerance(e.Tolerance),
+					})
+				}
+			}
+			sort.Slice(rows, func(i, j int) bool {
+				if rows[i][0] != rows[j][0] {
+					return rows[i][0] < rows[j][0]
+				}
+				ti, _ := strconv.Atoi(rows[i][3])
+				tj, _ := strconv.Atoi(rows[j][3])
+				if ti != tj {
+					return ti < tj
+				}
+				return rows[i][2] < rows[j][2]
+			})
+			return rows
+		},
+		Verify: func() error {
+			ops := openers()
+			if len(ops) == 0 {
+				return fmt.Errorf("no initial-build-order markers registered")
+			}
+			known := knownNameSet()
+			for _, m := range ops {
+				for _, e := range m.Expert {
+					if e.TargetSecond <= 0 {
+						return fmt.Errorf("%s milestone %q has non-positive target", m.Name, e.Key)
+					}
+					if e.Tolerance.EarlySeconds < 0 || e.Tolerance.LateSeconds < 0 {
+						return fmt.Errorf("%s milestone %q has negative tolerance", m.Name, e.Key)
+					}
+					if s := e.Match.Subject; s != "" && !known[s] {
+						return fmt.Errorf("%s milestone %q matches unknown subject %q", m.Name, e.Key, s)
+					}
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerBuildOrderDeadlines() {
+	Register(Section{
+		Key:   "21-build-order-deadlines",
+		Title: "Build-order rule deadlines",
+		Intro: "Each opener's detector commits its decision once the replay passes " +
+			"this second — the last moment the rule could still flip. \"End of replay\" " +
+			"means it's decided only when the game ends.",
+		Columns: []string{"Build order", "Race", "Rule deadline (s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, m := range openers() {
+				dl := strconv.Itoa(m.RuleDeadline)
+				if m.RuleDeadline >= endOfReplayThreshold {
+					dl = "end of replay"
+				}
+				rows = append(rows, []string{m.Name, string(m.Race), dl})
+			}
+			sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+			return rows
+		},
+		Verify: func() error {
+			for _, m := range openers() {
+				if m.RuleDeadline <= 0 {
+					return fmt.Errorf("opener %q has non-positive rule deadline", m.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerAbsenceThresholds() {
+	Register(Section{
+		Key:   "22-absence-thresholds",
+		Title: "Absence-marker game-length thresholds",
+		Intro: "\"Never X\" markers (e.g. *Never upgraded*) only fire on games long " +
+			"enough for the absence to mean something. The minimum length is " +
+			"matchup-specific — the 5th-percentile first-occurrence time across a large " +
+			"progamer 1v1 corpus. Outer race is the player's, inner is the opponent's.",
+		Columns: []string{"Marker", "Own race", "Opp race", "Min game length (s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, m := range markers.Markers() {
+				if m.MinReplaySecondsByMatchup == nil {
+					continue
+				}
+				for own, byOpp := range m.MinReplaySecondsByMatchup {
+					for opp, secs := range byOpp {
+						rows = append(rows, []string{m.Name, string(own), string(opp), strconv.Itoa(secs)})
+					}
+				}
+			}
+			sort.Slice(rows, func(i, j int) bool {
+				if rows[i][0] != rows[j][0] {
+					return rows[i][0] < rows[j][0]
+				}
+				if rows[i][1] != rows[j][1] {
+					return rows[i][1] < rows[j][1]
+				}
+				return rows[i][2] < rows[j][2]
+			})
+			return rows
+		},
+		Verify: func() error {
+			count := 0
+			for _, m := range markers.Markers() {
+				for own, byOpp := range m.MinReplaySecondsByMatchup {
+					for opp, secs := range byOpp {
+						count++
+						if secs <= 0 {
+							return fmt.Errorf("%s [%s vs %s] threshold %d <= 0", m.Name, own, opp, secs)
+						}
+					}
+				}
+			}
+			if count == 0 {
+				return fmt.Errorf("no per-matchup absence thresholds found")
+			}
+			return nil
+		},
+	})
+}
+
+func registerDetectionScalars() {
+	Register(Section{
+		Key:   "23-detection-scalars",
+		Title: "Detection scalars & versioning",
+		Intro: "Standalone constants the detectors depend on — dedup windows, " +
+			"muta/turret burst thresholds, cliff-drop corner boxes, the viewport " +
+			"window, and the algorithm version (bump it to force re-detection).",
+		Columns: []string{"Constant", "Value", "Meaning"},
+		Rows: func() [][]string {
+			return [][]string{
+				{"Algorithm version", strconv.Itoa(core.AlgorithmVersion), "Detection algorithm revision; incremented to trigger re-detection."},
+				{"Build dedup gap (s)", strconv.Itoa(markers.BuildDedupGapSeconds), "Repeat Build orders of the same building closer than this are one event."},
+				{"Build dedup max second (s)", strconv.Itoa(markers.BuildDedupMaxSecond), "Past this second, dedup stops and every Build is observed as-is."},
+				{"Mutalisk burst window (s)", strconv.Itoa(markers.MutaBurstWindowSec), "Window within which the Mutalisk morphs must cluster."},
+				{"Mutalisk burst min count", strconv.Itoa(markers.MutaBurstMinCount), "Minimum Mutalisks in the window to count as a burst."},
+				{"Turret burst window (s)", strconv.Itoa(markers.TurretBurstWindowSec), "Window within which the Missile Turrets must cluster."},
+				{"Turret burst min count", strconv.Itoa(markers.TurretBurstMinCount), "Minimum Missile Turrets in the window to count as a burst."},
+				{"Cliff-drop corner width (px)", strconv.Itoa(utils.CliffDropCornerWidthPx), "Width of the corner box a drop must land in to count as a cliff drop."},
+				{"Cliff-drop corner height (px)", strconv.Itoa(utils.CliffDropCornerHeightPx), "Height of that corner box."},
+				{"Viewport window start (s)", strconv.Itoa(models.ViewportMultitaskingWindowStartSecond), "Second from which viewport-multitasking is measured."},
+				{"Viewport width (px)", strconv.Itoa(models.ViewportWidthPixels), "Width of the screen viewport in map pixels."},
+				{"Viewport height (px)", strconv.Itoa(models.ViewportHeightPixels), "Height of the screen viewport in map pixels."},
+			}
+		},
+		Verify: func() error {
+			if core.AlgorithmVersion <= 0 {
+				return fmt.Errorf("AlgorithmVersion = %d, want > 0", core.AlgorithmVersion)
+			}
+			if markers.BuildDedupGapSeconds <= 0 || markers.BuildDedupMaxSecond <= 0 {
+				return fmt.Errorf("dedup constants must be positive")
+			}
+			if markers.MutaBurstMinCount <= 0 || markers.TurretBurstMinCount <= 0 {
+				return fmt.Errorf("burst counts must be positive")
+			}
+			if utils.CliffDropCornerWidthPx <= 0 || utils.CliffDropCornerHeightPx <= 0 {
+				return fmt.Errorf("cliff-drop corner box must be positive")
+			}
+			if models.ViewportWidthPixels <= 0 || models.ViewportHeightPixels <= 0 {
+				return fmt.Errorf("viewport dimensions must be positive")
+			}
+			return nil
+		},
+	})
+}
+
+func registerUnitEconomics() {
+	Register(Section{
+		Key:   "24-unit-economics",
+		Title: "Early-game unit economics",
+		Intro: "What producing each early-game unit/building costs and does to supply. " +
+			"Supply Δ is the cap increase from supply structures (Pylon/Depot/Overlord " +
+			"= +8); supply cost is what a unit consumes. Build times match the Build " +
+			"times section.",
+		Columns: []string{"Subject", "Minerals", "Gas", "Build time (s)", "Supply Δ", "Supply cost"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range cmdenrich.AllEcon() {
+				rows = append(rows, []string{
+					e.Subject, strconv.Itoa(e.Econ.Minerals), strconv.Itoa(e.Econ.Gas),
+					fnum(e.Econ.BuildTimeS), strconv.Itoa(e.Econ.SupplyDelta), strconv.Itoa(e.Econ.SupplyCost),
+				})
+			}
+			return rows
+		},
+		Verify: func() error {
+			for _, e := range cmdenrich.AllEcon() {
+				bt, ok := models.BuildTimeOf(e.Subject)
+				if !ok {
+					return fmt.Errorf("econ subject %q has no canonical build time", e.Subject)
+				}
+				if bt != e.Econ.BuildTimeS {
+					return fmt.Errorf("econ build time for %q is %v, canonical is %v", e.Subject, e.Econ.BuildTimeS, bt)
+				}
+				if e.Econ.Minerals <= 0 {
+					return fmt.Errorf("econ subject %q has non-positive minerals", e.Subject)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerGatherRates() {
+	Register(Section{
+		Key:   "25-gather-rates",
+		Title: "Worker gather rates",
+		Intro: "Mineral income per worker per minute at a near base, used in " +
+			"early-game economy math.",
+		Columns: []string{"Worker", "Minerals / min"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range cmdenrich.AllGatherRates() {
+				rows = append(rows, []string{e.Worker, fnum(e.MineralsPerMin)})
+			}
+			return rows
+		},
+		Verify: func() error {
+			rates := cmdenrich.AllGatherRates()
+			if len(rates) == 0 {
+				return fmt.Errorf("no gather rates")
+			}
+			known := knownNameSet()
+			for _, e := range rates {
+				if e.MineralsPerMin <= 0 {
+					return fmt.Errorf("gather rate for %q is non-positive", e.Worker)
+				}
+				if !known[e.Worker] {
+					return fmt.Errorf("gather-rate worker %q is not a known unit", e.Worker)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerTechTreeProducers() {
+	Register(Section{
+		Key:   "26-tech-tree-producers",
+		Title: "Tech tree: producers",
+		Intro: "Which building produces each early-game unit. The engine won't run a " +
+			"Train order without its producer, so a surviving Train is strong evidence " +
+			"the producer existed — the spam filter relies on this.",
+		Columns: []string{"Unit", "Produced by"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range cmdenrich.AllProducers() {
+				rows = append(rows, []string{e.Unit, e.Producer})
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, e := range cmdenrich.AllProducers() {
+				if !known[e.Unit] {
+					return fmt.Errorf("producer entry unit %q unknown", e.Unit)
+				}
+				if !known[e.Producer] {
+					return fmt.Errorf("producer %q unknown for unit %q", e.Producer, e.Unit)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerTechTreePrereqs() {
+	Register(Section{
+		Key:   "27-tech-tree-prereqs",
+		Title: "Tech tree: prerequisites",
+		Intro: "Buildings that must already exist before another can be placed (beyond " +
+			"the producer) — e.g. a Photon Cannon needs a Pylon and a Forge.",
+		Columns: []string{"Building", "Requires"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range cmdenrich.AllPrereqs() {
+				rows = append(rows, []string{e.Building, strings.Join(e.Prereqs, ", ")})
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, e := range cmdenrich.AllPrereqs() {
+				if !known[e.Building] {
+					return fmt.Errorf("prereq entry building %q unknown", e.Building)
+				}
+				if len(e.Prereqs) == 0 {
+					return fmt.Errorf("building %q has empty prerequisites", e.Building)
+				}
+				for _, p := range e.Prereqs {
+					if !known[p] {
+						return fmt.Errorf("prerequisite %q unknown for %q", p, e.Building)
+					}
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerFeaturingOrder() {
+	Register(Section{
+		Key:   "28-featuring-order",
+		Title: "Featuring strip order",
+		Intro: "The fixed left-to-right order of chips in the games-list \"Featuring\" " +
+			"strip — a mix of marker keys and game-event keys. Every key resolves to a " +
+			"marker or a game-event feature (next section), enforced by a test.",
+		Columns: []string{"#", "Feature key"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for i, key := range dashboard.FeaturingOrder() {
+				rows = append(rows, []string{strconv.Itoa(i + 1), key})
+			}
+			return rows
+		},
+		Verify: func() error {
+			order := dashboard.FeaturingOrder()
+			if len(order) == 0 {
+				return fmt.Errorf("featuring order is empty")
+			}
+			seen := map[string]bool{}
+			for _, k := range order {
+				if k == "" {
+					return fmt.Errorf("empty featuring key")
+				}
+				if seen[k] {
+					return fmt.Errorf("duplicate featuring key %q", k)
+				}
+				seen[k] = true
+			}
+			return nil
+		},
+	})
+}
+
+func registerGameEventFeatures() {
+	Register(Section{
+		Key:   "29-game-event-features",
+		Title: "Game-event featuring chips",
+		Intro: "Featuring chips for narrative game events that aren't markers (cannon " +
+			"rush, drop, mind control, …): each with a label and one or more unit icons.",
+		Columns: []string{"Key", "Label", "Icons"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, f := range dashboard.AllGameEventFeatures() {
+				rows = append(rows, []string{f.Key, f.Label, strings.Join(f.IconKeys, ", ")})
+			}
+			sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+			return rows
+		},
+		Verify: func() error {
+			feats := dashboard.AllGameEventFeatures()
+			if len(feats) == 0 {
+				return fmt.Errorf("no game-event features")
+			}
+			for _, f := range feats {
+				if f.Key == "" || f.Label == "" {
+					return fmt.Errorf("game-event feature with empty key/label")
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/internal/spec/sections_models.go
+++ b/internal/spec/sections_models.go
@@ -1,0 +1,437 @@
+package spec
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/icza/screp/rep/repcore"
+	"github.com/marianogappa/screpdb/internal/models"
+)
+
+// fnum formats a float without trailing zeros (e.g. 25.2, 50, 167.58).
+func fnum(f float64) string { return strconv.FormatFloat(f, 'f', -1, 64) }
+
+// sortedJoin returns the values sorted and comma-joined, for compact list cells.
+func sortedJoin(values []string) string {
+	cp := append([]string(nil), values...)
+	sort.Strings(cp)
+	return strings.Join(cp, ", ")
+}
+
+// knownNameSet returns the set of canonical unit + building names. Used by the
+// model sections' Verify closures to assert that building/unit references point
+// at real names.
+func knownNameSet() map[string]bool {
+	set := map[string]bool{}
+	for _, n := range models.Units {
+		set[n] = true
+	}
+	for _, n := range models.Buildings {
+		set[n] = true
+	}
+	return set
+}
+
+func validRace(r string) bool {
+	return r == models.RaceTerran || r == models.RaceZerg || r == models.RaceProtoss
+}
+
+func init() {
+	registerUnitNames()
+	registerOrderAttribution()
+	registerBuildTimes()
+	registerTechResearch()
+	registerUpgrades()
+	registerWorkerFlying()
+	registerUnitGeometry()
+	registerBuildingGeometry()
+	registerActionTypes()
+	registerReplayEnums()
+}
+
+func registerUnitNames() {
+	Register(Section{
+		Key:   "01-unit-names",
+		Title: "Unit & building names",
+		Intro: "The canonical names screpdb uses for every unit and building, grouped " +
+			"by race. Every name shown in the UI is one of these strings.",
+		Columns: []string{"Race", "Category", "Names"},
+		Rows: func() [][]string {
+			return [][]string{
+				{models.RaceTerran, "Units", sortedJoin(models.TerranUnits)},
+				{models.RaceTerran, "Buildings", sortedJoin(models.TerranBuildings)},
+				{models.RaceZerg, "Units", sortedJoin(models.ZergUnits)},
+				{models.RaceZerg, "Buildings", sortedJoin(models.ZergBuildings)},
+				{models.RaceProtoss, "Units", sortedJoin(models.ProtossUnits)},
+				{models.RaceProtoss, "Buildings", sortedJoin(models.ProtossBuildings)},
+			}
+		},
+		Verify: func() error {
+			if got, want := len(models.TerranUnits)+len(models.ZergUnits)+len(models.ProtossUnits), len(models.Units); got != want {
+				return fmt.Errorf("per-race unit counts sum to %d, want len(Units)=%d", got, want)
+			}
+			if got, want := len(models.TerranBuildings)+len(models.ZergBuildings)+len(models.ProtossBuildings), len(models.Buildings); got != want {
+				return fmt.Errorf("per-race building counts sum to %d, want len(Buildings)=%d", got, want)
+			}
+			return nil
+		},
+	})
+}
+
+func registerOrderAttribution() {
+	// siegeModeAlias is the one attributed unit name that is an internal
+	// alternate form (the sieged tank) rather than a member of the Units list.
+	siegeModeAlias := map[string]bool{models.GeneralUnitTerranSiegeTankSiegeMode: true}
+
+	Register(Section{
+		Key:   "02-order-attribution",
+		Title: "Order → unit attribution",
+		Intro: "Orders/actions that belong to exactly one unit type (e.g. " +
+			"`CastPsionicStorm` can only be a High Templar). screpdb uses this to " +
+			"attribute a command to the unit that issued it. Generic orders (Move, " +
+			"Attack, Hold) belong to many units and are omitted. `OrderName` and " +
+			"`ActionType` are separate namespaces.",
+		Columns: []string{"Key", "Namespace", "Issued by", "Race"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for k, v := range models.UnitOrderToUnit {
+				rows = append(rows, []string{k, "OrderName", v.Unit, v.Race})
+			}
+			for k, v := range models.ActionTypeToUnit {
+				rows = append(rows, []string{k, "ActionType", v.Unit, v.Race})
+			}
+			sort.Slice(rows, func(i, j int) bool {
+				if rows[i][0] != rows[j][0] {
+					return rows[i][0] < rows[j][0]
+				}
+				return rows[i][1] < rows[j][1]
+			})
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			check := func(ns string, m map[string]models.UnitOrigin) error {
+				for k, v := range m {
+					if v.Unit == "" {
+						return fmt.Errorf("%s %q has empty unit", ns, k)
+					}
+					if !validRace(v.Race) {
+						return fmt.Errorf("%s %q has invalid race %q", ns, k, v.Race)
+					}
+					if !known[v.Unit] && !siegeModeAlias[v.Unit] {
+						return fmt.Errorf("%s %q maps to unknown unit %q", ns, k, v.Unit)
+					}
+				}
+				return nil
+			}
+			if err := check("OrderName", models.UnitOrderToUnit); err != nil {
+				return err
+			}
+			return check("ActionType", models.ActionTypeToUnit)
+		},
+	})
+}
+
+func registerBuildTimes() {
+	Register(Section{
+		Key:   "03-build-times",
+		Title: "Build times",
+		Intro: "Build time in seconds at \"Fastest\" speed (every competitive replay " +
+			"uses it). Single source of truth for all timing logic — detection, expert " +
+			"timings, and the economy table all read these values. Zerglings are timed " +
+			"per pair (one egg makes two).",
+		Columns: []string{"Unit / Building", "Build time (s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range models.AllBuildTimes() {
+				rows = append(rows, []string{e.Name, fnum(e.Seconds)})
+			}
+			return rows
+		},
+		Verify: func() error {
+			for _, e := range models.AllBuildTimes() {
+				if e.Seconds <= 0 {
+					return fmt.Errorf("build time for %q is %v, want > 0", e.Name, e.Seconds)
+				}
+			}
+			// Anchor the two values reconciled in issue #138.
+			if models.BuildTimeZealot != 25.2 {
+				return fmt.Errorf("BuildTimeZealot = %v, want 25.2", models.BuildTimeZealot)
+			}
+			if models.BuildTimeZergling != 18 {
+				return fmt.Errorf("BuildTimeZergling = %v, want 18", models.BuildTimeZergling)
+			}
+			return nil
+		},
+	})
+}
+
+func registerTechResearch() {
+	Register(Section{
+		Key:   "04-tech-research",
+		Title: "Tech research",
+		Intro: "One-shot researches that unlock an ability or morph (Stim Packs, " +
+			"Lurker Aspect, Psionic Storm, …): where each is researched, its cost, and " +
+			"its duration at \"Fastest\" speed. screpdb uses the duration to time when " +
+			"the ability becomes available.",
+		Columns: []string{"Tech", "Race", "Researched at", "Minerals", "Gas", "Duration (s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range models.AllTechMeta() {
+				rows = append(rows, []string{
+					e.Name, e.Meta.Race, e.Meta.BuildingSubject,
+					strconv.Itoa(e.Meta.Minerals), strconv.Itoa(e.Meta.Gas), fnum(e.Meta.DurationS),
+				})
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, e := range models.AllTechMeta() {
+				if !validRace(e.Meta.Race) {
+					return fmt.Errorf("tech %q has invalid race %q", e.Name, e.Meta.Race)
+				}
+				if !known[e.Meta.BuildingSubject] {
+					return fmt.Errorf("tech %q researched at unknown building %q", e.Name, e.Meta.BuildingSubject)
+				}
+				if e.Meta.DurationS <= 0 {
+					return fmt.Errorf("tech %q has non-positive duration %v", e.Name, e.Meta.DurationS)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerUpgrades() {
+	lvl := func(m models.UpgradeLevelMeta) string {
+		return fmt.Sprintf("%d / %d / %s", m.Minerals, m.Gas, fnum(m.DurationS))
+	}
+	Register(Section{
+		Key:   "05-upgrades",
+		Title: "Upgrades",
+		Intro: "Passive upgrades: where each is researched, its max level (1 one-shot, " +
+			"3 tiered) and each level's cost. Level cells read `minerals / gas / " +
+			"seconds`; unused levels show an em dash. Used to time when an upgrade " +
+			"completes.",
+		Columns: []string{"Upgrade", "Race", "Researched at", "Max level", "L1 (m/g/s)", "L2 (m/g/s)", "L3 (m/g/s)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, e := range models.AllUpgradeMeta() {
+				row := []string{e.Name, e.Meta.Race, e.Meta.BuildingSubject, strconv.Itoa(e.Meta.MaxLevel)}
+				for i := 0; i < 3; i++ {
+					if i < e.Meta.MaxLevel {
+						row = append(row, lvl(e.Meta.Levels[i]))
+					} else {
+						row = append(row, "")
+					}
+				}
+				rows = append(rows, row)
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, e := range models.AllUpgradeMeta() {
+				if e.Meta.MaxLevel != 1 && e.Meta.MaxLevel != 3 {
+					return fmt.Errorf("upgrade %q has MaxLevel %d, want 1 or 3", e.Name, e.Meta.MaxLevel)
+				}
+				if !validRace(e.Meta.Race) {
+					return fmt.Errorf("upgrade %q has invalid race %q", e.Name, e.Meta.Race)
+				}
+				if !known[e.Meta.BuildingSubject] {
+					return fmt.Errorf("upgrade %q researched at unknown building %q", e.Name, e.Meta.BuildingSubject)
+				}
+				if e.Meta.Levels[0].DurationS <= 0 {
+					return fmt.Errorf("upgrade %q L1 has non-positive duration", e.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerWorkerFlying() {
+	Register(Section{
+		Key:   "06-worker-flying",
+		Title: "Worker & flying units",
+		Intro: "Two unit sets the detectors special-case, both excluded from " +
+			"drop-composition estimates: workers, and flying units (can't be carried " +
+			"in a transport).",
+		Columns: []string{"Category", "Units"},
+		Rows: func() [][]string {
+			return [][]string{
+				{"Workers", strings.Join(models.WorkerUnitNames(), ", ")},
+				{"Flying (non-transportable)", strings.Join(models.FlyingUnitNames(), ", ")},
+			}
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			if len(models.WorkerUnitNames()) == 0 || len(models.FlyingUnitNames()) == 0 {
+				return fmt.Errorf("worker/flying set is empty")
+			}
+			for _, n := range models.WorkerUnitNames() {
+				if !known[n] {
+					return fmt.Errorf("worker %q is not a known unit name", n)
+				}
+			}
+			// Flying set may include transient forms (e.g. "Mutalisk Cocoon")
+			// that aren't in the playable Units list, so only require non-empty.
+			for _, n := range models.FlyingUnitNames() {
+				if n == "" {
+					return fmt.Errorf("flying unit set contains an empty name")
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerUnitGeometry() {
+	Register(Section{
+		Key:     "07-unit-geometry",
+		Title:   "Unit geometry",
+		Intro:   "Pixel dimensions screpdb uses to draw unit overlays on the map.",
+		Columns: []string{"Unit", "Width (px)", "Height (px)"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, u := range models.AllUnitGeometry() {
+				rows = append(rows, []string{u.Name, strconv.Itoa(u.WidthPixels), strconv.Itoa(u.HeightPixels)})
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, u := range models.AllUnitGeometry() {
+				if u.WidthPixels <= 0 || u.HeightPixels <= 0 {
+					return fmt.Errorf("unit %q has non-positive dimensions", u.Name)
+				}
+				if !known[u.Name] {
+					return fmt.Errorf("unit geometry %q is not a known unit name", u.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerBuildingGeometry() {
+	Register(Section{
+		Key:   "08-building-geometry",
+		Title: "Building geometry",
+		Intro: "Pixel dimensions for building overlays. `Box` is the placement " +
+			"footprint, `Real` is the visible sprite, and the gaps are the insets from " +
+			"box to sprite on each side.",
+		Columns: []string{"Building", "Box W", "Box H", "Real W", "Real H", "Gap T", "Gap L", "Gap R", "Gap B"},
+		Rows: func() [][]string {
+			var rows [][]string
+			for _, b := range models.AllBuildingGeometry() {
+				rows = append(rows, []string{
+					b.Name,
+					strconv.Itoa(b.BoxWidthPixels), strconv.Itoa(b.BoxHeightPixels),
+					strconv.Itoa(b.RealWidthPixels), strconv.Itoa(b.RealHeightPixels),
+					strconv.Itoa(b.GapTopPixels), strconv.Itoa(b.GapLeftPixels),
+					strconv.Itoa(b.GapRightPixels), strconv.Itoa(b.GapBottomPixels),
+				})
+			}
+			return rows
+		},
+		Verify: func() error {
+			known := knownNameSet()
+			for _, b := range models.AllBuildingGeometry() {
+				if b.BoxWidthPixels <= 0 || b.BoxHeightPixels <= 0 {
+					return fmt.Errorf("building %q has non-positive box dimensions", b.Name)
+				}
+				if !known[b.Name] {
+					return fmt.Errorf("building geometry %q is not a known building name", b.Name)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerActionTypes() {
+	Register(Section{
+		Key:   "09-action-types",
+		Title: "Higher-level action types",
+		Intro: "screpdb collapses many raw commands into a few higher-level action " +
+			"types (train, build, morph). These are the exact string values it stores " +
+			"and matches on.",
+		Columns: []string{"Action type", "Value"},
+		Rows: func() [][]string {
+			return [][]string{
+				{"Train", models.ActionTypeTrain},
+				{"Build", models.ActionTypeBuild},
+				{"Unit Morph", models.ActionTypeUnitMorph},
+			}
+		},
+		Verify: func() error {
+			for _, v := range []string{models.ActionTypeTrain, models.ActionTypeBuild, models.ActionTypeUnitMorph} {
+				if v == "" {
+					return fmt.Errorf("empty action type constant")
+				}
+			}
+			return nil
+		},
+	})
+}
+
+func registerReplayEnums() {
+	speedNames := func() []string {
+		var out []string
+		for _, s := range repcore.Speeds {
+			out = append(out, s.Name)
+		}
+		return out
+	}
+	colorNames := func() []string {
+		seen := map[string]bool{}
+		var out []string
+		for _, c := range repcore.Colors {
+			if c.Name == "" || seen[c.Name] {
+				continue
+			}
+			seen[c.Name] = true
+			out = append(out, c.Name)
+		}
+		return out
+	}
+	Register(Section{
+		Key:   "10-replay-enums",
+		Title: "Replay enums",
+		Intro: "Fixed value sets screpdb reads from a parsed replay. Races are " +
+			"screpdb's; speeds and colors come from the screp parser " +
+			"(`github.com/icza/screp/rep/repcore`); matchups are derived from race " +
+			"initials.",
+		Columns: []string{"Enum", "Values", "Notes"},
+		Rows: func() [][]string {
+			return [][]string{
+				{"Races", strings.Join([]string{models.RaceTerran, models.RaceProtoss, models.RaceZerg}, ", "), "Random resolves to the actual race at game start."},
+				{"Game speeds", strings.Join(speedNames(), ", "), "Competitive replays are always played on Fastest."},
+				{"Player colors", strings.Join(colorNames(), ", "), "The player's slot color as parsed from the replay."},
+				{"1v1 matchups", "PvP, PvT, PvZ, TvT, TvZ, ZvZ", "Race initials sorted alphabetically; team/FFA games use the same scheme (e.g. PPvZZ)."},
+				{"Start location (clock)", "1–12", "The o'clock position of the player's start location on the map."},
+			}
+		},
+		Verify: func() error {
+			has := func(list []string, want string) bool {
+				for _, v := range list {
+					if v == want {
+						return true
+					}
+				}
+				return false
+			}
+			if !has(speedNames(), "Fastest") {
+				return fmt.Errorf("game speeds missing Fastest")
+			}
+			if !has(colorNames(), "Red") {
+				return fmt.Errorf("player colors missing Red")
+			}
+			return nil
+		},
+	})
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -1,0 +1,179 @@
+// Package spec generates SPECIFICATION.md — the human-readable, machine-decodable
+// catalogue of every "golden value" screpdb relies on to make its derived claims
+// (build-order names, expert timings, unit costs, build times, detection
+// thresholds, …).
+//
+// The document is GENERATED from the real Go constants and tables (this package
+// imports them and reads their live values), so it can never drift from the
+// code. A guard test (spec_guard_test.go) regenerates the document and diffs it
+// against the committed SPECIFICATION.md, failing CI if they differ. A coverage
+// test (coverage_test.go) asserts every registered section is non-empty and
+// carries an import-based Verify assertion. Together: if the spec is wrong, CI
+// is red.
+//
+// Adding a new golden table is a small, local change: register a new Section
+// (see sections_models.go / sections_detection.go) that reads the table's
+// exported enumerator and provide a Verify that asserts its values.
+package spec
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Section is one self-contained block of the specification: a prose intro
+// followed by a single fixed-column table. Sections register themselves via
+// Register (typically from an init function) and are emitted in Key order so
+// the document is deterministic and diffs are minimal.
+type Section struct {
+	// Key controls ordering (sections are emitted sorted by Key) and must be
+	// unique. Use a numeric prefix to group/order (e.g. "03-build-times").
+	Key string
+	// Title is the human-facing section heading.
+	Title string
+	// Intro is prose explaining what the table holds and why it matters to
+	// what the user sees on screen.
+	Intro string
+	// Columns are the fixed table headers (machine-decodable contract).
+	Columns []string
+	// Rows returns the table body, pre-sorted for determinism. Each row must
+	// have len(Columns) cells.
+	Rows func() [][]string
+	// Verify performs import-based assertions backing the section's values.
+	// It returns a non-nil error if any value is wrong. The coverage test runs
+	// every section's Verify; a section with no real assertion fails coverage.
+	Verify func() error
+}
+
+var registry []Section
+
+// Register adds a section to the document. Panics on duplicate or malformed
+// Key so wiring mistakes surface immediately at init time.
+func Register(s Section) {
+	if s.Key == "" || s.Title == "" || s.Rows == nil || s.Verify == nil || len(s.Columns) == 0 {
+		panic(fmt.Sprintf("spec.Register: incomplete section %q", s.Key))
+	}
+	for _, existing := range registry {
+		if existing.Key == s.Key {
+			panic(fmt.Sprintf("spec.Register: duplicate section key %q", s.Key))
+		}
+	}
+	registry = append(registry, s)
+}
+
+// Sections returns all registered sections sorted by Key (a copy; safe to
+// mutate). Used by Generate and the guard/coverage tests.
+func Sections() []Section {
+	out := make([]Section, len(registry))
+	copy(out, registry)
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+const header = `# screpdb specification
+
+> **Generated file — do not edit by hand.** Run ` + "`go generate ./...`" + ` to rebuild it,
+> then commit. CI fails if it's stale or if any value isn't test-backed.
+
+## Why this exists
+
+screpdb makes a lot of derived claims — "this is a **9 Pool**", "your Spawning
+Pool was 6s late", "a Zealot takes 25.2s". They all rest on **golden values**
+baked into the code.
+
+This document lets you audit them:
+
+- Every value is read straight from the constants the app runs on (the doc is generated *from* them).
+- Every value is checked by a test (` + "`go test ./...`" + `).
+
+So the doc can't drift from the code, and the code can't be silently wrong.
+
+Each section is a short intro plus a fixed-column table — readable by humans,
+parseable by machines. Keys are sorted, so diffs stay small.
+`
+
+// Generate renders the full specification document. The output is deterministic:
+// sections are emitted in Key order and each section's Rows are pre-sorted.
+func Generate() ([]byte, error) {
+	secs := Sections()
+
+	var b bytes.Buffer
+	b.WriteString(header)
+
+	// Table of contents.
+	b.WriteString("\n## Contents\n\n")
+	for _, s := range secs {
+		fmt.Fprintf(&b, "- [%s](#%s)\n", s.Title, anchor(s.Title))
+	}
+
+	for _, s := range secs {
+		if err := writeSection(&b, s); err != nil {
+			return nil, fmt.Errorf("section %q: %w", s.Key, err)
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+func writeSection(b *bytes.Buffer, s Section) error {
+	fmt.Fprintf(b, "\n## %s\n\n", s.Title)
+	if intro := strings.TrimSpace(s.Intro); intro != "" {
+		b.WriteString(intro)
+		b.WriteString("\n\n")
+	}
+
+	rows := s.Rows()
+	if len(rows) == 0 {
+		return fmt.Errorf("no rows")
+	}
+
+	// Header.
+	b.WriteString("| " + strings.Join(s.Columns, " | ") + " |\n")
+	seps := make([]string, len(s.Columns))
+	for i := range seps {
+		seps[i] = "---"
+	}
+	b.WriteString("| " + strings.Join(seps, " | ") + " |\n")
+
+	// Body.
+	for _, row := range rows {
+		if len(row) != len(s.Columns) {
+			return fmt.Errorf("row has %d cells, want %d: %v", len(row), len(s.Columns), row)
+		}
+		cells := make([]string, len(row))
+		for i, c := range row {
+			cells[i] = cell(c)
+		}
+		b.WriteString("| " + strings.Join(cells, " | ") + " |\n")
+	}
+	return nil
+}
+
+// cell sanitizes a table cell: pipes are escaped and newlines flattened so the
+// markdown table stays valid and single-line per row. Empty cells render as an
+// em dash for readability.
+func cell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// anchor converts a section title into a GitHub-flavored-markdown heading anchor.
+func anchor(title string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(title) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/internal/spec/spec_guard_test.go
+++ b/internal/spec/spec_guard_test.go
@@ -1,0 +1,40 @@
+package spec
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// committedSpecPath returns the absolute path of the committed SPECIFICATION.md
+// at the repo root (this test file lives in internal/spec, two levels down).
+func committedSpecPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve current file")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "SPECIFICATION.md")
+}
+
+// TestSpecificationUpToDate is the generation-parity guard: the committed
+// SPECIFICATION.md must byte-for-byte equal freshly generated output. This is
+// what makes the document unable to drift from the code. Enforced by the
+// existing `go test ./...` step in CI.
+func TestSpecificationUpToDate(t *testing.T) {
+	want, err := Generate()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	got, err := os.ReadFile(committedSpecPath(t))
+	if err != nil {
+		t.Fatalf("read committed SPECIFICATION.md: %v (run `go generate ./...`)", err)
+	}
+
+	if string(got) != string(want) {
+		t.Fatalf("SPECIFICATION.md is stale or hand-edited: regenerated output differs from the committed file.\n" +
+			"Run `go generate ./...` and commit the result.")
+	}
+}

--- a/internal/spec/tools/genspec/main.go
+++ b/internal/spec/tools/genspec/main.go
@@ -1,0 +1,54 @@
+// Command genspec regenerates SPECIFICATION.md at the repo root from the Go
+// source of truth. Invoked by `go generate ./...` (see ../../generate.go) and
+// the Makefile `spec-generate` target.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/marianogappa/screpdb/internal/spec"
+)
+
+func main() {
+	root, err := findRepoRoot()
+	if err != nil {
+		fail(err)
+	}
+
+	doc, err := spec.Generate()
+	if err != nil {
+		fail(err)
+	}
+
+	out := filepath.Join(root, "SPECIFICATION.md")
+	if err := os.WriteFile(out, doc, 0o644); err != nil {
+		fail(err)
+	}
+}
+
+// findRepoRoot walks up from the current working directory to the directory
+// containing go.mod. This makes the tool robust under `go generate ./...`, where
+// the working directory is the package dir, not the repo root.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found walking up from working directory")
+		}
+		dir = parent
+	}
+}
+
+func fail(err error) {
+	fmt.Fprintf(os.Stderr, "genspec: %v\n", err)
+	os.Exit(1)
+}

--- a/internal/utils/cliff_drop.go
+++ b/internal/utils/cliff_drop.go
@@ -25,8 +25,8 @@ func IsBigGameHuntersMap(name string) bool {
 // rectangle of these dimensions, anchored to the corresponding corner
 // of the map.
 const (
-	cliffDropCornerWidthPx  = 256
-	cliffDropCornerHeightPx = 128
+	CliffDropCornerWidthPx  = 256
+	CliffDropCornerHeightPx = 128
 )
 
 // IsCliffDropPosition reports whether (x,y) lies in the top-left or
@@ -36,11 +36,11 @@ func IsCliffDropPosition(x, y, mapWidthPx, mapHeightPx int) bool {
 	if mapWidthPx <= 0 || mapHeightPx <= 0 {
 		return false
 	}
-	if x >= 0 && x < cliffDropCornerWidthPx && y >= 0 && y < cliffDropCornerHeightPx {
+	if x >= 0 && x < CliffDropCornerWidthPx && y >= 0 && y < CliffDropCornerHeightPx {
 		return true
 	}
-	if x >= mapWidthPx-cliffDropCornerWidthPx && x <= mapWidthPx &&
-		y >= mapHeightPx-cliffDropCornerHeightPx && y <= mapHeightPx {
+	if x >= mapWidthPx-CliffDropCornerWidthPx && x <= mapWidthPx &&
+		y >= mapHeightPx-CliffDropCornerHeightPx && y <= mapHeightPx {
 		return true
 	}
 	return false


### PR DESCRIPTION
Closes #138.

Publishes [`SPECIFICATION.md`](../blob/feat/specification-md-issue-138/SPECIFICATION.md): a human-readable, machine-decodable catalogue of every **golden value** screpdb relies on to make its derived claims (unit names, build times, expert build-order timings, tech/upgrade costs, detection thresholds, and more).

The guarantee: **generated from the code so it can't drift, and fully test-backed so it can't be silently wrong.** If the spec is wrong, CI is red.

## What's in it

- **`internal/spec`** — a self-registering `Section` registry that imports the golden-value packages and reads their **live Go values** (not source text), rendering deterministic, sorted markdown (prose intro + fixed-column table per section).
- **`go generate ./...`** wiring via `internal/spec/tools/genspec` (writes `SPECIFICATION.md` at the repo root), plus a `spec-generate` Makefile target. First `//go:generate` directive in the repo.
- **19 sections** spanning game knowledge (names, build times, tech/upgrade meta, geometry, replay enums, …) and detection golden values (build orders + expert timings, rule deadlines, absence thresholds, dedup/burst/cliff/viewport scalars, economics, tech tree, featuring strip).

## How it's enforced (`go test ./...`)

- **Generation parity** — committed file must byte-match freshly generated output (`TestSpecificationUpToDate`).
- **Coverage** — every section renders rows and passes an **import-based `Verify`** assertion; a golden table documented without a backing assertion fails.
- **Cross-consistency** — econ build times equal the canonical models build times; featuring keys resolve to real markers/game-events; openers have resolvable feature keys.
- Geometry-registry completeness guarded via `go/ast` (the one place runtime enumeration is impossible).

## Refactor: single source of truth

The cross-consistency work surfaced duplicated build times. `internal/models/build_times.go` is now the one canonical table, and `cmdenrich/costs.go` references the `models.BuildTime*` consts — reconciling the prior **Zealot 25.2** and **Zergling 18** discrepancies. Exported enumerators were added across `models`, `cmdenrich`, and `dashboard` for the generator.

## README

Adds a "Specification — how the numbers are computed" section with skeptical-user framing.

## Notes

- Verified the negative case: hand-changing a golden value turns CI red (both the parity guard and the section `Verify`).
- The `internal/spec/tools` generator is exempted in the I/O-facade enforcement allowlist alongside the existing `gen_openapi_bridge` build tooling.
- Follow-up filed as #141 (whether the time-gap `BuildDedupGapSeconds` is now redundant with the resource-based `earlyfilter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
