### PR TITLE
feat: expert timings for composition Terran build orders (closes #158)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -684,7 +684,7 @@ Standalone constants the detectors depend on — dedup windows, muta/turret burs
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| Algorithm version | 29 | Detection algorithm revision; incremented to trigger re-detection. |
+| Algorithm version | 30 | Detection algorithm revision; incremented to trigger re-detection. |
 | Build dedup gap (s) | 3 | Repeat Build orders of the same building at the same tile, closer than this, are one event (double-tap / misclick); different-tile placements are kept. |
 | Build dedup max second (s) | 240 | Past this second, dedup stops and every Build is observed as-is (a tile can be legitimately rebuilt on later). |
 | Mutalisk burst window (s) | 30 | Window within which the Mutalisk morphs must cluster. |

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -415,6 +415,22 @@ The openings screpdb recognizes and each milestone's "progamer ideal" timing. Th
 | 1 Gate Core | Protoss | Gateway | 86 | ±6 |
 | 1 Gate Core | Protoss | Assimilator | 116 | ±10 |
 | 1 Gate Core | Protoss | Cybernetics Core | 138 | ±10 |
+| 1-1-1 | Terran | Supply Depot | 57 | −10 / +24 |
+| 1-1-1 | Terran | Barracks | 85 | −28 / +20 |
+| 1-1-1 | Terran | Refinery | 98 | −15 / +70 |
+| 1-1-1 | Terran | Factory | 160 | −15 / +70 |
+| 1-1-1 | Terran | Starport | 226 | −40 / +80 |
+| 1-1-1 | Terran | First Wraith | 271 | −40 / +90 |
+| 1-1-1 into Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 1-1-1 into Mech | Terran | Barracks | 85 | −26 / +18 |
+| 1-1-1 into Mech | Terran | Refinery | 99 | −12 / +70 |
+| 1-1-1 into Mech | Terran | Factory | 153 | −12 / +80 |
+| 1-1-1 into Mech | Terran | Starport | 254 | −50 / +70 |
+| 1-1-1 into Mech | Terran | First Siege Tank | 312 | −80 / +120 |
+| 1-Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 1-Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 1-Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 1-Rax Bio | Terran | Academy | 230 | −45 / +90 |
 | 10 Hatch | Zerg | Hatchery | 80 | ±5 |
 | 10 Hatch | Zerg | Spawning Pool | 110 | −3 / +10 |
 | 10 Pool | Zerg | Spawning Pool | 92 | ±5 |
@@ -431,18 +447,103 @@ The openings screpdb recognizes and each milestone's "progamer ideal" timing. Th
 | 2 Gate | Protoss | 1st Gateway | 70 | ±6 |
 | 2 Gate | Protoss | 2nd Gateway | 86 | ±10 |
 | 2 Gate | Protoss | First Zealot | 108 | ±3 |
+| 2-Fac Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 2-Fac Mech | Terran | Barracks | 85 | −26 / +18 |
+| 2-Fac Mech | Terran | Refinery | 100 | −12 / +70 |
+| 2-Fac Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 2-Fac Mech | Terran | 2nd Factory | 275 | −90 / +130 |
+| 2-Fac Mech | Terran | First Siege Tank | 290 | −60 / +120 |
+| 2-Fac Tankless Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 2-Fac Tankless Mech | Terran | Barracks | 85 | −26 / +18 |
+| 2-Fac Tankless Mech | Terran | Refinery | 100 | −12 / +70 |
+| 2-Fac Tankless Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 2-Fac Tankless Mech | Terran | First Vulture | 205 | −20 / +50 |
+| 2-Fac Tankless Mech | Terran | 2nd Factory | 243 | −90 / +130 |
+| 2-Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 2-Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 2-Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 2-Rax Bio | Terran | 2nd Barracks | 220 | −90 / +130 |
+| 2-Rax Bio | Terran | Academy | 230 | −45 / +90 |
+| 3-Fac Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 3-Fac Mech | Terran | Barracks | 85 | −26 / +18 |
+| 3-Fac Mech | Terran | Refinery | 100 | −12 / +70 |
+| 3-Fac Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 3-Fac Mech | Terran | First Siege Tank | 290 | −60 / +120 |
+| 3-Fac Mech | Terran | 3rd Factory | 458 | −90 / +130 |
+| 3-Fac Tankless Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 3-Fac Tankless Mech | Terran | Barracks | 85 | −26 / +18 |
+| 3-Fac Tankless Mech | Terran | Refinery | 100 | −12 / +70 |
+| 3-Fac Tankless Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 3-Fac Tankless Mech | Terran | First Vulture | 205 | −20 / +50 |
+| 3-Fac Tankless Mech | Terran | 3rd Factory | 349 | −90 / +130 |
+| 3-Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 3-Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 3-Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 3-Rax Bio | Terran | Academy | 230 | −45 / +90 |
+| 3-Rax Bio | Terran | 3rd Barracks | 342 | −90 / +130 |
 | 4 Hatch | Zerg | Hatchery | 40 | ±6 |
 | 4 Hatch | Zerg | Spawning Pool | 70 | −6 / +12 |
 | 4 Pool | Zerg | Spawning Pool | 33 | ±4 |
 | 4 Pool | Zerg | First Zerglings | 83 | ±3 |
+| 4-Fac Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 4-Fac Mech | Terran | Barracks | 85 | −26 / +18 |
+| 4-Fac Mech | Terran | Refinery | 100 | −12 / +70 |
+| 4-Fac Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 4-Fac Mech | Terran | First Siege Tank | 290 | −60 / +120 |
+| 4-Fac Mech | Terran | 4th Factory | 480 | −90 / +130 |
+| 4-Fac Tankless Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 4-Fac Tankless Mech | Terran | Barracks | 85 | −26 / +18 |
+| 4-Fac Tankless Mech | Terran | Refinery | 100 | −12 / +70 |
+| 4-Fac Tankless Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 4-Fac Tankless Mech | Terran | First Vulture | 205 | −20 / +50 |
+| 4-Fac Tankless Mech | Terran | 4th Factory | 422 | −90 / +130 |
+| 4-Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 4-Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 4-Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 4-Rax Bio | Terran | Academy | 230 | −45 / +90 |
+| 4-Rax Bio | Terran | 4th Barracks | 355 | −90 / +130 |
 | 5 Hatch | Zerg | Hatchery | 50 | ±6 |
 | 5 Hatch | Zerg | Spawning Pool | 80 | −6 / +12 |
 | 5 Pool | Zerg | Spawning Pool | 45 | ±5 |
 | 5 Pool | Zerg | First Zerglings | 95 | ±4 |
+| 5-Fac Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 5-Fac Mech | Terran | Barracks | 85 | −26 / +18 |
+| 5-Fac Mech | Terran | Refinery | 100 | −12 / +70 |
+| 5-Fac Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 5-Fac Mech | Terran | First Siege Tank | 290 | −60 / +120 |
+| 5-Fac Mech | Terran | 5th Factory | 501 | −90 / +130 |
+| 5-Fac Tankless Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 5-Fac Tankless Mech | Terran | Barracks | 85 | −26 / +18 |
+| 5-Fac Tankless Mech | Terran | Refinery | 100 | −12 / +70 |
+| 5-Fac Tankless Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 5-Fac Tankless Mech | Terran | First Vulture | 205 | −20 / +50 |
+| 5-Fac Tankless Mech | Terran | 5th Factory | 471 | −90 / +130 |
+| 5-Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 5-Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 5-Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 5-Rax Bio | Terran | Academy | 230 | −45 / +90 |
+| 5-Rax Bio | Terran | 5th Barracks | 476 | −90 / +130 |
 | 6 Hatch | Zerg | Hatchery | 58 | ±6 |
 | 6 Hatch | Zerg | Spawning Pool | 88 | −6 / +12 |
 | 6 Pool | Zerg | Spawning Pool | 52 | ±5 |
 | 6 Pool | Zerg | First Zerglings | 102 | ±4 |
+| 6+ Fac Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 6+ Fac Mech | Terran | Barracks | 85 | −26 / +18 |
+| 6+ Fac Mech | Terran | Refinery | 100 | −12 / +70 |
+| 6+ Fac Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 6+ Fac Mech | Terran | First Siege Tank | 290 | −60 / +120 |
+| 6+ Fac Mech | Terran | 6th Factory | 528 | −90 / +130 |
+| 6+ Fac Tankless Mech | Terran | Supply Depot | 55 | −10 / +24 |
+| 6+ Fac Tankless Mech | Terran | Barracks | 85 | −26 / +18 |
+| 6+ Fac Tankless Mech | Terran | Refinery | 100 | −12 / +70 |
+| 6+ Fac Tankless Mech | Terran | 1st Factory | 152 | −12 / +80 |
+| 6+ Fac Tankless Mech | Terran | First Vulture | 205 | −20 / +50 |
+| 6+ Fac Tankless Mech | Terran | 6th Factory | 560 | −90 / +130 |
+| 6+ Rax Bio | Terran | Supply Depot | 56 | −10 / +24 |
+| 6+ Rax Bio | Terran | Barracks | 84 | −28 / +20 |
+| 6+ Rax Bio | Terran | Refinery | 185 | −80 / +50 |
+| 6+ Rax Bio | Terran | Academy | 230 | −45 / +90 |
+| 6+ Rax Bio | Terran | 6th Barracks | 512 | −90 / +130 |
 | 7 Hatch | Zerg | Hatchery | 66 | ±6 |
 | 7 Hatch | Zerg | Spawning Pool | 96 | −6 / +12 |
 | 7 Pool | Zerg | Spawning Pool | 60 | ±5 |
@@ -477,9 +578,21 @@ The openings screpdb recognizes and each milestone's "progamer ideal" timing. Th
 | Gate Expand | Protoss | Pylon | 48 | ±4 |
 | Gate Expand | Protoss | Gateway | 88 | ±10 |
 | Gate Expand | Protoss | Nexus | 165 | ±15 |
+| Goliath | Terran | Supply Depot | 55 | −10 / +24 |
+| Goliath | Terran | Barracks | 86 | −28 / +18 |
+| Goliath | Terran | Refinery | 102 | −12 / +70 |
+| Goliath | Terran | Factory | 161 | −15 / +120 |
+| Goliath | Terran | Armory | 242 | −40 / +100 |
+| Goliath | Terran | First Goliath | 339 | −75 / +70 |
 | Nexus First | Protoss | Pylon | 48 | ±4 |
 | Nexus First | Protoss | Nexus | 145 | ±20 |
 | Nexus First | Protoss | Gateway | 175 | ±20 |
+| Wraith | Terran | Supply Depot | 56 | −10 / +24 |
+| Wraith | Terran | Barracks | 84 | −28 / +18 |
+| Wraith | Terran | Refinery | 98 | −10 / +60 |
+| Wraith | Terran | Factory | 152 | −12 / +60 |
+| Wraith | Terran | Starport | 205 | −15 / +60 |
+| Wraith | Terran | First Wraith | 253 | −20 / +70 |
 
 ## Build-order rule deadlines
 

--- a/internal/dashboard/frontend/src/components/charts/BuildOrderTimelineRows.jsx
+++ b/internal/dashboard/frontend/src/components/charts/BuildOrderTimelineRows.jsx
@@ -15,7 +15,7 @@ import { getUnitIcon } from '../../lib/gameAssets';
 //   }
 
 const LEGEND_TOOLTIP =
-  'Ranges are derived from averages across tens of thousands of progamer replays. This model is an approximation — data is imperfect and degrades as the metagame evolves.';
+  'Each gold band shows when progamers usually reach this step — averaged across tens of thousands of their games. The icon on each row is when THIS player did it: green if they landed in the usual progamer window, red if they were earlier or later. It is an approximation and drifts as the metagame changes.';
 
 const formatTime = (seconds) => {
   const value = Math.max(0, Math.floor(Number(seconds) || 0));
@@ -107,7 +107,7 @@ function BuildOrderTimelineRows({ group }) {
           style={{ marginLeft: 'auto', color: 'rgba(251, 191, 36, 1)', cursor: 'help' }}
           title={LEGEND_TOOLTIP}
         >
-          * Progamer average ranges
+          Gold band = usual progamer timing ⓘ
         </span>
       </div>
       <div ref={wrapperRef} className="workflow-timing-chart-wrap">
@@ -121,6 +121,15 @@ function BuildOrderTimelineRows({ group }) {
             const buildTime = Number(entry.build_time_seconds) || 0;
             const withinTolerance = Boolean(entry.within_tolerance);
             const found = Boolean(entry.found);
+            // Plain-language verdict for the hover tooltip. No verdict when there's
+            // no progamer range to compare against (count-only rows).
+            const actualVerdict = noExpert
+              ? null
+              : withinTolerance
+                ? 'On pace with the progamers'
+                : (actual < target - early
+                  ? 'Earlier than the usual progamer timing'
+                  : 'Later than the usual progamer timing');
             const actualColor = noExpert
               ? 'rgba(148, 197, 230, 0.95)' // neutral blue — no golden range to compare against
               : (found
@@ -195,16 +204,16 @@ function BuildOrderTimelineRows({ group }) {
                     {buildTime > 0 ? (
                       <g
                         onMouseEnter={(e) => updateHover(e, {
-                          pointKind: 'Expert build span',
+                          pointKind: 'Usual progamer timing',
                           eventKey: entry.key,
                           time: target,
-                          tol: `${buildTime}s build → ${formatTime(target + buildTime)}`,
+                          detail: `${buildTime}s to build → ready ${formatTime(target + buildTime)}`,
                         })}
                         onMouseMove={(e) => updateHover(e, {
-                          pointKind: 'Expert build span',
+                          pointKind: 'Usual progamer timing',
                           eventKey: entry.key,
                           time: target,
-                          tol: `${buildTime}s build → ${formatTime(target + buildTime)}`,
+                          detail: `${buildTime}s to build → ready ${formatTime(target + buildTime)}`,
                         })}
                         onMouseLeave={() => setHover(null)}
                       >
@@ -239,16 +248,16 @@ function BuildOrderTimelineRows({ group }) {
                     ) : null}
                     <g
                       onMouseEnter={(e) => updateHover(e, {
-                        pointKind: 'Expert target',
+                        pointKind: 'Usual progamer timing',
                         eventKey: entry.key,
                         time: target,
-                        tol: `±${early === late ? early : `${early}/${late}`}s`,
+                        detail: `progamers usually ${formatTime(target - early)} – ${formatTime(target + late)}`,
                       })}
                       onMouseMove={(e) => updateHover(e, {
-                        pointKind: 'Expert target',
+                        pointKind: 'Usual progamer timing',
                         eventKey: entry.key,
                         time: target,
-                        tol: `±${early === late ? early : `${early}/${late}`}s`,
+                        detail: `progamers usually ${formatTime(target - early)} – ${formatTime(target + late)}`,
                       })}
                       onMouseLeave={() => setHover(null)}
                     >
@@ -282,16 +291,16 @@ function BuildOrderTimelineRows({ group }) {
                     {buildTime > 0 ? (
                       <g
                         onMouseEnter={(e) => updateHover(e, {
-                          pointKind: 'Player build span',
+                          pointKind: 'This player',
                           eventKey: entry.key,
                           time: actual,
-                          tol: `${buildTime}s build → ${formatTime(actual + buildTime)}`,
+                          detail: `${buildTime}s to build → ready ${formatTime(actual + buildTime)}`,
                         })}
                         onMouseMove={(e) => updateHover(e, {
-                          pointKind: 'Player build span',
+                          pointKind: 'This player',
                           eventKey: entry.key,
                           time: actual,
-                          tol: `${buildTime}s build → ${formatTime(actual + buildTime)}`,
+                          detail: `${buildTime}s to build → ready ${formatTime(actual + buildTime)}`,
                         })}
                         onMouseLeave={() => setHover(null)}
                       >
@@ -335,16 +344,16 @@ function BuildOrderTimelineRows({ group }) {
                     </text>
                     <g
                       onMouseEnter={(e) => updateHover(e, {
-                        pointKind: 'Player actual',
+                        pointKind: 'This player',
                         eventKey: entry.key,
                         time: actual,
-                        withinTolerance,
+                        verdict: actualVerdict,
                       })}
                       onMouseMove={(e) => updateHover(e, {
-                        pointKind: 'Player actual',
+                        pointKind: 'This player',
                         eventKey: entry.key,
                         time: actual,
-                        withinTolerance,
+                        verdict: actualVerdict,
                       })}
                       onMouseLeave={() => setHover(null)}
                     >
@@ -422,12 +431,9 @@ function BuildOrderTimelineRows({ group }) {
             style={{ left: `${hover.x}px`, top: `${hover.y}px` }}
           >
             <div><strong>{hover.eventKey}</strong></div>
-            <div><strong>Point</strong> {hover.pointKind}</div>
-            <div><strong>Time</strong> {formatTime(hover.time)}</div>
-            {hover.tol ? <div><strong>Tolerance</strong> {hover.tol}</div> : null}
-            {hover.pointKind === 'Player actual' ? (
-              <div>{hover.withinTolerance ? '(within tolerance)' : '(out of tolerance)'}</div>
-            ) : null}
+            <div>{hover.pointKind} — {formatTime(hover.time)}</div>
+            {hover.detail ? <div style={{ opacity: 0.7 }}>{hover.detail}</div> : null}
+            {hover.verdict ? <div style={{ marginTop: 2 }}>{hover.verdict}</div> : null}
           </div>
         ) : null}
       </div>

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -33,7 +33,14 @@ import (
 // primitives (Predominant, time-bounded produce/build counts) and a non-1v1
 // matchup gate back them. CC First / BBS / Bunker Rush are kept; the Terran
 // residual is now "Terran (Other)" (bo_terran_other).
-const AlgorithmVersion = 29
+//
+// 30: Expert milestone timings for the composition-based Terran BOs (issue
+// #158) — Wraith, Goliath, N-Rax Bio, N-Fac Mech, N-Fac Tankless Mech, 1-1-1
+// (+ into Mech) now carry Expert events, so the detector persists their
+// expert_actuals payload. Bumped so replays analyzed under v29 (which stored an
+// empty payload for these BOs) re-analyze and populate the Build Orders chart's
+// actual-vs-expert markers.
+const AlgorithmVersion = 30
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -149,6 +149,8 @@ const (
 	subjRefinery       = models.GeneralUnitRefinery
 	subjAcademy        = models.GeneralUnitAcademy
 	subjFactory        = models.GeneralUnitFactory
+	subjMachineShop    = models.GeneralUnitMachineShop
+	subjArmory         = models.GeneralUnitArmory
 	subjStarport       = models.GeneralUnitStarport
 	subjEngineeringBay = models.GeneralUnitEngineeringBay
 	subjMissileTurret  = models.GeneralUnitMissileTurret
@@ -318,35 +320,103 @@ func allMarkers() []Marker {
 		All(tCohort, tcOneOneOne),        // plain 1-1-1
 	)
 
+	// Expert milestone timings for the composition-based Terran BOs (issue #158),
+	// mined from a corpus of ~2,860 expert/progamer replays. Each target is the
+	// median actual second across that bucket's detected games; tolerances span
+	// roughly the p10–p90 expert range (wider, and skewed late, for the macro
+	// buildings that arrive on a sliding economy timing). The opening backbone
+	// (Depot / 1st Barracks) is shared across the Terran macro openers, but gas
+	// timing splits the families — bio delays its Refinery (~185s) while mech
+	// takes early gas (~100s) — so each family carries its own opening table.
+	// Family tech (Academy for bio, 1st Factory for mech) and the bucket-defining
+	// Nth building carry the per-build signal. Nth-building tables are indexed by
+	// count (2..6); indices 0,1 are unused.
+	tBioOpening := []ExpertEvent{
+		{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 56, Tolerance: Asym(10, 24)},
+		{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 84, Tolerance: Asym(28, 20)},
+		{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 185, Tolerance: Asym(80, 50)},
+		{Key: "Academy", Match: MatchBuild(subjAcademy), TargetSecond: 230, Tolerance: Asym(45, 90)},
+	}
+	tMechOpening := []ExpertEvent{
+		{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 55, Tolerance: Asym(10, 24)},
+		{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 85, Tolerance: Asym(26, 18)},
+		{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 100, Tolerance: Asym(12, 70)},
+		{Key: "1st Factory", Match: MatchBuild(subjFactory), TargetSecond: 152, Tolerance: Asym(12, 80)},
+	}
+	tBioNthRax := [7]int{0, 0, 220, 342, 355, 476, 512}
+	tMechNthFac := [7]int{0, 0, 275, 458, 480, 501, 528}
+	tMechTank := 290
+	tTanklessNthFac := [7]int{0, 0, 243, 349, 422, 471, 560}
+	tTanklessVulture := 205
+
 	// Compact builders for the per-count composition buckets (issue #155). Each
 	// is an initial BO inside tCohort, made pairwise-disjoint by the predominance
 	// split (bio vs mech), the Tank present/absent split, the exact count, and
 	// Not(...) guards against the higher-signal Wraith/Goliath/1-1-1 rules.
 	mkPill := func(label, icon string) *Pill { return &Pill{Label: label, IconKey: icon} }
-	bioBucket := func(name, fkey string, rax Predicate) Marker {
+	// countPred builds the bucket's count predicate: an exact count for the
+	// 1..5 rungs, "at least" for the 6+ top rung.
+	countPred := func(subj string, n int, exact bool) Predicate {
+		if exact {
+			return BuildCountEqualsBefore(subj, n, 600)
+		}
+		return CountBuildsBefore(subj, n, 600)
+	}
+	// nthLabel renders the bucket-defining building milestone label, e.g.
+	// "2nd Barracks", "6th Factory".
+	nthLabel := func(n int, building string) string {
+		suffix := "th"
+		switch n {
+		case 1:
+			suffix = "st"
+		case 2:
+			suffix = "nd"
+		case 3:
+			suffix = "rd"
+		}
+		return fmt.Sprintf("%d%s %s", n, suffix, building)
+	}
+	bioBucket := func(name, fkey string, n int, exact bool) Marker {
+		ev := append([]ExpertEvent{}, tBioOpening...)
+		if n >= 2 {
+			ev = append(ev, ExpertEvent{Key: nthLabel(n, "Barracks"), Match: MatchNthBuild(subjBarracks, n), TargetSecond: tBioNthRax[n], Tolerance: Asym(90, 130)})
+		}
 		return Marker{
 			Name: name, PatternName: InitialBuildOrderPatternNamePrefix + name, FeatureKey: fkey,
 			Race: RaceTerran, Kind: KindInitialBuildOrder, Matchup: []string{"TvZ", MatchupNon1v1},
-			Rule:          All(tCohort, tcBio, Not(tcWraith), Not(tcGoliath), rax),
+			Rule:          All(tCohort, tcBio, Not(tcWraith), Not(tcGoliath), countPred(subjBarracks, n, exact)),
 			RuleDeadline:  600,
+			Expert:        ev,
 			SummaryPlayer: mkPill(name, "marine"), GamesList: mkPill(name, "marine"),
 		}
 	}
-	mechBucket := func(name, fkey string, fac Predicate) Marker {
+	mechBucket := func(name, fkey string, n int, exact bool) Marker {
+		ev := append([]ExpertEvent{}, tMechOpening...)
+		ev = append(ev,
+			ExpertEvent{Key: nthLabel(n, "Factory"), Match: MatchNthBuild(subjFactory, n), TargetSecond: tMechNthFac[n], Tolerance: Asym(90, 130)},
+			ExpertEvent{Key: "First Siege Tank", Match: MatchFirstProduce(subjSiegeTank), TargetSecond: tMechTank, Tolerance: Asym(60, 120)},
+		)
 		return Marker{
 			Name: name, PatternName: InitialBuildOrderPatternNamePrefix + name, FeatureKey: fkey,
 			Race: RaceTerran, Kind: KindInitialBuildOrder,
-			Rule:          All(tCohort, fac, tcMechPred, tcTank1, Not(tcOneOneOne), Not(tcWraith), Not(tcGoliath)),
+			Rule:          All(tCohort, countPred(subjFactory, n, exact), tcMechPred, tcTank1, Not(tcOneOneOne), Not(tcWraith), Not(tcGoliath)),
 			RuleDeadline:  600,
+			Expert:        ev,
 			SummaryPlayer: mkPill(name, "siegetank"), GamesList: mkPill(name, "siegetank"),
 		}
 	}
-	tanklessBucket := func(name, fkey string, fac Predicate) Marker {
+	tanklessBucket := func(name, fkey string, n int, exact bool) Marker {
+		ev := append([]ExpertEvent{}, tMechOpening...)
+		ev = append(ev,
+			ExpertEvent{Key: nthLabel(n, "Factory"), Match: MatchNthBuild(subjFactory, n), TargetSecond: tTanklessNthFac[n], Tolerance: Asym(90, 130)},
+			ExpertEvent{Key: "First Vulture", Match: MatchFirstProduce(subjVulture), TargetSecond: tTanklessVulture, Tolerance: Asym(20, 50)},
+		)
 		return Marker{
 			Name: name, PatternName: InitialBuildOrderPatternNamePrefix + name, FeatureKey: fkey,
 			Race: RaceTerran, Kind: KindInitialBuildOrder,
-			Rule:          All(tCohort, fac, tcMechPred, tcTank0, Not(tcWraith), Not(tcGoliath)),
+			Rule:          All(tCohort, countPred(subjFactory, n, exact), tcMechPred, tcTank0, Not(tcWraith), Not(tcGoliath)),
 			RuleDeadline:  600,
+			Expert:        ev,
 			SummaryPlayer: mkPill(name, "vulture"), GamesList: mkPill(name, "vulture"),
 		}
 	}
@@ -876,8 +946,16 @@ func allMarkers() []Marker {
 			// Wraith: TvZ air build — 2+ Starports and 5+ Wraiths by 10:00.
 			Name: "Wraith", PatternName: "Build Order: Wraith", FeatureKey: "bo_t_wraith",
 			Race: RaceTerran, Kind: KindInitialBuildOrder, Matchup: []string{"TvZ"},
-			Rule:          All(tCohort, tcWraith),
-			RuleDeadline:  600,
+			Rule:         All(tCohort, tcWraith),
+			RuleDeadline: 600,
+			Expert: []ExpertEvent{
+				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 56, Tolerance: Asym(10, 24)},
+				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 84, Tolerance: Asym(28, 18)},
+				{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 98, Tolerance: Asym(10, 60)},
+				{Key: "Factory", Match: MatchBuild(subjFactory), TargetSecond: 152, Tolerance: Asym(12, 60)},
+				{Key: "Starport", Match: MatchBuild(subjStarport), TargetSecond: 205, Tolerance: Asym(15, 60)},
+				{Key: "First Wraith", Match: MatchFirstProduce(subjWraith), TargetSecond: 253, Tolerance: Asym(20, 70)},
+			},
 			SummaryPlayer: &Pill{Label: "Wraith", IconKey: "wraith"},
 			GamesList:     &Pill{Label: "Wraith", IconKey: "wraith"},
 		},
@@ -886,48 +964,72 @@ func allMarkers() []Marker {
 			// 4+ Goliaths by 10:00 (with tanks it's Mech instead).
 			Name: "Goliath", PatternName: "Build Order: Goliath", FeatureKey: "bo_t_goliath",
 			Race: RaceTerran, Kind: KindInitialBuildOrder, Matchup: []string{"TvZ"},
-			Rule:          All(tCohort, tcGoliath, Not(tcWraith)),
-			RuleDeadline:  600,
+			Rule:         All(tCohort, tcGoliath, Not(tcWraith)),
+			RuleDeadline: 600,
+			Expert: []ExpertEvent{
+				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 55, Tolerance: Asym(10, 24)},
+				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 86, Tolerance: Asym(28, 18)},
+				{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 102, Tolerance: Asym(12, 70)},
+				{Key: "Factory", Match: MatchBuild(subjFactory), TargetSecond: 161, Tolerance: Asym(15, 120)},
+				{Key: "Armory", Match: MatchBuild(subjArmory), TargetSecond: 242, Tolerance: Asym(40, 100)},
+				{Key: "First Goliath", Match: MatchFirstProduce(subjGoliath), TargetSecond: 339, Tolerance: Asym(75, 70)},
+			},
 			SummaryPlayer: &Pill{Label: "Goliath", IconKey: "goliath"},
 			GamesList:     &Pill{Label: "Goliath", IconKey: "goliath"},
 		},
 		// Bio (Marine/Medic predominant, 8+ Marines; TvZ or non-1v1), split by
 		// Barracks count by 10:00.
-		bioBucket("1-Rax Bio", "bo_t_bio_1rax", BuildCountEqualsBefore(subjBarracks, 1, 600)),
-		bioBucket("2-Rax Bio", "bo_t_bio_2rax", BuildCountEqualsBefore(subjBarracks, 2, 600)),
-		bioBucket("3-Rax Bio", "bo_t_bio_3rax", BuildCountEqualsBefore(subjBarracks, 3, 600)),
-		bioBucket("4-Rax Bio", "bo_t_bio_4rax", BuildCountEqualsBefore(subjBarracks, 4, 600)),
-		bioBucket("5-Rax Bio", "bo_t_bio_5rax", BuildCountEqualsBefore(subjBarracks, 5, 600)),
-		bioBucket("6+ Rax Bio", "bo_t_bio_6rax", CountBuildsBefore(subjBarracks, 6, 600)),
+		bioBucket("1-Rax Bio", "bo_t_bio_1rax", 1, true),
+		bioBucket("2-Rax Bio", "bo_t_bio_2rax", 2, true),
+		bioBucket("3-Rax Bio", "bo_t_bio_3rax", 3, true),
+		bioBucket("4-Rax Bio", "bo_t_bio_4rax", 4, true),
+		bioBucket("5-Rax Bio", "bo_t_bio_5rax", 5, true),
+		bioBucket("6+ Rax Bio", "bo_t_bio_6rax", 6, false),
 		{
 			// 1-1-1 into Mech: early Starport + Wraith, then mech (≥2 Factories,
 			// ≥1 Tank, mech-predominant).
 			Name: "1-1-1 into Mech", PatternName: "Build Order: 1-1-1 into Mech", FeatureKey: "bo_t_111_mech",
 			Race: RaceTerran, Kind: KindInitialBuildOrder,
-			Rule:          All(tCohort, tcOneOneOne, tcFac2, tcMechPred, tcTank1, Not(tcWraith), Not(tcGoliath)),
-			RuleDeadline:  600,
+			Rule:         All(tCohort, tcOneOneOne, tcFac2, tcMechPred, tcTank1, Not(tcWraith), Not(tcGoliath)),
+			RuleDeadline: 600,
+			Expert: []ExpertEvent{
+				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 55, Tolerance: Asym(10, 24)},
+				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 85, Tolerance: Asym(26, 18)},
+				{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 99, Tolerance: Asym(12, 70)},
+				{Key: "Factory", Match: MatchBuild(subjFactory), TargetSecond: 153, Tolerance: Asym(12, 80)},
+				{Key: "Starport", Match: MatchBuild(subjStarport), TargetSecond: 254, Tolerance: Asym(50, 70)},
+				{Key: "First Siege Tank", Match: MatchFirstProduce(subjSiegeTank), TargetSecond: 312, Tolerance: Asym(80, 120)},
+			},
 			SummaryPlayer: &Pill{Label: "1-1-1 into Mech", IconKey: "siegetank"},
 			GamesList:     &Pill{Label: "1-1-1 into Mech", IconKey: "siegetank"},
 		},
 		// Mech (mech-predominant, ≥1 Tank), split by Factory count by 10:00.
-		mechBucket("2-Fac Mech", "bo_t_mech_2fac", BuildCountEqualsBefore(subjFactory, 2, 600)),
-		mechBucket("3-Fac Mech", "bo_t_mech_3fac", BuildCountEqualsBefore(subjFactory, 3, 600)),
-		mechBucket("4-Fac Mech", "bo_t_mech_4fac", BuildCountEqualsBefore(subjFactory, 4, 600)),
-		mechBucket("5-Fac Mech", "bo_t_mech_5fac", BuildCountEqualsBefore(subjFactory, 5, 600)),
-		mechBucket("6+ Fac Mech", "bo_t_mech_6fac", CountBuildsBefore(subjFactory, 6, 600)),
+		mechBucket("2-Fac Mech", "bo_t_mech_2fac", 2, true),
+		mechBucket("3-Fac Mech", "bo_t_mech_3fac", 3, true),
+		mechBucket("4-Fac Mech", "bo_t_mech_4fac", 4, true),
+		mechBucket("5-Fac Mech", "bo_t_mech_5fac", 5, true),
+		mechBucket("6+ Fac Mech", "bo_t_mech_6fac", 6, false),
 		// Tankless Mech (mech-predominant, no Tank by 10:00 — pure Vulture/Goliath).
-		tanklessBucket("2-Fac Tankless Mech", "bo_t_tankless_2fac", BuildCountEqualsBefore(subjFactory, 2, 600)),
-		tanklessBucket("3-Fac Tankless Mech", "bo_t_tankless_3fac", BuildCountEqualsBefore(subjFactory, 3, 600)),
-		tanklessBucket("4-Fac Tankless Mech", "bo_t_tankless_4fac", BuildCountEqualsBefore(subjFactory, 4, 600)),
-		tanklessBucket("5-Fac Tankless Mech", "bo_t_tankless_5fac", BuildCountEqualsBefore(subjFactory, 5, 600)),
-		tanklessBucket("6+ Fac Tankless Mech", "bo_t_tankless_6fac", CountBuildsBefore(subjFactory, 6, 600)),
+		tanklessBucket("2-Fac Tankless Mech", "bo_t_tankless_2fac", 2, true),
+		tanklessBucket("3-Fac Tankless Mech", "bo_t_tankless_3fac", 3, true),
+		tanklessBucket("4-Fac Tankless Mech", "bo_t_tankless_4fac", 4, true),
+		tanklessBucket("5-Fac Tankless Mech", "bo_t_tankless_5fac", 5, true),
+		tanklessBucket("6+ Fac Tankless Mech", "bo_t_tankless_6fac", 6, false),
 		{
 			// 1-1-1: early Starport + Wraith that stays balanced (neither bio-
 			// nor mech-predominant) — the classic Vulture/Tank/Wraith opener.
 			Name: "1-1-1", PatternName: "Build Order: 1-1-1", FeatureKey: "bo_t_111",
 			Race: RaceTerran, Kind: KindInitialBuildOrder,
-			Rule:          All(tCohort, tcOneOneOne, Not(tcBio), Not(tcMechPred), Not(tcWraith), Not(tcGoliath)),
-			RuleDeadline:  600,
+			Rule:         All(tCohort, tcOneOneOne, Not(tcBio), Not(tcMechPred), Not(tcWraith), Not(tcGoliath)),
+			RuleDeadline: 600,
+			Expert: []ExpertEvent{
+				{Key: "Supply Depot", Match: MatchBuild(subjSupplyDepot), TargetSecond: 57, Tolerance: Asym(10, 24)},
+				{Key: "Barracks", Match: MatchBuild(subjBarracks), TargetSecond: 85, Tolerance: Asym(28, 20)},
+				{Key: "Refinery", Match: MatchBuild(subjRefinery), TargetSecond: 98, Tolerance: Asym(15, 70)},
+				{Key: "Factory", Match: MatchBuild(subjFactory), TargetSecond: 160, Tolerance: Asym(15, 70)},
+				{Key: "Starport", Match: MatchBuild(subjStarport), TargetSecond: 226, Tolerance: Asym(40, 80)},
+				{Key: "First Wraith", Match: MatchFirstProduce(subjWraith), TargetSecond: 271, Tolerance: Asym(40, 90)},
+			},
 			SummaryPlayer: &Pill{Label: "1-1-1", IconKey: "starport"},
 			GamesList:     &Pill{Label: "1-1-1", IconKey: "starport"},
 		},

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -29,7 +29,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Build Order: 5-Rax Bio",
-        "value": "600"
+        "value": "{\"expert_actuals\":[{\"second\":55,\"found\":true},{\"second\":85,\"found\":true},{\"second\":174,\"found\":true},{\"second\":238,\"found\":true},{\"second\":530,\"found\":true}]}"
       },
       {
         "replay_player_id": 1,
@@ -78,7 +78,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Build Order: 6+ Rax Bio",
-        "value": "599"
+        "value": "{\"expert_actuals\":[{\"second\":58,\"found\":true},{\"second\":87,\"found\":true},{\"second\":174,\"found\":true},{\"second\":246,\"found\":true},{\"second\":506,\"found\":true}]}"
       },
       {
         "replay_player_id": 1,
@@ -102,7 +102,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Build Order: 6+ Fac Mech",
-        "value": "599"
+        "value": "{\"expert_actuals\":[{\"second\":54,\"found\":true},{\"second\":83,\"found\":true},{\"second\":98,\"found\":true},{\"second\":150,\"found\":true},{\"second\":575,\"found\":true},{\"second\":249,\"found\":true}]}"
       },
       {
         "replay_player_id": 0,
@@ -335,7 +335,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Build Order: 5-Fac Mech",
-        "value": "976"
+        "value": "{\"expert_actuals\":[{\"second\":56,\"found\":true},{\"second\":89,\"found\":true},{\"second\":100,\"found\":true},{\"second\":150,\"found\":true},{\"second\":547,\"found\":true},{\"second\":380,\"found\":true}]}"
       },
       {
         "replay_player_id": 0,


### PR DESCRIPTION
Mines per-bucket milestone timings from a ~2,860-replay expert corpus to give every composition-based Terran BO (Wraith, Goliath, N-Rax Bio, N-Fac Mech, N-Fac Tankless Mech, 1-1-1, 1-1-1 into Mech) an expert-timing chart in the Build Orders tab, bumps `AlgorithmVersion` so existing DBs re-analyze to populate the actual markers, and rewrites the chart's tooltips/legend into plain language for non-experts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
