### PR TITLE
feat: rework early-game event items layout & overlays (closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This is a best-effort, in-process guard, not an OS sandbox: paths handed to trus
 Changes to screpdb are authored by an LLM coding agent (e.g. Claude Code). As part of authoring a change, that LLM re-assesses whether the change could weaken the I/O rules above and records a dated, one-line verdict in the log below (see `AGENTS.md`). It's an honour-system receipt written by the same LLM that wrote the code — it can be tampered with, just as the facades themselves can — but recording it makes any tampering visible in the diff. `TestIOSafetyAuditPresent` fails CI (`go test ./...`) if the log has no entry, so a change cannot land with an empty audit. The authoritative guard remains the enforcement test above.
 
 <!-- IO-AUDIT:START -->
+- **2026-06-07** — `OK`. Early-game event overlay rework (issue #159): consolidated BO timeline events + map overlays. Pure presentation/dashboard-response changes (Go struct field, frontend rendering); no new os/net calls, no allowlist or enforcement-test changes.
 - **2026-05-31** — `OK`. Introduced the `iofacade`/`netfacade` chokepoints, the enforcement test, and removed the AI + fswatch surfaces; this change establishes the I/O rules rather than weakening them.
 <!-- IO-AUDIT:END -->
 

--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -2656,12 +2656,31 @@ func (d *Dashboard) populateMarkersForGameDetail(detail *workflowGameDetail) err
 	// Registry order drives display order so specific variants sit next to
 	// their general cousins.
 	allMarkers := markers.Markers()
+	// Start-location label per player, read from the player_start events
+	// already populated on the timeline. Lets the FE render "X starts at L and
+	// opens with BO" on the consolidated openers row.
+	startLocationByPlayer := map[int64]string{}
+	for i := range detail.GameEvents {
+		ev := &detail.GameEvents[i]
+		if strings.EqualFold(ev.Type, "player_start") && ev.Actor != nil && ev.Base != nil {
+			startLocationByPlayer[ev.Actor.PlayerID] = ev.Base.Name
+		}
+	}
+	// boOpeners accumulates one entry per (player × detected opener BO). They
+	// are surfaced as a single consolidated "bo_openers" game event at second 0
+	// (see below) rather than one timed event per BO — the per-BO timing was
+	// uninformative and the per-event rows read as noise. Every player gets at
+	// least one entry (with an empty BuildOrder when none was resolved) so the
+	// FE always shows the player's name, residual/uncalculated BO or not.
+	var boOpeners []workflowGameEventBuildOrder
+	anyBO := false
 	for _, player := range detail.Players {
 		detected := detectedByPlayer[player.PlayerID]
-		if len(detected) == 0 {
-			continue
-		}
+		playerHadOpener := false
 		for i := range allMarkers {
+			if len(detected) == 0 {
+				break
+			}
 			bo := &allMarkers[i]
 			if bo.Kind != markers.KindInitialBuildOrder {
 				continue
@@ -2704,22 +2723,53 @@ func (d *Dashboard) populateMarkersForGameDetail(detail *workflowGameDetail) err
 				Events:     events,
 			})
 
-			// Surface the BO on the Game Events timeline at the first
-			// building's actual second (per user spec — units don't
-			// count). Skip if no building event was resolved (e.g. a
-			// stream that only matched the rule via produce facts).
-			if firstSec, ok := firstBuildingActualSecond(bo, events); ok {
-				detail.GameEvents = append(detail.GameEvents, workflowGameEvent{
-					Type:   bo.FeatureKey,
-					Second: int64(firstSec),
-					Actor: &workflowGameEventPlayer{
-						PlayerID: player.PlayerID,
-						Name:     player.Name,
-						Color:    player.Color,
-					},
+			// Surface the BO on the consolidated openers event. We still
+			// gate on a resolved first building (per user spec — units
+			// don't count): a BO that only matched via produce facts has
+			// no concrete opening to show. The actual second is no longer
+			// used (the consolidated event sits at 0:00), only the gate.
+			if _, ok := firstBuildingActualSecond(bo, events); ok {
+				boOpeners = append(boOpeners, workflowGameEventBuildOrder{
+					PlayerID:      player.PlayerID,
+					Name:          player.Name,
+					Color:         player.Color,
+					Race:          player.Race,
+					IsWinner:      player.IsWinner,
+					Team:          player.Team,
+					StartLocation: startLocationByPlayer[player.PlayerID],
+					BuildOrder:    bo.Name,
+					FeatureKey:    bo.FeatureKey,
 				})
+				playerHadOpener = true
+				anyBO = true
 			}
 		}
+		// No resolved opener for this player — still emit a name-only entry so
+		// the FE shows the player on the openers row and labels their start.
+		if !playerHadOpener {
+			boOpeners = append(boOpeners, workflowGameEventBuildOrder{
+				PlayerID:      player.PlayerID,
+				Name:          player.Name,
+				Color:         player.Color,
+				Race:          player.Race,
+				IsWinner:      player.IsWinner,
+				Team:          player.Team,
+				StartLocation: startLocationByPlayer[player.PlayerID],
+			})
+		}
+	}
+	// Emit the openers as one consolidated event at second 0 — one entry per
+	// (player × BO), plus a name-only entry for players without one. The FE
+	// groups by player (one line each) and labels each starting location on the
+	// map. Type starts with "bo_" so the ownership back-propagation below hands
+	// it the starting-position snapshot. Skip entirely when no BO was resolved
+	// for anyone (nothing meaningful to open the timeline with).
+	if anyBO {
+		detail.GameEvents = append(detail.GameEvents, workflowGameEvent{
+			Type:        "bo_openers",
+			Second:      0,
+			BuildOrders: boOpeners,
+		})
 	}
 	// detail.GameEvents was already populated by populateDetectedPatterns
 	// in time-sorted order — re-sort after appending BO entries so the

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -571,6 +571,24 @@ type workflowGameEvent struct {
 	// size ≥2 are included (solos filtered for clarity). Source is the
 	// {"teams":[["A","B"],...]} payload written by parser.BuildAllianceDerivedEvents.
 	AllianceTeams [][]workflowGameEventPlayer `json:"alliance_teams,omitempty"`
+	// BuildOrders: populated only for the consolidated "bo_openers" event at
+	// second 0 — one entry per (player × detected opener BO). The FE groups
+	// these by player to render one line per player and to label each starting
+	// location on the map. BO timing is intentionally dropped (it conveyed
+	// nothing useful), so the single event sits at 0:00.
+	BuildOrders []workflowGameEventBuildOrder `json:"build_orders,omitempty"`
+}
+
+type workflowGameEventBuildOrder struct {
+	PlayerID      int64  `json:"player_id"`
+	Name          string `json:"name"`
+	Color         string `json:"color,omitempty"`
+	Race          string `json:"race,omitempty"`
+	IsWinner      bool   `json:"is_winner,omitempty"`
+	Team          int64  `json:"team"`
+	StartLocation string `json:"start_location,omitempty"`
+	BuildOrder    string `json:"build_order"`
+	FeatureKey    string `json:"feature_key"`
 }
 
 type workflowGameEventPlayer struct {

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -334,11 +334,60 @@ const gameEventTargetLocationLabel = (event) => {
   return baseName;
 };
 
+// boOpenerLines groups the consolidated "bo_openers" event's per-(player × BO)
+// entries into one line per player, preserving the backend's registry ordering
+// for each player's BO names. Each line carries the player identity (name,
+// color, race, winner, team) needed to render both the events-list row and the
+// per-start-location map labels.
+const boOpenerLines = (event) => {
+  const entries = Array.isArray(event?.build_orders) ? event.build_orders : [];
+  const byPlayer = new Map();
+  for (const entry of entries) {
+    const pid = entry?.player_id;
+    if (pid == null) continue;
+    const key = String(pid);
+    if (!byPlayer.has(key)) {
+      byPlayer.set(key, {
+        playerID: pid,
+        name: String(entry?.name || '').trim() || 'Player',
+        color: entry?.color || '',
+        race: entry?.race || '',
+        isWinner: Boolean(entry?.is_winner),
+        team: entry?.team,
+        startLocation: String(entry?.start_location || '').trim(),
+        boNames: [],
+      });
+    }
+    const boName = String(entry?.build_order || '').trim();
+    const line = byPlayer.get(key);
+    if (boName && !line.boNames.includes(boName)) line.boNames.push(boName);
+  }
+  return Array.from(byPlayer.values());
+};
+
+// boOpenerLineText renders one opener line as a sentence: "X starts at L and
+// opens with BO", dropping whichever clause is missing (no start location, no
+// resolved BO, or both — leaving just the name).
+const boOpenerLineText = (line) => {
+  const bo = line.boNames.length > 0 ? `opens with ${line.boNames.join(' / ')}` : '';
+  const start = line.startLocation ? `starts at ${line.startLocation}` : '';
+  if (start && bo) return `${line.name} ${start} and ${bo}`;
+  if (start) return `${line.name} ${start}`;
+  if (bo) return `${line.name} ${bo}`;
+  return line.name;
+};
+
 const gameEventDescription = (event, registry) => {
   const eventType = normalizeEventType(event?.type);
   const actor = String(event?.actor?.name || '').trim();
   const target = String(event?.target?.name || '').trim();
   const location = gameEventLocationLabel(event);
+
+  if (eventType === 'bo_openers') {
+    const lines = boOpenerLines(event);
+    if (lines.length === 0) return 'Build orders';
+    return lines.map((line) => boOpenerLineText(line)).join('; ');
+  }
 
   if (typeof eventType === 'string' && eventType.startsWith('bo_')) {
     const def = registry?.[eventType];
@@ -462,6 +511,38 @@ const renderGameEventDescription = (event, registry, playerRaceByID) => {
   const location = gameEventLocationLabel(event);
   const actorSpan = gamePlayerNameSpan(event?.actor, 'a');
   const targetSpan = gamePlayerNameSpan(event?.target, 't');
+
+  if (eventType === 'bo_openers') {
+    const lines = boOpenerLines(event);
+    if (lines.length === 0) return 'Build orders';
+    return (
+      <span className="workflow-bo-openers">
+        {lines.map((line) => {
+          const raceIcon = getRaceIcon(line.race);
+          return (
+            <span key={`bo-line-${line.playerID}`} className="workflow-bo-openers-line">
+              {raceIcon ? <img src={raceIcon} alt={line.race || 'race'} className="unit-icon-inline workflow-bo-openers-race" /> : null}
+              {line.isWinner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+              <span
+                className="workflow-event-row-player"
+                style={legendTextStyle(String(line.color || ''), playerColorToCss(line.color))}
+              >
+                {line.name}
+              </span>
+              {(() => {
+                const bo = line.boNames.length > 0 ? `opens with ${line.boNames.join(' / ')}` : '';
+                const start = line.startLocation ? `starts at ${line.startLocation}` : '';
+                if (start && bo) return <> {start} and {bo}</>;
+                if (start) return <> {start}</>;
+                if (bo) return <> {bo}</>;
+                return null;
+              })()}
+            </span>
+          );
+        })}
+      </span>
+    );
+  }
 
   if (typeof eventType === 'string' && eventType.startsWith('bo_')) {
     const def = registry?.[eventType];
@@ -694,7 +775,7 @@ const renderSummaryMapStack = ({
               key={overlay.key}
               points={overlay.points}
               className="workflow-event-map-base-polygon"
-              style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.ownerColor }}
+              style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.teamColor || overlay.ownerColor, strokeWidth: overlay.strokeWidth || 0.4 }}
             >
               <title>{overlay.ownerName}</title>
             </polygon>
@@ -1338,20 +1419,28 @@ const DEFENSIVE_BUILDING_KEYS = new Set([
 ]);
 
 const DEFAULT_SUMMARY_FILTERS = {
+  attack: false,
+  expansion: false,
+  leaves: false,
   nuke: false,
   drop: false,
   recall: false,
   becameRace: false,
   rush: false,
+  alliance: false,
   scout: false,
 };
 
 const SUMMARY_TOPIC_PATTERNS = {
+  attack: /\battacks?\b/i,
+  expansion: /\bexpands?\b|\bexpansion\b/i,
+  leaves: /\bleaves the game\b|\bstops playing\b/i,
   nuke: /\bnuke|nuclear\b/i,
   drop: /\bdrop|dropship|shuttle\b/i,
   recall: /\brecall\b/i,
   becameRace: /\b(became|becomes)\s+(terran|zerg)\b|\bbecame_(terran|zerg)\b/i,
   rush: /\brush|all[\s-]?in|cheese\b/i,
+  alliance: /\bform(s)? an alliance\b|\ballies with\b|\balliance\b/i,
   scout: /\bscouts?\b|\bscout\b/i,
 };
 
@@ -3443,6 +3532,13 @@ function App() {
       if (normalizeEventType(event?.type) === 'takeover') {
         return false;
       }
+      // Scouts are intentionally not surfaced: a scout's timing is misleading
+      // (instantaneous for Zerg overlords, late for P/T) and we can't tell if
+      // it actually arrived. Dropped per issue #159 — the BO openers carry the
+      // early-game signal instead.
+      if (normalizeEventType(event?.type) === 'scout') {
+        return false;
+      }
       return summaryTextMatches(gameEventSearchText(event, markerRegistry));
     });
     const deduped = [];
@@ -3472,12 +3568,16 @@ function App() {
   ), [topicFilteredGameEvents, mainEventsPlayerEnabledById]);
   const gameEventTopicAvailability = useMemo(() => {
     const base = {
+      attack: false,
+      expansion: false,
+      leaves: false,
       nuke: false,
       drop: false,
       recall: false,
       scout: false,
       becameRace: false,
       rush: false,
+      alliance: false,
     };
     const allEvents = Array.isArray(mainGame?.game_events) ? mainGame.game_events : [];
     for (const event of allEvents) {
@@ -3485,12 +3585,16 @@ function App() {
       const nt = normalizeEventType(event?.type);
       if (nt === 'takeover') continue;
       const text = gameEventSearchText(event, markerRegistry);
+      if (nt === 'attack') base.attack = true;
+      if (nt === 'expansion') base.expansion = true;
+      if (nt === 'leave_game' || nt === 'player_stopped_playing') base.leaves = true;
       if (SUMMARY_TOPIC_PATTERNS.nuke.test(text)) base.nuke = true;
       if (SUMMARY_TOPIC_PATTERNS.drop.test(text)) base.drop = true;
       if (SUMMARY_TOPIC_PATTERNS.recall.test(text)) base.recall = true;
       if (nt === 'scout' || SUMMARY_TOPIC_PATTERNS.scout.test(text)) base.scout = true;
       if (SUMMARY_TOPIC_PATTERNS.becameRace.test(text) || nt === 'became_terran' || nt === 'became_zerg') base.becameRace = true;
       if (SUMMARY_TOPIC_PATTERNS.rush.test(text)) base.rush = true;
+      if (nt === 'late_alliance') base.alliance = true;
     }
     return base;
   }, [mainGame?.game_events, markerRegistry]);
@@ -3535,6 +3639,30 @@ function App() {
     const preferredIdx = firstRowVisibleIdx >= 0 ? firstRowVisibleIdx : 0;
     setMainSelectedGameEventKey(gameEventTopicKey(preferredIdx));
   }, [topicFilteredGameEvents, mainEventsPlayerEnabledById, mainSelectedGameEventKey]);
+  const mainGameTeamByPlayerID = useMemo(() => {
+    const m = new Map();
+    (Array.isArray(mainGamePlayers) ? mainGamePlayers : []).forEach((p) => {
+      if (p?.player_id != null) m.set(String(p.player_id), p.team);
+    });
+    return m;
+  }, [mainGamePlayers]);
+  // Team-colour polygon borders apply only when there's a real team (≥2 players
+  // sharing one). 1v1 / 1v1v1 / FFA — every player on their own team — keep the
+  // plain player-colour border. Guard on ≥2 distinct teams too so a replay with
+  // no team info (everyone on team 0) isn't mistaken for one big team.
+  const isTeamGame = useMemo(() => {
+    const counts = new Map();
+    (Array.isArray(mainGamePlayers) ? mainGamePlayers : []).forEach((p) => {
+      counts.set(p?.team, (counts.get(p?.team) || 0) + 1);
+    });
+    if (counts.size < 2) return false;
+    return [...counts.values()].some((n) => n >= 2);
+  }, [mainGamePlayers]);
+  const polygonStrokeFor = (ownerColor, team) => (
+    isTeamGame && team != null
+      ? { teamColor: getTeamColor(team), strokeWidth: 0.9 }
+      : { teamColor: ownerColor, strokeWidth: 0.4 }
+  );
   const selectedMainGameOwnershipPolygons = useMemo(() => {
     const ownership = Array.isArray(selectedMainGameEvent?.ownership) ? selectedMainGameEvent.ownership : [];
     return ownership
@@ -3548,15 +3676,17 @@ function App() {
           .join(' ');
         if (!points) return null;
         const ownerColor = playerColorToCss(entry.owner.color);
+        const team = mainGameTeamByPlayerID.get(String(entry.owner.player_id));
         return {
           key: `ownership-${idx}-${entry.base?.name || 'base'}`,
           points,
           ownerName: entry.owner.name,
           ownerColor,
+          ...polygonStrokeFor(ownerColor, team),
         };
       })
       .filter(Boolean);
-  }, [selectedMainGameEvent, mainEventMapBounds]);
+  }, [selectedMainGameEvent, mainEventMapBounds, mainGameTeamByPlayerID, isTeamGame]);
   const selectedMainGameLegend = useMemo(() => {
     return (Array.isArray(mainGamePlayers) ? mainGamePlayers : [])
       .map((player) => ({
@@ -3576,22 +3706,64 @@ function App() {
       if (!ev?.actor) return;
       const polygon = Array.isArray(ev?.base?.polygon) ? ev.base.polygon : [];
       if (polygon.length < 3) return;
-      const points = polygon
+      const percentPoints = polygon
         .map((point) => mapPointToPercent(point, bounds))
-        .filter(Boolean)
-        .map((point) => `${point.x},${point.y}`)
-        .join(' ');
+        .filter(Boolean);
+      const points = percentPoints.map((point) => `${point.x},${point.y}`).join(' ');
       if (!points) return;
       const pid = eventActorID(ev);
+      const centroid = percentPoints.reduce(
+        (acc2, p) => ({ x: acc2.x + p.x / percentPoints.length, y: acc2.y + p.y / percentPoints.length }),
+        { x: 0, y: 0 },
+      );
+      const team = pid != null ? mainGameTeamByPlayerID.get(String(pid)) : undefined;
+      const ownerColor = playerColorToCss(ev.actor.color);
       acc.push({
         key: `sum-start-poly-${pid != null ? pid : idx}`,
         points,
+        centroid,
+        playerID: pid,
         ownerName: String(ev.actor.name || '').trim() || 'Player',
-        ownerColor: playerColorToCss(ev.actor.color),
+        ownerColor,
+        ...polygonStrokeFor(ownerColor, team),
       });
     });
     return acc;
-  }, [mainGame?.game_events, mainEventMapBounds]);
+  }, [mainGame?.game_events, mainEventMapBounds, mainGameTeamByPlayerID, isTeamGame]);
+  // The BO openers event sits at 0:00 with no persisted ownership snapshot, so
+  // draw the starting-location polygons directly from the player_start events.
+  // Every other event keeps using its ownership snapshot.
+  const selectedMainGameMapPolygons = useMemo(() => (
+    normalizeEventType(selectedMainGameEvent?.type) === 'bo_openers'
+      ? summaryMapStartPolygons
+      : selectedMainGameOwnershipPolygons
+  ), [selectedMainGameEvent, summaryMapStartPolygons, selectedMainGameOwnershipPolygons]);
+  // Per-start-location labels for the consolidated BO openers event: race icon
+  // + crown + name on line 1, BO name(s) on line 2, painted on each player's
+  // starting polygon. Only computed when that event is selected.
+  const selectedMainGameBOLabels = useMemo(() => {
+    if (normalizeEventType(selectedMainGameEvent?.type) !== 'bo_openers') return [];
+    const lines = boOpenerLines(selectedMainGameEvent);
+    if (lines.length === 0) return [];
+    const lineByPlayer = new Map(lines.map((line) => [String(line.playerID), line]));
+    return summaryMapStartPolygons
+      .map((poly) => {
+        const line = poly.playerID != null ? lineByPlayer.get(String(poly.playerID)) : null;
+        if (!line || !poly.centroid) return null;
+        return {
+          key: `bo-label-${poly.key}`,
+          x: poly.centroid.x,
+          y: poly.centroid.y,
+          name: line.name,
+          color: playerColorToCss(line.color),
+          rawColor: line.color,
+          race: line.race,
+          isWinner: line.isWinner,
+          boNames: line.boNames,
+        };
+      })
+      .filter(Boolean);
+  }, [selectedMainGameEvent, summaryMapStartPolygons]);
   const mainGameFeaturingPillsList = useMemo(
     () => buildMainGameFeaturingPills(mainGame, markerDefinitions),
     [mainGame, markerDefinitions],
@@ -5489,115 +5661,96 @@ function App() {
 
                 {mainGameTab === 'events' && (
                   <div className="workflow-card workflow-card-recent-games">
-                    <div className="workflow-section-top-row">
-                      <div className="workflow-events-filter-cluster workflow-events-topic-filters">
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.nuke ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.nuke}
-                            checked={mainSummaryFilters.nuke}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, nuke: e.target.checked }))}
-                          />
-                          nuke
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.drop ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.drop}
-                            checked={mainSummaryFilters.drop}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, drop: e.target.checked }))}
-                          />
-                          drop
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.recall ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.recall}
-                            checked={mainSummaryFilters.recall}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, recall: e.target.checked }))}
-                          />
-                          recall
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.scout ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.scout}
-                            checked={mainSummaryFilters.scout}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, scout: e.target.checked }))}
-                          />
-                          scout
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.becameRace ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.becameRace}
-                            checked={mainSummaryFilters.becameRace}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, becameRace: e.target.checked }))}
-                          />
-                          became race
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.rush ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.rush}
-                            checked={mainSummaryFilters.rush}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, rush: e.target.checked }))}
-                          />
-                          rush
-                        </label>
+                    <div className="workflow-events-controls">
+                      <div className="workflow-events-filters">
+                      <div className="workflow-events-filter-row" role="group" aria-label="Filter events by type">
+                        {[
+                          { key: 'attack', label: 'Attack' },
+                          { key: 'expansion', label: 'Expansion' },
+                          { key: 'drop', label: 'Drop' },
+                          { key: 'rush', label: 'Rush' },
+                          { key: 'leaves', label: 'Leaves' },
+                          { key: 'recall', label: 'Recall' },
+                          { key: 'nuke', label: 'Nuke' },
+                          { key: 'becameRace', label: 'Became race' },
+                          { key: 'alliance', label: 'Alliance' },
+                        ].map(({ key, label }) => {
+                          const available = gameEventTopicAvailability[key];
+                          const active = mainSummaryFilters[key];
+                          return (
+                            <label
+                              key={key}
+                              className={`workflow-events-filter-chip${active ? ' workflow-events-filter-chip--active' : ''}${!available ? ' workflow-events-filter-chip--disabled' : ''}`}
+                            >
+                              <input
+                                type="checkbox"
+                                disabled={!available}
+                                checked={active}
+                                onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, [key]: e.target.checked }))}
+                              />
+                              {label}
+                            </label>
+                          );
+                        })}
                       </div>
