### PR TITLE
fix(melee): credit winners on multi-team melee with late alliances (closes #130)

### DIFF
--- a/internal/parser/alliances.go
+++ b/internal/parser/alliances.go
@@ -673,28 +673,19 @@ func dominantResolvedTeams(snapshots []AllianceSnapshot, durationSec int, active
 	return out
 }
 
-// DeriveWinnersFromLeaves applies the "largest remaining team wins" algorithm
-// (mirrors screp's `computeWinners` at replay.go:701-805) to the post-fallback
-// team assignments. Mutates the players slice: sets IsWinner=true on every
-// member of the detected winning team (and clears it on every other player —
-// this function is the authoritative winner setter for the fallback path).
+// winningTeamByLeaves implements screp's "largest remaining team wins" rule
+// (mirrors `computeWinners` at rep/replay.go:701-805) over an arbitrary team
+// grouping. teamOf maps each non-observer player_id to a team key (humans and
+// computers alike). Returns (winningTeamKey, true) when a single winner is
+// determined, or (0, false) when it can't be decided — the same situations in
+// which screp leaves WinnerTeam == 0.
 //
 // repSaverPID is optional. screp doesn't record a Leave Game command for the
 // replay saver, so when known we append a virtual leave for them as the last
 // leaver — that's what lets the "all non-obs players left" tie-break fire on
 // games where one team simply quit and the saver from the other team is the
 // final non-leaver.
-//
-// Bails out (no winners assigned) when the algorithm can't determine a single
-// winner. That's the same behavior screp has when WinnerTeam == 0.
-func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Command, repSaverPID *byte) {
-	for _, p := range players {
-		if p == nil {
-			continue
-		}
-		p.IsWinner = false
-	}
-
+func winningTeamByLeaves(players []*models.Player, commands []*models.Command, teamOf map[byte]byte, repSaverPID *byte) (byte, bool) {
 	teamSizes := map[byte]int{}
 	teamCompsCount := map[byte]int{}
 	nonObsCount := 0
@@ -703,10 +694,11 @@ func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Comman
 		if p == nil || p.IsObserver {
 			continue
 		}
+		team := teamOf[p.PlayerID]
 		if p.Type == "Computer" {
-			teamCompsCount[p.Team]++
+			teamCompsCount[team]++
 		} else {
-			teamSizes[p.Team]++
+			teamSizes[team]++
 		}
 		nonObsCount++
 		pidToPlayer[p.PlayerID] = p
@@ -714,7 +706,7 @@ func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Comman
 
 	for team := range teamCompsCount {
 		if teamSizes[team] == 0 {
-			return
+			return 0, false
 		}
 	}
 
@@ -735,13 +727,13 @@ func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Comman
 	}
 
 	for _, pid := range leaverPIDs {
-		if p, ok := pidToPlayer[pid]; ok {
-			teamSizes[p.Team]--
+		if _, ok := pidToPlayer[pid]; ok {
+			teamSizes[teamOf[pid]]--
 		}
 	}
 
 	if len(teamSizes) < 2 || len(leaverPIDs) == 0 {
-		return
+		return 0, false
 	}
 
 	var maxTeam byte
@@ -759,25 +751,123 @@ func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Comman
 			}
 		}
 		if count == 1 {
-			markWinnersOnTeam(players, maxTeam)
-			return
+			return maxTeam, true
 		}
 	}
 
 	if len(leaverPIDs) == nonObsCount {
 		lastPID := leaverPIDs[len(leaverPIDs)-1]
-		if last, ok := pidToPlayer[lastPID]; ok {
-			markWinnersOnTeam(players, last.Team)
+		if _, ok := pidToPlayer[lastPID]; ok {
+			return teamOf[lastPID], true
 		}
 	}
+	return 0, false
 }
 
