### PR TITLE
fix(events): re-snapshot teams at Finalize so allies aren't shown attacking each other (closes #146)

### DIFF
--- a/internal/patterns/worldstate/engine.go
+++ b/internal/patterns/worldstate/engine.go
@@ -329,6 +329,18 @@ func (e *Engine) Finalize() {
 	}
 	e.finalized = true
 
+	// Re-snapshot teams from the player pointers. NewEngine captured p.Team at
+	// Initialize time, but the parser's alliance-fallback pass rewrites p.Team
+	// afterwards for FFA / Big Game Hunters replays where screp left every
+	// player at team 0 (resolving teams from in-game alliance commands). Those
+	// pointers are the same ones the engine holds, so reading them here picks
+	// up the resolved teams. Without this, BuildAttacks would see the stale
+	// all-zero snapshot — which sameTeamByMap treats as "unknown" — and report
+	// allied players attacking each other. See issue #146.
+	for pid, p := range e.players {
+		e.teams[pid] = p.Team
+	}
+
 	var ownership []PolyOwnership
 	var candidates []CandidateAttack
 

--- a/internal/patterns/worldstate/engine_test.go
+++ b/internal/patterns/worldstate/engine_test.go
@@ -525,6 +525,42 @@ func TestBuildAttacks_DoesNotEmitAttackOnTeammatePolygon(t *testing.T) {
 	}
 }
 
+// TestBuildAttacks_HonorsTeamsResolvedAfterNewEngine reproduces issue #146:
+// FFA / Big Game Hunters replays where screp leaves every player at team 0
+// have their teams resolved from in-game alliance commands by the parser's
+// fallback pass — which mutates p.Team *after* NewEngine has already
+// snapshotted the all-zero teams. Finalize must re-read the resolved teams
+// from the player pointers, otherwise allies are reported attacking each other.
+func TestBuildAttacks_HonorsTeamsResolvedAfterNewEngine(t *testing.T) {
+	replay := &models.Replay{DurationSeconds: 900, MapWidth: 128, MapHeight: 128}
+	// Both players start unresolved (team 0), as screp leaves them on FFA maps.
+	p1 := &models.Player{PlayerID: 1, SlotID: 1, Name: "T1", Race: "Terran", Team: 0, Type: models.PlayerTypeHuman}
+	p2 := &models.Player{PlayerID: 2, SlotID: 2, Name: "T2", Race: "Terran", Team: 0, Type: models.PlayerTypeHuman}
+	engine := NewEngine(replay, []*models.Player{p1, p2}, rushProxyTestMapContext())
+
+	for i := 0; i < 15; i++ {
+		engine.ProcessCommand(&models.Command{
+			Player:               p1,
+			ActionType:           "Targeted Order",
+			OrderName:            stringPtr("Attack Move"),
+			X:                    intPtr(tilePixel(40)),
+			Y:                    intPtr(tilePixel(40)),
+			SecondsFromGameStart: 360 + i,
+		})
+	}
+
+	// Alliance fallback resolves both onto the same team after NewEngine but
+	// before Finalize, mutating the same player pointers the engine holds.
+	p1.Team = 1
+	p2.Team = 1
+
+	for _, ev := range engine.ReplayEvents() {
+		if ev.EventType == "attack" || ev.EventType == "scout" {
+			t.Fatalf("expected no %s event once alliance-resolved teams mark the players as allies, got %+v", ev.EventType, ev)
+		}
+	}
+}
+
 func TestBuildAttacks_DoesNotEmitDropOnTeammatePolygon(t *testing.T) {
 	replay := &models.Replay{DurationSeconds: 900, MapWidth: 128, MapHeight: 128}
 	p1 := &models.Player{PlayerID: 1, SlotID: 1, Name: "T1", Race: "Terran", Team: 1, Type: models.PlayerTypeHuman}

--- a/internal/patterns/worldstate/testdata/recalls_golden.json
+++ b/internal/patterns/worldstate/testdata/recalls_golden.json
@@ -266,8 +266,7 @@
         "count": 1,
         "source_label": "7",
         "target_label": "5",
-        "target_via": "p",
-        "target_owner_pid": 7
+        "target_via": "p"
       },
       {
         "second": 1621,


### PR DESCRIPTION
## Problem

In FFA / Big Game Hunters replays, the matchup header showed correctly-resolved teams (e.g. `-=FallenAngel=-` & `chobo86` allied), yet **Game Events reported those same allies attacking each other** ([#146](https://github.com/marianogappa/screpdb/issues/146)).

## Root cause

A stale-snapshot ordering bug:

1. `replay.go` calls `Initialize` → `NewEngine`, which snapshots `e.teams[pid] = p.Team`.
2. `replay.go` *then* runs the **alliance-fallback** that rewrites `p.Team` for replays where screp left everyone at team 0 (resolving teams from in-game alliance commands) — but only **after** the engine already snapshotted teams as all-zero.
3. `BuildAttacks` (run at `Finalize`) used the stale all-zero `e.teams`, and `sameTeamByMap` treats team 0 as "unknown", so it never filtered allied players.

The matchup header is recomputed *post*-fallback, which is why it looked right while the events were wrong — exactly the issue title.

## Fix

Re-snapshot teams from the player pointers at the top of `Finalize`, just before `BuildAttacks`/`BuildDrops` consume them. The engine already holds the same `*models.Player` pointers the parser mutates, so this picks up the resolved teams regardless of call ordering.

## Verification

- Added `TestBuildAttacks_HonorsTeamsResolvedAfterNewEngine` reproducing the mutate-after-`NewEngine` scenario. Confirmed it **fails** without the fix and **passes** with it.
- Recall golden updated by one field: a defensive recall to an *allied* base (a 2v2v2v2 where a player recalls to their teammate's base) no longer mislabels the teammate as an enemy target owner — the intended team-aware correction, matching the replay name `recalls_with_defensive.rep`.
- Full suite: **296 tests pass across 39 packages**.

> Note: this fixes analysis at ingest time, so existing rows carry the old events until re-ingested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
