### PR TITLE
fix: repair broken Skill proxies tabs (closes #147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Run frontend tests
+        run: make ui-test
+
       - name: Build embedded UI and cross-platform binaries
         run: make cross-binaries
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: openapi-generate spec-generate ui-build build release cross-binaries windows-syso clean-windows-syso
+.PHONY: openapi-generate spec-generate ui-build ui-test build release cross-binaries windows-syso clean-windows-syso
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 REL_LDFLAGS := -s -w -X github.com/marianogappa/screpdb/internal/buildinfo.Version=$(VERSION)
@@ -35,6 +35,10 @@ spec-generate:
 
 ui-build:
 	cd internal/dashboard/frontend && npm ci && npm run build
+
+# Frontend unit tests (route/state contracts). Zero extra deps: node --test.
+ui-test:
+	cd internal/dashboard/frontend && npm ci && npm test
 
 build: ui-build
 	go build -ldflags "$(REL_LDFLAGS)" -o screpdb .

--- a/internal/dashboard/frontend/package.json
+++ b/internal/dashboard/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test"
   },
   "dependencies": {
     "d3": "^7.9.0",

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { api } from './api';
 import GlobalReplayFilterModal from './components/GlobalReplayFilterModal';
 import IngestModal from './components/IngestModal';
+import Histogram from './components/charts/Histogram';
 import TimingScatterRows from './components/charts/TimingScatterRows';
 import FirstUnitEfficiencyTimelineRows from './components/charts/FirstUnitEfficiencyTimelineRows';
 import BuildOrderTimelineRows from './components/charts/BuildOrderTimelineRows';
@@ -40,6 +41,7 @@ import {
   buildMainRouteSearch,
   mainRouteHref,
   mainRouteSnapshotEqual,
+  shouldLoadPlayerSkillProxyInsights,
   MAIN_GAME_TABS,
   MAIN_PLAYER_TABS,
   MAIN_PLAYER_SKILL_PROXY_SUBTABS,
@@ -2718,8 +2720,7 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (activeView !== 'player' || !selectedPlayerKey) return;
-    if (mainPlayerTab !== 'skill-proxies' || mainPlayerSubtab !== 'summary') return;
+    if (!shouldLoadPlayerSkillProxyInsights({ activeView, selectedPlayerKey, mainPlayerTab })) return;
     if (!mainPlayerApmInsight && !mainPlayerApmInsightLoading && !mainPlayerApmInsightError) {
       loadMainPlayerApmInsight(selectedPlayerKey);
     }
@@ -2733,7 +2734,7 @@ function App() {
       loadMainPlayerViewportInsight(selectedPlayerKey);
     }
   }, [
-    activeView, selectedPlayerKey, mainPlayerTab, mainPlayerSubtab,
+    activeView, selectedPlayerKey, mainPlayerTab,
     mainPlayerApmInsight, mainPlayerApmInsightLoading, mainPlayerApmInsightError,
     mainPlayerDelayInsight, mainPlayerDelayInsightLoading, mainPlayerDelayInsightError,
     mainPlayerCadenceInsight, mainPlayerCadenceInsightLoading, mainPlayerCadenceInsightError,
@@ -6358,7 +6359,7 @@ function App() {
                       onClick={() => {
                         if (isSkillProxiesTab) return;
                         setMainPlayerTab('skill-proxies');
-                        setMainPlayerSubtab('');
+                        setMainPlayerSubtab('summary');
                       }}>
                       Skill proxies
                     </button>

--- a/internal/dashboard/frontend/src/components/charts/Histogram.jsx
+++ b/internal/dashboard/frontend/src/components/charts/Histogram.jsx
@@ -1,0 +1,417 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+
+const DEFAULT_COLORS = ['#4e79a7'];
+
+function Histogram({ data, config }) {
+  const svgRef = useRef(null);
+  const containerRef = useRef(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, text: '' });
+
+  useEffect(() => {
+    const updateDimensions = () => {
+      if (containerRef.current) {
+        const { width, height } = containerRef.current.getBoundingClientRect();
+        const newWidth = Math.max(300, width);
+        const newHeight = Math.max(300, height);
+        setDimensions(prev => {
+          if (Math.abs(prev.width - newWidth) > 1 || Math.abs(prev.height - newHeight) > 1) {
+            return { width: newWidth, height: newHeight };
+          }
+          return prev;
+        });
+      }
+    };
+
+    updateDimensions();
+    const resizeObserver = new ResizeObserver(updateDimensions);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (dimensions.width === 0 || !svgRef.current) {
+      return;
+    }
+
+    const margin = { top: 20, right: 30, bottom: 60, left: 60 };
+    const width = dimensions.width - margin.left - margin.right;
+    const height = dimensions.height - margin.top - margin.bottom;
+
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    // Clear existing content
+    d3.select(svgRef.current).selectAll('*').remove();
+
+    const svg = d3.select(svgRef.current)
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+      .append('g')
+      .attr('transform', `translate(${margin.left}, ${margin.top})`);
+    setTooltip((prev) => ({ ...prev, visible: false }));
+
+    const hasPrecomputedBins = Array.isArray(config?.precomputed_bins) && config.precomputed_bins.length > 0;
+
+    let binsData = [];
+    if (hasPrecomputedBins) {
+      binsData = config.precomputed_bins
+        .map((bin) => ({
+          x0: Number(bin?.x0),
+          x1: Number(bin?.x1),
+          count: Number(bin?.count) || 0,
+        }))
+        .filter((bin) => Number.isFinite(bin.x0) && Number.isFinite(bin.x1) && bin.x1 >= bin.x0);
+    } else {
+      if (!data || data.length === 0 || !config?.histogram_value_column) return;
+      const values = data.map((d) => Number(d[config.histogram_value_column]) || 0).filter((v) => !Number.isNaN(v));
+      if (values.length === 0) return;
+      const bins = config.histogram_bins || Math.ceil(Math.sqrt(values.length));
+      binsData = d3.bin()
+        .domain(d3.extent(values))
+        .thresholds(bins)(values)
+        .map((bin) => ({
+          x0: bin.x0,
+          x1: bin.x1,
+          count: bin.length,
+        }));
+    }
+
+    if (binsData.length === 0) return;
+
+    const xScale = d3.scaleLinear()
+      .domain([binsData[0].x0, binsData[binsData.length - 1].x1])
+      .range([0, width]);
+
+    const mean = Number(config?.mean);
+    const stddev = Number(config?.stddev);
+    if (config?.style === 'monobell_relax' && Number.isFinite(mean) && Number.isFinite(stddev) && stddev > 0) {
+      const normalPDF = (value) => {
+        const z = (value - mean) / stddev;
+        return (1 / (stddev * Math.sqrt(2 * Math.PI))) * Math.exp(-0.5 * z * z);
+      };
+      const samples = d3.range(0, 240).map((idx) => {
+        const t = idx / 239;
+        const xValue = xScale.domain()[0] + t * (xScale.domain()[1] - xScale.domain()[0]);
+        return { x: xValue, p: normalPDF(xValue) };
+      });
+      const yScale = d3.scaleLinear()
+        .domain([0, Math.max(1e-6, Number(d3.max(samples, (item) => item.p) || 0))])
+        .range([height, 0]);
+
+      svg.append('g')
+        .attr('transform', `translate(0, ${height})`)
+        .call(d3.axisBottom(xScale).tickSizeOuter(0))
+        .selectAll('text')
+        .attr('fill', '#fff');
+      svg.append('g')
+        .call(d3.axisLeft(yScale).ticks(6))
+        .selectAll('text')
+        .attr('fill', '#fff');
+
+      const lineBuilder = d3.line()
+        .x((item) => xScale(item.x))
+        .y((item) => yScale(item.p))
+        .curve(d3.curveMonotoneX);
+      svg.append('path')
+        .datum(samples)
+        .attr('fill', 'none')
+        .attr('stroke', '#dbeafe')
+        .attr('stroke-width', 2.8)
+        .attr('opacity', 0.95)
+        .attr('d', lineBuilder);
+
+      svg.append('line')
+        .attr('x1', xScale(mean))
+        .attr('x2', xScale(mean))
+        .attr('y1', 0)
+        .attr('y2', height)
+        .attr('stroke', '#f59e0b')
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', '6,4');
+
+      const overlayPoints = (Array.isArray(config?.overlay_points) ? config.overlay_points : [])
+        .map((point) => ({
+          value: Number(point?.value),
+          label: String(point?.label || '').trim(),
+          key: String(point?.player_key || point?.label || '').trim(),
+          playerKey: String(point?.player_key || '').trim(),
+          gamesPlayed: Number(point?.games_played || 0),
+          tooltipLines: Array.isArray(point?.tooltip_lines)
+            ? point.tooltip_lines.map((line) => String(line || '').trim()).filter((line) => line)
+            : [],
+        }))
+        .filter((point) => Number.isFinite(point.value) && point.label)
+        .sort((a, b) => a.value - b.value);
+      const overlayValueLabel = String(config?.overlay_value_label || '').trim() || 'APM';
+      const overlayCountLabel = String(config?.overlay_count_label || '').trim() || 'games';
+      const onOverlayPointClick = typeof config?.on_overlay_point_click === 'function' ? config.on_overlay_point_click : null;
+
+      const palette = ['#60a5fa', '#f472b6', '#34d399', '#f59e0b', '#a78bfa', '#22d3ee', '#f87171', '#10b981', '#fb7185', '#c4b5fd'];
+      const placements = overlayPoints.map((point, idx) => {
+        const fullLabel = point.label;
+        const label = fullLabel.length > 22 ? `${fullLabel.slice(0, 21)}...` : fullLabel;
+        return {
+          ...point,
+          color: palette[(idx * 7) % palette.length],
+          fullLabel,
+          label,
+          labelW: Math.max(34, Math.min(220, label.length * 7.6)),
+          labelH: 15,
+          xPixel: xScale(point.value),
+          yCurve: yScale(normalPDF(point.value)),
+          dotY: yScale(normalPDF(point.value)),
+          labelX: xScale(point.value) + 8,
+          labelY: yScale(normalPDF(point.value)),
+        };
+      });
+
+      const laneCount = 30;
+      const laneTop = 14;
+      const laneBottom = height - 14;
+      const laneYs = Array.from({ length: laneCount }, (_, idx) => laneTop + (idx / Math.max(1, laneCount - 1)) * (laneBottom - laneTop));
+      const laneLastRightX = new Array(laneCount).fill(-1e9);
+      const minGap = 14;
+      placements.forEach((point, idx) => {
+        let bestLane = idx % laneCount;
+        let bestScore = Infinity;
+        for (let lane = 0; lane < laneCount; lane += 1) {
+          const free = point.xPixel + 8 - laneLastRightX[lane];
+          const gapPenalty = Math.max(0, minGap - free) * 8;
+          const distPenalty = Math.abs(laneYs[lane] - point.yCurve) * 0.6;
+          const score = gapPenalty + distPenalty;
+          if (score < bestScore) {
+            bestScore = score;
+            bestLane = lane;
+          }
+        }
+        point.dotY = laneYs[bestLane];
+        point.labelY = laneYs[bestLane] - 1;
+        point.labelX = Math.min(width - point.labelW - 2, point.xPixel + 8);
+        laneLastRightX[bestLane] = point.labelX + point.labelW;
+      });
+
+      for (let iter = 0; iter < 260; iter += 1) {
+        let moved = false;
+        for (let i = 0; i < placements.length; i += 1) {
+          for (let j = i + 1; j < placements.length; j += 1) {
+            const a = placements[i];
+            const b = placements[j];
+            const ax1 = a.labelX;
+            const ax2 = a.labelX + a.labelW;
+            const ay1 = a.labelY - a.labelH;
+            const ay2 = a.labelY + 2;
+            const bx1 = b.labelX;
+            const bx2 = b.labelX + b.labelW;
+            const by1 = b.labelY - b.labelH;
+            const by2 = b.labelY + 2;
+            const overlapX = ax1 < bx2 && ax2 > bx1;
+            const overlapY = ay1 < by2 && ay2 > by1;
+            if (!overlapX || !overlapY) continue;
+            const dir = a.labelY <= b.labelY ? -1 : 1;
+            a.labelY = Math.max(12, Math.min(height - 4, a.labelY + dir * 0.95));
+            b.labelY = Math.max(12, Math.min(height - 4, b.labelY - dir * 0.95));
+            moved = true;
+          }
+        }
+        if (!moved) break;
+      }
+      placements.forEach((point) => {
+        point.dotY = Math.max(10, Math.min(height - 6, point.labelY + 1));
+        point.labelY = Math.max(12, Math.min(height - 4, point.labelY));
+      });
+
+      const layer = svg.append('g');
+      layer.selectAll('circle')
+        .data(placements)
+        .enter()
+        .append('circle')
+        .attr('cx', (point) => point.xPixel)
+        .attr('cy', (point) => point.dotY)
+        .attr('r', 3.2)
+        .attr('fill', (point) => point.color)
+        .attr('stroke', 'rgba(255,255,255,0.92)')
+        .attr('stroke-width', 1)
+        .style('cursor', (point) => (onOverlayPointClick && point.playerKey ? 'pointer' : 'default'))
+        .on('mousemove', (event, point) => {
+          const fallback = `${point.fullLabel} - ${point.value.toFixed(1)} ${overlayValueLabel} (${point.gamesPlayed} ${overlayCountLabel})`;
+          setTooltip({
+            visible: true,
+            x: event.clientX + 10,
+            y: event.clientY + 10,
+            text: point.tooltipLines.length > 0 ? point.tooltipLines.join('\n') : fallback,
+          });
+        })
+        .on('mouseleave', () => setTooltip((prev) => ({ ...prev, visible: false })))
+        .on('click', (_, point) => {
+          if (onOverlayPointClick && point.playerKey) {
+            onOverlayPointClick(point.playerKey);
+          }
+        });
+
+      layer.selectAll('text')
+        .data(placements)
+        .enter()
+        .append('text')
+        .attr('x', (point) => point.labelX)
+        .attr('y', (point) => point.labelY)
+        .attr('fill', (point) => point.color)
+        .attr('font-size', '14px')
+        .attr('font-weight', 680)
+        .attr('paint-order', 'stroke')
+        .attr('stroke', 'rgba(8,11,20,0.98)')
+        .attr('stroke-width', 4)
+        .style('cursor', (point) => (onOverlayPointClick && point.playerKey ? 'pointer' : 'default'))
+        .style('text-decoration', (point) => (onOverlayPointClick && point.playerKey ? 'underline' : 'none'))
+        .text((point) => point.label)
+        .on('mousemove', (event, point) => {
+          const fallback = `${point.fullLabel} - ${point.value.toFixed(1)} ${overlayValueLabel} (${point.gamesPlayed} ${overlayCountLabel})`;
+          setTooltip({
+            visible: true,
+            x: event.clientX + 10,
+            y: event.clientY + 10,
+            text: point.tooltipLines.length > 0 ? point.tooltipLines.join('\n') : fallback,
+          });
+        })
+        .on('mouseleave', () => setTooltip((prev) => ({ ...prev, visible: false })))
+        .on('click', (_, point) => {
+          if (onOverlayPointClick && point.playerKey) {
+            onOverlayPointClick(point.playerKey);
+          }
+        });
+    } else {
+      const yMax = Math.max(1, Number(d3.max(binsData, (d) => d.count) || 0));
+      const yScale = d3.scaleLinear()
+        .domain([0, yMax])
+        .range([height, 0]);
+
+      const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
+      svg.append('g')
+        .attr('transform', `translate(0, ${height})`)
+        .call(xAxis)
+        .selectAll('text')
+        .attr('fill', '#fff');
+      svg.append('g')
+        .call(d3.axisLeft(yScale))
+        .selectAll('text')
+        .attr('fill', '#fff');
+
+      if (Number.isFinite(mean) && Number.isFinite(stddev) && stddev > 0) {
+        const bandStart = Math.max(xScale.domain()[0], mean - stddev);
+        const bandEnd = Math.min(xScale.domain()[1], mean + stddev);
+        if (bandEnd > bandStart) {
+          svg.append('rect')
+            .attr('x', xScale(bandStart))
+            .attr('y', 0)
+            .attr('width', xScale(bandEnd) - xScale(bandStart))
+            .attr('height', height)
+            .attr('fill', '#9ec5ff')
+            .attr('opacity', 0.12);
+        }
+      }
+
+      svg.selectAll('.bar')
+        .data(binsData)
+        .enter()
+        .append('rect')
+        .attr('class', 'bar')
+        .attr('x', (d) => xScale(d.x0))
+        .attr('y', (d) => yScale(d.count))
+        .attr('width', (d) => Math.max(0, xScale(d.x1) - xScale(d.x0) - 1))
+        .attr('height', (d) => height - yScale(d.count))
+        .attr('fill', DEFAULT_COLORS[0])
+        .attr('opacity', 0.7);
+
+      const curvePoints = binsData.map((bin) => ({
+        x: (Number(bin.x0) + Number(bin.x1)) / 2,
+        y: Number(bin.count) || 0,
+      }));
+      const lineBuilder = d3.line()
+        .x((d) => xScale(d.x))
+        .y((d) => yScale(d.y))
+        .curve(d3.curveCatmullRom.alpha(0.5));
+      if (curvePoints.length >= 2) {
+        svg.append('path')
+          .datum(curvePoints)
+          .attr('fill', 'none')
+          .attr('stroke', '#e5ecff')
+          .attr('stroke-width', 2)
+          .attr('opacity', 0.85)
+          .attr('d', lineBuilder);
+      }
+
+      if (Number.isFinite(mean)) {
+        svg.append('line')
+          .attr('x1', xScale(mean))
+          .attr('x2', xScale(mean))
+          .attr('y1', 0)
+          .attr('y2', height)
+          .attr('stroke', '#f59e0b')
+          .attr('stroke-width', 2)
+          .attr('stroke-dasharray', '5,4');
+      }
+    }
+
+    svg.append("text")
+      .attr("text-anchor", "end")
+      .attr("x", width)
+      .attr("y", height + 35)
+      .attr('fill', '#fff')
+      .attr('font-size', '12px')
+      .text(config?.x_axis_label || config?.histogram_value_column || 'Value');
+
+    svg.append("text")
+      .attr("text-anchor", "middle")
+      .attr("x", -height / 2)
+      .attr("y", -44)
+      .attr("transform", "rotate(-90)")
+      .attr('fill', '#fff')
+      .attr('font-size', '12px')
+      .text(config?.y_axis_label || 'Count');
+
+  }, [data, config, dimensions]);
+
+  const hasPrecomputedBins = Array.isArray(config?.precomputed_bins) && config.precomputed_bins.length > 0;
+  if ((!data || data.length === 0) && !hasPrecomputedBins) {
+    return <div className="chart-empty">No data available</div>;
+  }
+
+  const chartHeight = Number(config?.chart_height);
+  const resolvedHeight = Number.isFinite(chartHeight) && chartHeight > 0 ? `${Math.round(chartHeight)}px` : '100%';
+  const minHeight = Number.isFinite(chartHeight) && chartHeight > 0 ? `${Math.round(chartHeight)}px` : '300px';
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: resolvedHeight, minHeight, overflow: 'hidden', position: 'relative' }}>
+      <svg ref={svgRef} className="histogram" style={{ width: '100%', height: '100%', display: 'block' }} />
+      {tooltip.visible ? (
+        <div
+          style={{
+            position: 'fixed',
+            left: `${tooltip.x}px`,
+            top: `${tooltip.y}px`,
+            background: 'rgba(7, 11, 22, 0.96)',
+            border: '1px solid rgba(170, 196, 255, 0.45)',
+            color: '#e7efff',
+            borderRadius: '7px',
+            padding: '6px 8px',
+            fontSize: '12px',
+            pointerEvents: 'none',
+            zIndex: 9999,
+            whiteSpace: 'pre-line',
+          }}
+        >
+          {tooltip.text}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default Histogram;
+

--- a/internal/dashboard/frontend/src/lib/componentRefs.test.js
+++ b/internal/dashboard/frontend/src/lib/componentRefs.test.js
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Regression guard for #147: a JSX component (`<Histogram .../>`) was rendered
+// after its import + definition had been deleted. Vite/esbuild does NOT flag
+// references to undefined identifiers, so the build stayed green while the tab
+// crashed at runtime with "Histogram is not defined". This test statically
+// resolves every capitalised JSX tag in our source to an import or a local
+// definition, catching that whole class of bug before it ships.
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Tags that look capitalised but are not user components needing a binding.
+const IGNORED_TAGS = new Set(['React', 'Fragment']);
+
+function listJsxFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listJsxFiles(full));
+    } else if (entry.endsWith('.jsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Names brought into scope: imports (default / named / namespace) plus
+// local declarations (const/let/var/function/class).
+function collectBoundNames(src) {
+  const names = new Set();
+
+  for (const m of src.matchAll(/import\s+([\s\S]*?)\s+from\s+['"][^'"]+['"]/g)) {
+    const clause = m[1];
+    // default and namespace specifiers: `Foo`, `* as Foo`
+    for (const d of clause.matchAll(/(?:^|,)\s*(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s*(?=,|{|$)/g)) {
+      names.add(d[1]);
+    }
+    // named specifiers inside { ... }, honouring `as` aliases
+    const braced = clause.match(/\{([\s\S]*?)\}/);
+    if (braced) {
+      for (const part of braced[1].split(',')) {
+        const t = part.trim();
+        if (!t) continue;
+        const alias = t.split(/\s+as\s+/).pop().trim();
+        if (alias) names.add(alias);
+      }
+    }
+  }
+
+  for (const m of src.matchAll(/\b(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g)) {
+    names.add(m[1]);
+  }
+
+  return names;
+}
+
+// Capitalised JSX opening tags, e.g. `<Histogram` or `<Foo.Bar` (root = Foo).
+function collectComponentRefs(src) {
+  const refs = new Set();
+  for (const m of src.matchAll(/<([A-Z][\w$]*)/g)) {
+    refs.add(m[1].split('.')[0]);
+  }
+  return refs;
+}
+
+test('every JSX component reference resolves to an import or local definition', () => {
+  const files = listJsxFiles(SRC_DIR);
+  assert.ok(files.length > 0, 'expected to find .jsx source files');
+
+  const problems = [];
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    const bound = collectBoundNames(src);
+    for (const ref of collectComponentRefs(src)) {
+      if (IGNORED_TAGS.has(ref)) continue;
+      if (!bound.has(ref)) {
+        problems.push(`${path.relative(SRC_DIR, file)}: <${ref}> is used but never imported or defined`);
+      }
+    }
+  }
+
+  assert.deepEqual(problems, [], `Unresolved JSX components:\n${problems.join('\n')}`);
+});

--- a/internal/dashboard/frontend/src/lib/mainRoute.js
+++ b/internal/dashboard/frontend/src/lib/mainRoute.js
@@ -32,6 +32,22 @@ export const MAIN_PLAYER_TABS = [
 
 export const MAIN_PLAYER_SKILL_PROXY_SUBTABS = ['summary', 'usage-signals'];
 
+/**
+ * Whether the player Skill-proxies "Population comparison" insights should be
+ * fetched for the current view state. Gated on the tab alone — the player
+ * Skill-proxies surface renders the same population cards for every subtab, so
+ * the loader must not hinge on a specific subtab value. (Regression #147: the
+ * in-page tab button set the subtab to '' while the loader required 'summary',
+ * leaving the panel permanently empty.)
+ * @param {{ activeView: string, selectedPlayerKey: string, mainPlayerTab: string }} s
+ * @returns {boolean}
+ */
+export function shouldLoadPlayerSkillProxyInsights(s) {
+  if (!s || s.activeView !== 'player') return false;
+  if (!s.selectedPlayerKey) return false;
+  return s.mainPlayerTab === 'skill-proxies';
+}
+
 const normalizeSearch = (search) => {
   if (!search || search === '?') return '';
   return String(search).startsWith('?') ? search.slice(1) : search;

--- a/internal/dashboard/frontend/src/lib/mainRoute.test.js
+++ b/internal/dashboard/frontend/src/lib/mainRoute.test.js
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseMainRouteSearch,
+  buildMainRouteSearch,
+  shouldLoadPlayerSkillProxyInsights,
+  MAIN_PLAYER_SKILL_PROXY_SUBTABS,
+} from './mainRoute.js';
+
+// Regression coverage for #147: the player Skill-proxies "Population
+// comparison" panel went permanently empty because the in-page tab button set
+// the subtab to '' while the insight loader required subtab === 'summary'.
+
+test('shouldLoadPlayerSkillProxyInsights: fires for any subtab while on skill-proxies', () => {
+  const base = { activeView: 'player', selectedPlayerKey: 'chobo86', mainPlayerTab: 'skill-proxies' };
+  // The exact bug: button set subtab to '' — must still load.
+  assert.equal(shouldLoadPlayerSkillProxyInsights(base), true);
+  // And it must not regress for the canonical / alternate subtab values either.
+  for (const sub of ['', 'summary', 'usage-signals', undefined]) {
+    assert.equal(
+      shouldLoadPlayerSkillProxyInsights({ ...base, mainPlayerSubtab: sub }),
+      true,
+      `expected load for subtab=${JSON.stringify(sub)}`,
+    );
+  }
+});
+
+test('shouldLoadPlayerSkillProxyInsights: does not fire outside the skill-proxies tab', () => {
+  assert.equal(
+    shouldLoadPlayerSkillProxyInsights({ activeView: 'player', selectedPlayerKey: 'x', mainPlayerTab: 'summary' }),
+    false,
+  );
+  assert.equal(
+    shouldLoadPlayerSkillProxyInsights({ activeView: 'player', selectedPlayerKey: 'x', mainPlayerTab: 'recent-games' }),
+    false,
+  );
+});
+
+test('shouldLoadPlayerSkillProxyInsights: requires player view and a selected player', () => {
+  assert.equal(
+    shouldLoadPlayerSkillProxyInsights({ activeView: 'games', selectedPlayerKey: 'x', mainPlayerTab: 'skill-proxies' }),
+    false,
+  );
+  assert.equal(
+    shouldLoadPlayerSkillProxyInsights({ activeView: 'player', selectedPlayerKey: '', mainPlayerTab: 'skill-proxies' }),
+    false,
+  );
+  assert.equal(shouldLoadPlayerSkillProxyInsights(null), false);
+});
+
+test('skill-proxies subtab normalizes to summary and round-trips', () => {
+  // Bare skill-proxies link → canonical summary subtab.
+  const parsed = parseMainRouteSearch('?view=player&player=chobo86&playerTab=skill-proxies');
+  assert.equal(parsed.playerTab, 'skill-proxies');
+  assert.equal(parsed.playerSubtab, 'summary');
+  assert.ok(MAIN_PLAYER_SKILL_PROXY_SUBTABS.includes(parsed.playerSubtab));
+
+  // An empty subtab (what the tab button used to set) still resolves to summary.
+  const built = buildMainRouteSearch({
+    activeView: 'player',
+    selectedPlayerKey: 'chobo86',
+    mainPlayerTab: 'skill-proxies',
+    mainPlayerSubtab: '',
+  });
+  assert.equal(parseMainRouteSearch(`?${built}`).playerSubtab, 'summary');
+});


### PR DESCRIPTION
Fixes https://github.com/marianogappa/screpdb/issues/147

## Problem

Per #147, the Skill-proxies surfaces were either always empty or crashing the UI. Two independent regressions were responsible:

### 1. Player → Skill proxies: always empty
The in-page **Skill proxies** tab button set the skill-proxy subtab to `''` (introduced in #116), but the insight loader still required `mainPlayerSubtab === 'summary'`. So clicking the tab bailed out early and the **Population comparison** cards never fetched. (Direct URL nav worked because the route normalizer defaults the subtab to `summary` — which is why it was intermittent.)

**Fix:** restore the canonical `'summary'` subtab on click, and gate the loader on the tab alone via a new pure `shouldLoadPlayerSkillProxyInsights()` helper, so an empty subtab can't silently break it again.

### 2. Replay report + Players view: crashing
#135 deleted `components/charts/Histogram.jsx` (417 lines) and its import from `App.jsx`, but left **6** `<Histogram>` usages. esbuild doesn't flag undefined identifiers, so the build passed while these tabs threw `ReferenceError: Histogram is not defined` at runtime and unmounted the app:
- Game report → Skill proxies → *Unit production cadence*, *Viewport multitasking*
- Players view → *APM Histogram*, *First Unit Delay*, *Unit Production Cadence*, *Viewport Multitasking*

**Fix:** restore the component from `194fe17^` (usages were never changed, so it matches) and re-add the import.

## Integration testing (issue's second point)

CI ran `go test ./...` but had **no JS test step**. This PR adds a zero-dependency `node --test` suite, wired via `npm test`, a `make ui-test` target, and a CI step:
- `mainRoute.test.js` — locks the route/loader contract that broke (loader fires for any subtab incl. `''`; skill-proxies subtab round-trips to `summary`).
- `componentRefs.test.js` — static guard resolving every capitalized JSX tag to an import or local definition. Verified it **fails** on the missing Histogram import and **passes** once restored — it catches the whole "used-but-undefined component" class.

## Verification

Ran the real dashboard against `screp.db`:

| Surface | Before | After |
|---|---|---|
| Player → Skill proxies (in-page click) | empty panel | 4 cards render (APM 135.2, viewport 10.89/min, delay 5.08s, cadence 2.401) |
| Game → cadence / viewport | `ReferenceError`, crash to home | histogram SVG + 8 player rows |
| Players → all 4 insight tabs | crash | histograms render |

Zero console errors after exercising all tabs. `make ui-test` → 5/5 pass; `go build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