-                      {!hasTeamInfo ? (
-                        <div className="workflow-section-warning">
-                          ⚠️ {mainGame?.team_info_incomplete ? 'Team information is incomplete' : 'This replay has no team information'}. Expect issues like attack events firing between teammates.
+                      {mainGamePlayers.length > 0 ? (
+                        <div className="workflow-events-filter-row workflow-events-player-filters" role="group" aria-label="Filter events by player">
+                          {mainGamePlayers.map((player) => {
+                            const enabled = mainEventsPlayerEnabledById[String(player.player_id)] !== false;
+                            return (
+                              <label
+                                key={`event-filter-${player.player_id}`}
+                                className={`workflow-events-player-chip${enabled ? '' : ' workflow-events-player-chip--off'}`}
+                                style={legendTextStyle(player.color, playerColorToCss(player.color))}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={enabled}
+                                  onChange={(e) => setMainEventsPlayerEnabledById((prev) => ({
+                                    ...prev,
+                                    [String(player.player_id)]: e.target.checked,
+                                  }))}
+                                />
+                                <span>{player.name}</span>
+                              </label>
+                            );
+                          })}
+                          <button
+                            type="button"
+                            className="workflow-legend-bulk-btn"
+                            onClick={() => setMainEventsPlayerEnabledById(
+                              Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), false])),
+                            )}
+                          >
+                            None
+                          </button>
+                          <button
+                            type="button"
+                            className="workflow-legend-bulk-btn"
+                            onClick={() => setMainEventsPlayerEnabledById(
+                              Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), true])),
+                            )}
+                          >
+                            All
+                          </button>
                         </div>
                       ) : null}