-func markWinnersOnTeam(players []*models.Player, team byte) {
+// DeriveWinnersFromLeaves applies the "largest remaining team wins" algorithm
+// to the static `p.Team` assignments. Mutates the players slice: clears
+// IsWinner on everyone, then sets it on every member of the detected winning
+// team. Bails out (no winners assigned) when the algorithm can't determine a
+// single winner — the same behavior screp has when WinnerTeam == 0.
+func DeriveWinnersFromLeaves(players []*models.Player, commands []*models.Command, repSaverPID *byte) {
+	for _, p := range players {
+		if p == nil {
+			continue
+		}
+		p.IsWinner = false
+	}
+
+	teamOf := map[byte]byte{}
 	for _, p := range players {
 		if p == nil || p.IsObserver {
 			continue
 		}
-		if p.Team == team {
+		teamOf[p.PlayerID] = p.Team
+	}
+
+	if team, ok := winningTeamByLeaves(players, commands, teamOf, repSaverPID); ok {
+		markWinnersByTeam(players, teamOf, team)
+	}
+}
+
+// DeriveWinnersFromFinalTopology credits the winning coalition of a multi-team
+// melee using the END-OF-GAME alliance topology rather than the longest-held
+// (display) teams. This lets a coalition that formed or shifted mid-game be
+// credited correctly and — crucially — credits a stable team whose alliance
+// screp missed because computeMeleeTeams only inspects the first ~90 seconds
+// (and otherwise assigns every player a singleton team, which then ties).
+// Because the grouping is the end-of-game coalition, the credited winners can
+// span two different "original" (longest-held) display teams — that's expected
+// when alliances shifted; the Alliances tab explains why.
+//
+// Players are grouped by their largest mutual-alliance clique in the final
+// snapshot (see assignCoalitions); the same "largest remaining team after
+// leaves" rule then picks the winner.
+//
+// Non-destructive: only when a single winner coalition is determined does it
+// clear and re-set IsWinner (allied-victory semantics — a teammate who left is
+// still on the winning side). When undecidable it leaves existing IsWinner
+// flags untouched, so it never erases a winner it can't reproduce.
+func DeriveWinnersFromFinalTopology(players []*models.Player, commands []*models.Command, ar AllianceResult, repSaverPID *byte) {
+	var finalTeams [][]byte
+	if n := len(ar.Snapshots); n > 0 {
+		finalTeams = ar.Snapshots[n-1].Teams
+	}
+	coalitionOf := assignCoalitions(players, finalTeams)
+
+	team, ok := winningTeamByLeaves(players, commands, coalitionOf, repSaverPID)
+	if !ok {
+		return
+	}
+	for _, p := range players {
+		if p == nil || p.IsObserver {
+			continue
+		}
+		p.IsWinner = coalitionOf[p.PlayerID] == team
+	}
+}
+
+// assignCoalitions maps each non-observer player_id to a coalition key derived
+// from the final alliance topology. Cliques are processed largest-first (they
+// arrive pre-sorted size-desc then min-pid from mutualAllianceTeams), so each
+// player lands in their largest clique; the coalition key is the clique's
+// min pid. Players not in any clique — and computers, which never appear in the
+// alliance graph — get their own singleton coalition keyed by their own pid.
+func assignCoalitions(players []*models.Player, finalTeams [][]byte) map[byte]byte {
+	coalitionOf := map[byte]byte{}
+	for _, team := range finalTeams {
+		if len(team) == 0 {
+			continue
+		}
+		key := team[0]
+		for _, pid := range team {
+			if pid < key {
+				key = pid
+			}
+		}
+		for _, pid := range team {
+			if _, done := coalitionOf[pid]; !done {
+				coalitionOf[pid] = key
+			}
+		}
+	}
+	for _, p := range players {
+		if p == nil || p.IsObserver {
+			continue
+		}
+		if _, done := coalitionOf[p.PlayerID]; !done {
+			coalitionOf[p.PlayerID] = p.PlayerID
+		}
+	}
+	return coalitionOf
+}
+
+func markWinnersByTeam(players []*models.Player, teamOf map[byte]byte, team byte) {
+	for _, p := range players {
+		if p == nil || p.IsObserver {
+			continue
+		}
+		if teamOf[p.PlayerID] == team {
 			p.IsWinner = true
 		}
 	}

--- a/internal/parser/alliances_test.go
+++ b/internal/parser/alliances_test.go
@@ -606,6 +606,105 @@ func TestDeriveWinnersFromLeaves_AllComputerTeam_NoWinner(t *testing.T) {
 	}
 }
 
+// --- End-of-game topology winner derivation (#130) ----------------------
+
+// TestDeriveWinnersFromFinalTopology_StableTeamAlliedLate is the FallenAngel +
+// chobo86 regression: two players ally well after screp's 90s window and never
+// change, the other two leave. screp would have seen the pair as solo at 90s
+// and assigned singleton teams (no winner); the end-of-game topology credits
+// the stable pair.
+func TestDeriveWinnersFromFinalTopology_StableTeamAlliedLate(t *testing.T) {
+	a, b, c, d := p(1, 1), p(2, 2), p(3, 3), p(4, 4)
+	players := []*models.Player{a, b, c, d}
+	cmds := []*models.Command{
+		allianceCmd(180, a, 1, 2),
+		allianceCmd(181, b, 1, 2),
+		leaveCmd(600, c),
+		leaveCmd(700, d),
+	}
+	ar := AnalyzeAlliances(players, cmds, 900, emptyActivity())
+	DeriveWinnersFromFinalTopology(players, cmds, ar, nil)
+
+	if !a.IsWinner || !b.IsWinner {
+		t.Fatalf("stable allied pair should win")
+	}
+	if c.IsWinner || d.IsWinner {
+		t.Fatalf("leavers should not win")
+	}
+}
+
+// TestDeriveWinnersFromFinalTopology_WinnerSpansOriginalTeams: the longest-held
+// (display) topology is a 2v2 {1,2}/{3,4}, but late in the game 2 and 3 re-ally
+// while 1 and 4 leave. The end-of-game winning coalition {2,3} therefore spans
+// two different "original" teams — which is expected and allowed.
+func TestDeriveWinnersFromFinalTopology_WinnerSpansOriginalTeams(t *testing.T) {
+	a, b, c, d := p(1, 1), p(2, 2), p(3, 3), p(4, 4)
+	players := []*models.Player{a, b, c, d}
+	cmds := []*models.Command{
+		// Long-held 2v2: {1,2} and {3,4} from sec 10.
+		allianceCmd(10, a, 1, 2),
+		allianceCmd(11, b, 1, 2),
+		allianceCmd(12, c, 3, 4),
+		allianceCmd(13, d, 3, 4),
+		// Late re-alliance: 2 and 3 pair up, dropping their old partners.
+		allianceCmd(600, b, 2, 3),
+		allianceCmd(601, c, 2, 3),
+		// 1 and 4 (now solo) leave.
+		leaveCmd(750, a),
+		leaveCmd(800, d),
+	}
+	ar := AnalyzeAlliances(players, cmds, 900, emptyActivity())
+
+	// Display teams come from the longest-held 2v2: 2 and 3 are on different
+	// original teams.
+	if ar.ResolvedTeams[2] == ar.ResolvedTeams[3] {
+		t.Fatalf("expected 2 and 3 on different original (longest-held) teams")
+	}
+
+	DeriveWinnersFromFinalTopology(players, cmds, ar, nil)
+	if !b.IsWinner || !c.IsWinner {
+		t.Fatalf("end-of-game coalition {2,3} should win")
+	}
+	if a.IsWinner || d.IsWinner {
+		t.Fatalf("leavers 1 and 4 should not win")
+	}
+}
+
+// TestDeriveWinnersFromFinalTopology_FFALastManStanding: no alliances at all;
+// everyone but one leaves → the survivor wins.
+func TestDeriveWinnersFromFinalTopology_FFALastManStanding(t *testing.T) {
+	a, b, c := p(1, 1), p(2, 2), p(3, 3)
+	players := []*models.Player{a, b, c}
+	cmds := []*models.Command{leaveCmd(100, a), leaveCmd(200, b)}
+	ar := AnalyzeAlliances(players, cmds, 300, emptyActivity())
+	if ar.AnyMutualResolved {
+		t.Fatalf("no alliances expected in FFA")
+	}
+	DeriveWinnersFromFinalTopology(players, cmds, ar, nil)
+	if a.IsWinner || b.IsWinner {
+		t.Fatalf("leavers should not win")
+	}
+	if !c.IsWinner {
+		t.Fatalf("last player standing should win")
+	}
+}
+
+// TestDeriveWinnersFromFinalTopology_NonDestructive: when no winner can be
+// determined (no leaves), existing IsWinner flags are left untouched.
+func TestDeriveWinnersFromFinalTopology_NonDestructive(t *testing.T) {
+	a, b, c := p(1, 1), p(2, 2), p(3, 3)
+	a.IsWinner = true // pretend a prior stage credited this player
+	players := []*models.Player{a, b, c}
+	ar := AnalyzeAlliances(players, nil, 300, emptyActivity())
+	DeriveWinnersFromFinalTopology(players, nil, ar, nil)
+	if !a.IsWinner {
+		t.Fatalf("existing winner flag should be preserved when undecidable")
+	}
+	if b.IsWinner || c.IsWinner {
+		t.Fatalf("no new winners should be set when undecidable")
+	}
+}
+
 func TestIsStacking(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/parser/replay.go
+++ b/internal/parser/replay.go
@@ -216,10 +216,14 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 		allianceResult = &ar
 		data.Replay.TeamStacking = ar.TeamStackingFlag
 
-		// Hybrid team strategy: trust screp when it resolved teams; only fall
-		// back to our derivation if screp left every active player at team=0.
-		fellBack := false
-		if allActiveTeamsZero(data.Players) && ar.AnyMutualResolved {
+		// Team DISPLAY: prefer our full-game longest-held topology ("original
+		// teams") whenever we observed real mutual alliances. screp's
+		// computeMeleeTeams only inspects the first ~90s and, finding no
+		// alliance there, assigns every player a distinct singleton team — so
+		// trusting it would miss alliances that form later. A single static set
+		// can't capture alliance dynamism; longest-held is the most
+		// representative, and the Alliances tab shows the full timeline.
+		if ar.AnyMutualResolved {
 			for _, p := range data.Players {
 				if p.IsObserver || p.Type == "Computer" {
 					continue
@@ -229,29 +233,24 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 				}
 			}
 			data.Replay.TeamFormat, data.Replay.Matchup = computeTeamFormatAndMatchup(data.Players)
-			fellBack = true
 		}
 
 		if !allActivePlayersHaveTeam(data.Players) {
 			data.Replay.TeamInfoIncomplete = true
-			// screp's WinnerTeam was computed against the original (all-zero)
-			// team values; suppress winner claims when our derivation also
-			// couldn't fully resolve teams.
-			for _, p := range data.Players {
-				p.IsWinner = false
-			}
-		} else if fellBack {
-			// Our derivation produced a usable team partition. screp skipped
-			// winner detection (its `len(teamSizes) < 2` early-exit fires when
-			// every non-obs player is on team 0), so re-run the same algorithm
-			// against our teams.
-			var repSaverPID *byte
-			if rep.Computed != nil && rep.Computed.RepSaverPlayerID != nil {
-				v := *rep.Computed.RepSaverPlayerID
-				repSaverPID = &v
-			}
-			DeriveWinnersFromLeaves(data.Players, data.Commands, repSaverPID)
 		}
+
+		// Winner attribution is authoritative for multi-team melee and is
+		// decoupled from the display teams: it groups players by the
+		// END-OF-GAME alliance coalition, so a stable team that allied after
+		// screp's 90s window still gets credited, and a coalition that won may
+		// span two "original" display teams. Runs even when team assignment is
+		// incomplete — a clear surviving coalition is still a clear winner.
+		var repSaverPID *byte
+		if rep.Computed != nil && rep.Computed.RepSaverPlayerID != nil {
+			v := *rep.Computed.RepSaverPlayerID
+			repSaverPID = &v
+		}
+		DeriveWinnersFromFinalTopology(data.Players, data.Commands, ar, repSaverPID)
 	}
 
 	// Run the early-game spam filter before pattern detection so the
@@ -340,20 +339,6 @@ func countActiveMeleePlayers(players []*models.Player) int {
 		n++
 	}
 	return n
-}
-
-// allActiveTeamsZero reports whether every non-observer non-computer player
-// has Team==0 — the signal that screp gave up on team derivation.
-func allActiveTeamsZero(players []*models.Player) bool {
-	for _, p := range players {
-		if p == nil || p.IsObserver || p.Type == "Computer" {
-			continue
-		}
-		if p.Team != 0 {
-			return false
-		}
-	}
-	return true
 }
 
 // allActivePlayersHaveTeam returns true once every active player has a non-zero


### PR DESCRIPTION
## Problem

On multi-team **Melee** games, winners often weren't credited (no crowns) — even for a stable team that *never* changed alliances and clearly won (e.g. FallenAngel + chobo86).

### Root cause

screp's melee team detection (`computeMeleeTeams`) only inspects alliance commands in the **first ~90 seconds**. Alliances usually form minutes in, so screp finds none in that window and assigns every player a distinct **singleton team**. Our pipeline only ran its own full-game alliance analysis when screp left *all* teams at zero (`allActiveTeamsZero`), so screp's non-zero singleton teams blocked it entirely — and screp's own winner detection can't pick a unique largest team among singletons → `WinnerTeam == 0` → no `is_winner` set.

## Changes

- **`replay.go`**: Use our full-game longest-held topology for the displayed "original teams" whenever mutual alliances exist (no longer gated on screp leaving teams at zero). Always run authoritative winner derivation, including when team assignment is incomplete.
- **`alliances.go`**: Extract the shared "largest remaining team after leaves" core (`winningTeamByLeaves`). Add `DeriveWinnersFromFinalTopology`, which groups players by their **end-of-game** mutual-alliance coalition. This credits a stable team that allied late, allows a winning coalition to span two "original" display teams when alliances shifted (the Alliances tab explains why), and handles FFA last-man-standing. It's **non-destructive** — only overrides `IsWinner` when a winner is confidently determined.

### Design decisions (per discussion)

1. Team **display** keeps the longest-held topology ("original teams") — a single static set can't capture dynamism.
2. **Winner** is the end-of-game surviving coalition, decoupled from display teams, so credited winners may span two original teams.
3. Winners are attributed even when team assignment is incomplete.

## Tests

New unit tests in `alliances_test.go`: stable-team-allied-late (the FA/chobo regression), winner-spans-original-teams, FFA-last-man-standing, non-destructive-when-undecidable. Existing `DeriveWinnersFromLeaves` tests pass through the refactor.

- `go build ./...` ✓ · `go vet` ✓ · `go test ./...` → **300 passed** across 39 packages (incl. the `bgh.rep` real-replay smoke test through the changed path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