-                      <div className="workflow-section-warning">
-                        ⚠️ Event narratives are derived from imperfect replay signals: expect some errors.
+                      </div>
+                      <div className="workflow-events-warnings">
+                        {!hasTeamInfo ? (
+                          <div className="workflow-section-warning workflow-events-warning">
+                            ⚠️ {mainGame?.team_info_incomplete ? 'Team information is incomplete' : 'This replay has no team information'}. Expect issues like attack events firing between teammates.
+                          </div>
+                        ) : null}
+                        <div className="workflow-section-warning workflow-events-warning">
+                          ⚠️ Event narratives are derived from imperfect replay signals: expect some errors.
+                        </div>
                       </div>
                     </div>
                     <div className="workflow-events-layout">
                         <div className="workflow-event-map-panel" ref={setMainEventMapPanelEl}>
                           {mainMapVisualAvailable ? (
                             <>
-                              {mainGamePlayers.length > 0 ? (
-                                <div className="workflow-event-map-legend workflow-event-map-legend--filters" role="group" aria-label="Filter events by player">
-                                  {mainGamePlayers.map((player) => (
-                                    <label
-                                      key={`event-filter-${player.player_id}`}
-                                      className="workflow-event-legend-filter-item"
-                                      style={legendTextStyle(player.color, playerColorToCss(player.color))}
-                                    >
-                                      <input
-                                        type="checkbox"
-                                        checked={mainEventsPlayerEnabledById[String(player.player_id)] !== false}
-                                        onChange={(e) => setMainEventsPlayerEnabledById((prev) => ({
-                                          ...prev,
-                                          [String(player.player_id)]: e.target.checked,
-                                        }))}
-                                      />
-                                      <span>{player.name}</span>
-                                    </label>
-                                  ))}
-                                  <button
-                                    type="button"
-                                    className="workflow-legend-bulk-btn"
-                                    onClick={() => setMainEventsPlayerEnabledById(
-                                      Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), false])),
-                                    )}
-                                  >
-                                    None
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className="workflow-legend-bulk-btn"
-                                    onClick={() => setMainEventsPlayerEnabledById(
-                                      Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), true])),
-                                    )}
-                                  >
-                                    All
-                                  </button>
-                                </div>
-                              ) : null}
                               <div className="workflow-event-map-frame">
                                 <img src={mainMapVisualURL} alt={`${mainGame.map_name} event overlay`} className="workflow-event-map-image" />
                                 {selectedMainGameEvent ? (
@@ -5632,12 +5785,12 @@ function App() {
                                         <polygon points="0 0, 5 2.5, 0 5" fill="context-stroke" />
                                       </marker>
                                     </defs>
-                                    {selectedMainGameOwnershipPolygons.map((overlay) => (
+                                    {selectedMainGameMapPolygons.map((overlay) => (
                                       <polygon
                                         key={overlay.key}
                                         points={overlay.points}
                                         className="workflow-event-map-base-polygon"
-                                        style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.ownerColor }}
+                                        style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.teamColor || overlay.ownerColor, strokeWidth: overlay.strokeWidth || 0.4 }}
                                       />
                                     ))}
                                     {selectedMainGameArrow ? (
@@ -5838,6 +5991,25 @@ function App() {
                                     }}
                                   />
                                 ) : null}
+                                {selectedMainGameBOLabels.map((label) => {
+                                  const raceIcon = getRaceIcon(label.race);
+                                  return (
+                                    <div
+                                      key={label.key}
+                                      className="workflow-event-map-bo-label"
+                                      style={{ left: `${label.x}%`, top: `${label.y}%` }}
+                                    >
+                                      <div className="workflow-event-map-bo-label-name" style={legendTextStyle(String(label.rawColor || ''), label.color)}>
+                                        {raceIcon ? <img src={raceIcon} alt={label.race || 'race'} className="unit-icon-inline workflow-event-map-bo-label-race" /> : null}
+                                        {label.isWinner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+                                        {label.name}
+                                      </div>
+                                      {label.boNames.length > 0 ? (
+                                        <div className="workflow-event-map-bo-label-bo">{label.boNames.join(' / ')}</div>
+                                      ) : null}
+                                    </div>
+                                  );
+                                })}
                               </div>
                             </>
                           ) : (
@@ -5895,7 +6067,7 @@ function App() {
                                     className={`workflow-event-row ${selected ? 'workflow-event-row-selected' : ''}`}
                                     onClick={() => setMainSelectedGameEventKey(eventKey)}
                                   >
-                                    <span>{formatDuration(event.second)}</span>
+                                    <span className="workflow-event-row-time">{formatDuration(event.second)}</span>
                                     <span className="workflow-event-row-body">
                                       <span>{renderGameEventDescription(event, markerRegistry, mainEventRaceByPlayerID)}</span>
                                       {(iconEntries.length > 0 || castEntries.length > 0) ? (

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -3416,6 +3416,94 @@ body {
   gap: 10px;
 }
 
+/* Game Events filter bar: two stacked rows (event types, then players) on the
+   left, with the warning(s) on the right spanning both rows. Sits above the
+   map/list grid so the map and the events list top-align. */
+.workflow-events-controls {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.workflow-events-filters {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workflow-events-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Borderless toggle chips — a soft fill marks the active/hovered state. */
+.workflow-events-filter-chip,
+.workflow-events-player-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  user-select: none;
+  transition: background 120ms ease, opacity 120ms ease;
+}
+
+.workflow-events-filter-chip input,
+.workflow-events-player-chip input {
+  margin: 0;
+  cursor: inherit;
+}
+
+.workflow-events-filter-chip:hover,
+.workflow-events-player-chip:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.workflow-events-filter-chip--active,
+.workflow-events-filter-chip--active:hover {
+  background: rgba(100, 150, 255, 0.18);
+  color: #fff;
+}
+
+.workflow-events-filter-chip--disabled,
+.workflow-events-filter-chip--disabled:hover {
+  opacity: 0.32;
+  cursor: not-allowed;
+  background: transparent;
+}
+
+/* Player chips keep their player colour (set inline). Disabled = filtered out. */
+.workflow-events-player-chip--off {
+  opacity: 0.4;
+}
+
+/* Warnings column: to the right of the filter rows, vertically centred so a
+   single notice reads as spanning both rows. */
+.workflow-events-warnings {
+  flex: 0 0 auto;
+  width: clamp(220px, 30%, 420px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+}
+
+.workflow-events-controls .workflow-events-warning {
+  margin: 0;
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
 .workflow-event-map-panel {
   display: flex;
   flex-direction: column;
@@ -3504,6 +3592,62 @@ body {
   fill: rgba(100, 150, 255, 0.25);
   stroke: rgba(120, 180, 255, 0.95);
   stroke-width: 0.4;
+}
+
+/* Consolidated BO openers event: per-start-location label painted on each
+   player's starting polygon. Race icon + crown + name on the first line, BO
+   name(s) on the second. Centered on the polygon centroid via the inline
+   left/top percent + translate(-50%, -50%). */
+.workflow-event-map-bo-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  text-align: center;
+  line-height: 1.15;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.95), 0 0 2px rgba(0, 0, 0, 0.95);
+  white-space: nowrap;
+}
+
+.workflow-event-map-bo-label-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.workflow-event-map-bo-label-race {
+  width: 14px;
+  height: 14px;
+}
+
+.workflow-event-map-bo-label-bo {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+/* BO openers event row: one line per player stacked vertically. */
+.workflow-bo-openers {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.workflow-bo-openers-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.workflow-bo-openers-race {
+  width: 15px;
+  height: 15px;
 }
 
 .workflow-event-map-attack-line {
@@ -3692,17 +3836,27 @@ body {
 
 .workflow-event-row {
   display: grid;
-  grid-template-columns: 80px 1fr;
-  gap: 10px;
-  align-items: start;
-  padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.03);
+  grid-template-columns: 56px 1fr;
+  gap: 12px;
+  align-items: baseline;
+  padding: 5px 8px;
+  background: transparent;
   border-radius: 6px;
-  border: 1px solid transparent;
+  border: none;
   width: 100%;
   text-align: left;
   color: inherit;
   cursor: pointer;
+}
+
+.workflow-event-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.workflow-event-row-time {
+  color: rgba(255, 255, 255, 0.45);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
 }
 
 .workflow-event-row-body {
@@ -3746,23 +3900,22 @@ body {
   font-weight: 600;
 }
 
-.workflow-event-row-selected {
-  border-color: rgba(100, 150, 255, 0.55);
-  background: rgba(100, 150, 255, 0.16);
+.workflow-event-row-selected,
+.workflow-event-row-selected:hover {
+  background: rgba(100, 150, 255, 0.12);
 }
 
 .workflow-events-section-header {
-  margin: 8px 0 2px;
-  padding: 2px 6px;
-  font-size: 0.74rem;
+  margin: 12px 0 2px;
+  padding: 0 8px;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.7);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.4);
 }
 
 .workflow-events-section-header:first-child {
-  margin-top: 0;
+  margin-top: 2px;
 }
 
 @keyframes workflow-event-overlay-appear {


### PR DESCRIPTION
fixes https://github.com/marianogappa/screpdb/issues/159

- **Scouts dropped** from the Game Events list — a scout's timing is misleading (instantaneous for Zerg, late for P/T) and arrival can't be verified.
- **Build orders consolidated** into a single event at `0:00` with one line per player — `"X starts at <location> and opens with <BO>"`, falling back to `"X starts at <location>"` (or just the name) when the BO is residual/unresolved. The per-BO timing (which conveyed nothing useful) is gone.
- **Starting-location overlays** on the map: each player's polygon is labelled with race icon + crown (if winner) + name, and the BO on a second line.
- **Team info on polygons**: the polygon now fills with the player's in-game colour and uses a fatter team-colour border — but only in real team games (≥2 players sharing a team). 1v1 / 1v1v1 / FFA keep the plain player-colour border.
- **Filters redesigned**: borderless, capitalised toggle chips laid out in two rows (event types, then players) above the map so the map and the events list top-align; the warning sits on the right spanning both rows. Added `Attack`, `Expansion`, `Leaves`, `Alliance` filters and reordered everything by 1v1 relevance (money-map/team-only ones pushed right); chips dim when the event doesn't occur in the replay.

Implementation notes:
- New `bo_openers` game event + `workflowGameEventBuildOrder` payload (per-player name/colour/race/winner/team/start-location/BO) synthesized in the game-detail endpoint; these are dashboard-response only, not persisted to `replay_events`, so no `AlgorithmVersion` bump is needed.
- All other changes are frontend rendering/CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
