### PR TITLE
Early-game event overlays: summary-pill cleanups, Wraiths marker, production-based base ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ This is a best-effort, in-process guard, not an OS sandbox: paths handed to trus
 Changes to screpdb are authored by an LLM coding agent (e.g. Claude Code). As part of authoring a change, that LLM re-assesses whether the change could weaken the I/O rules above and records a dated, one-line verdict in the log below (see `AGENTS.md`). It's an honour-system receipt written by the same LLM that wrote the code — it can be tampered with, just as the facades themselves can — but recording it makes any tampering visible in the diff. `TestIOSafetyAuditPresent` fails CI (`go test ./...`) if the log has no entry, so a change cannot land with an empty audit. The authoritative guard remains the enforcement test above.
 
 <!-- IO-AUDIT:START -->
+- **2026-06-07** — `OK`. Early-game event overlay rework (issue #159): consolidated BO timeline events + map overlays. Pure presentation/dashboard-response changes (Go struct field, frontend rendering); no new os/net calls, no allowlist or enforcement-test changes.
 - **2026-05-31** — `OK`. Introduced the `iofacade`/`netfacade` chokepoints, the enforcement test, and removed the AI + fswatch surfaces; this change establishes the I/O rules rather than weakening them.
 <!-- IO-AUDIT:END -->
 

--- a/internal/dashboard/endpoint_main_game_detail.go
+++ b/internal/dashboard/endpoint_main_game_detail.go
@@ -2656,12 +2656,31 @@ func (d *Dashboard) populateMarkersForGameDetail(detail *workflowGameDetail) err
 	// Registry order drives display order so specific variants sit next to
 	// their general cousins.
 	allMarkers := markers.Markers()
+	// Start-location label per player, read from the player_start events
+	// already populated on the timeline. Lets the FE render "X starts at L and
+	// opens with BO" on the consolidated openers row.
+	startLocationByPlayer := map[int64]string{}
+	for i := range detail.GameEvents {
+		ev := &detail.GameEvents[i]
+		if strings.EqualFold(ev.Type, "player_start") && ev.Actor != nil && ev.Base != nil {
+			startLocationByPlayer[ev.Actor.PlayerID] = ev.Base.Name
+		}
+	}
+	// boOpeners accumulates one entry per (player × detected opener BO). They
+	// are surfaced as a single consolidated "bo_openers" game event at second 0
+	// (see below) rather than one timed event per BO — the per-BO timing was
+	// uninformative and the per-event rows read as noise. Every player gets at
+	// least one entry (with an empty BuildOrder when none was resolved) so the
+	// FE always shows the player's name, residual/uncalculated BO or not.
+	var boOpeners []workflowGameEventBuildOrder
+	anyBO := false
 	for _, player := range detail.Players {
 		detected := detectedByPlayer[player.PlayerID]
-		if len(detected) == 0 {
-			continue
-		}
+		playerHadOpener := false
 		for i := range allMarkers {
+			if len(detected) == 0 {
+				break
+			}
 			bo := &allMarkers[i]
 			if bo.Kind != markers.KindInitialBuildOrder {
 				continue
@@ -2704,22 +2723,53 @@ func (d *Dashboard) populateMarkersForGameDetail(detail *workflowGameDetail) err
 				Events:     events,
 			})
 
-			// Surface the BO on the Game Events timeline at the first
-			// building's actual second (per user spec — units don't
-			// count). Skip if no building event was resolved (e.g. a
-			// stream that only matched the rule via produce facts).
-			if firstSec, ok := firstBuildingActualSecond(bo, events); ok {
-				detail.GameEvents = append(detail.GameEvents, workflowGameEvent{
-					Type:   bo.FeatureKey,
-					Second: int64(firstSec),
-					Actor: &workflowGameEventPlayer{
-						PlayerID: player.PlayerID,
-						Name:     player.Name,
-						Color:    player.Color,
-					},
+			// Surface the BO on the consolidated openers event. We still
+			// gate on a resolved first building (per user spec — units
+			// don't count): a BO that only matched via produce facts has
+			// no concrete opening to show. The actual second is no longer
+			// used (the consolidated event sits at 0:00), only the gate.
+			if _, ok := firstBuildingActualSecond(bo, events); ok {
+				boOpeners = append(boOpeners, workflowGameEventBuildOrder{
+					PlayerID:      player.PlayerID,
+					Name:          player.Name,
+					Color:         player.Color,
+					Race:          player.Race,
+					IsWinner:      player.IsWinner,
+					Team:          player.Team,
+					StartLocation: startLocationByPlayer[player.PlayerID],
+					BuildOrder:    bo.Name,
+					FeatureKey:    bo.FeatureKey,
 				})
+				playerHadOpener = true
+				anyBO = true
 			}
 		}
+		// No resolved opener for this player — still emit a name-only entry so
+		// the FE shows the player on the openers row and labels their start.
+		if !playerHadOpener {
+			boOpeners = append(boOpeners, workflowGameEventBuildOrder{
+				PlayerID:      player.PlayerID,
+				Name:          player.Name,
+				Color:         player.Color,
+				Race:          player.Race,
+				IsWinner:      player.IsWinner,
+				Team:          player.Team,
+				StartLocation: startLocationByPlayer[player.PlayerID],
+			})
+		}
+	}
+	// Emit the openers as one consolidated event at second 0 — one entry per
+	// (player × BO), plus a name-only entry for players without one. The FE
+	// groups by player (one line each) and labels each starting location on the
+	// map. Type starts with "bo_" so the ownership back-propagation below hands
+	// it the starting-position snapshot. Skip entirely when no BO was resolved
+	// for anyone (nothing meaningful to open the timeline with).
+	if anyBO {
+		detail.GameEvents = append(detail.GameEvents, workflowGameEvent{
+			Type:        "bo_openers",
+			Second:      0,
+			BuildOrders: boOpeners,
+		})
 	}
 	// detail.GameEvents was already populated by populateDetectedPatterns
 	// in time-sorted order — re-sort after appending BO entries so the

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -571,6 +571,24 @@ type workflowGameEvent struct {
 	// size ≥2 are included (solos filtered for clarity). Source is the
 	// {"teams":[["A","B"],...]} payload written by parser.BuildAllianceDerivedEvents.
 	AllianceTeams [][]workflowGameEventPlayer `json:"alliance_teams,omitempty"`
+	// BuildOrders: populated only for the consolidated "bo_openers" event at
+	// second 0 — one entry per (player × detected opener BO). The FE groups
+	// these by player to render one line per player and to label each starting
+	// location on the map. BO timing is intentionally dropped (it conveyed
+	// nothing useful), so the single event sits at 0:00.
+	BuildOrders []workflowGameEventBuildOrder `json:"build_orders,omitempty"`
+}
+
+type workflowGameEventBuildOrder struct {
+	PlayerID      int64  `json:"player_id"`
+	Name          string `json:"name"`
+	Color         string `json:"color,omitempty"`
+	Race          string `json:"race,omitempty"`
+	IsWinner      bool   `json:"is_winner,omitempty"`
+	Team          int64  `json:"team"`
+	StartLocation string `json:"start_location,omitempty"`
+	BuildOrder    string `json:"build_order"`
+	FeatureKey    string `json:"feature_key"`
 }
 
 type workflowGameEventPlayer struct {

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -334,11 +334,60 @@ const gameEventTargetLocationLabel = (event) => {
   return baseName;
 };
 
+// boOpenerLines groups the consolidated "bo_openers" event's per-(player × BO)
+// entries into one line per player, preserving the backend's registry ordering
+// for each player's BO names. Each line carries the player identity (name,
+// color, race, winner, team) needed to render both the events-list row and the
+// per-start-location map labels.
+const boOpenerLines = (event) => {
+  const entries = Array.isArray(event?.build_orders) ? event.build_orders : [];
+  const byPlayer = new Map();
+  for (const entry of entries) {
+    const pid = entry?.player_id;
+    if (pid == null) continue;
+    const key = String(pid);
+    if (!byPlayer.has(key)) {
+      byPlayer.set(key, {
+        playerID: pid,
+        name: String(entry?.name || '').trim() || 'Player',
+        color: entry?.color || '',
+        race: entry?.race || '',
+        isWinner: Boolean(entry?.is_winner),
+        team: entry?.team,
+        startLocation: String(entry?.start_location || '').trim(),
+        boNames: [],
+      });
+    }
+    const boName = String(entry?.build_order || '').trim();
+    const line = byPlayer.get(key);
+    if (boName && !line.boNames.includes(boName)) line.boNames.push(boName);
+  }
+  return Array.from(byPlayer.values());
+};
+
+// boOpenerLineText renders one opener line as a sentence: "X starts at L and
+// opens with BO", dropping whichever clause is missing (no start location, no
+// resolved BO, or both — leaving just the name).
+const boOpenerLineText = (line) => {
+  const bo = line.boNames.length > 0 ? `opens with ${line.boNames.join(' / ')}` : '';
+  const start = line.startLocation ? `starts at ${line.startLocation}` : '';
+  if (start && bo) return `${line.name} ${start} and ${bo}`;
+  if (start) return `${line.name} ${start}`;
+  if (bo) return `${line.name} ${bo}`;
+  return line.name;
+};
+
 const gameEventDescription = (event, registry) => {
   const eventType = normalizeEventType(event?.type);
   const actor = String(event?.actor?.name || '').trim();
   const target = String(event?.target?.name || '').trim();
   const location = gameEventLocationLabel(event);
+
+  if (eventType === 'bo_openers') {
+    const lines = boOpenerLines(event);
+    if (lines.length === 0) return 'Build orders';
+    return lines.map((line) => boOpenerLineText(line)).join('; ');
+  }
 
   if (typeof eventType === 'string' && eventType.startsWith('bo_')) {
     const def = registry?.[eventType];
@@ -462,6 +511,38 @@ const renderGameEventDescription = (event, registry, playerRaceByID) => {
   const location = gameEventLocationLabel(event);
   const actorSpan = gamePlayerNameSpan(event?.actor, 'a');
   const targetSpan = gamePlayerNameSpan(event?.target, 't');
+
+  if (eventType === 'bo_openers') {
+    const lines = boOpenerLines(event);
+    if (lines.length === 0) return 'Build orders';
+    return (
+      <span className="workflow-bo-openers">
+        {lines.map((line) => {
+          const raceIcon = getRaceIcon(line.race);
+          return (
+            <span key={`bo-line-${line.playerID}`} className="workflow-bo-openers-line">
+              {raceIcon ? <img src={raceIcon} alt={line.race || 'race'} className="unit-icon-inline workflow-bo-openers-race" /> : null}
+              {line.isWinner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+              <span
+                className="workflow-event-row-player"
+                style={legendTextStyle(String(line.color || ''), playerColorToCss(line.color))}
+              >
+                {line.name}
+              </span>
+              {(() => {
+                const bo = line.boNames.length > 0 ? `opens with ${line.boNames.join(' / ')}` : '';
+                const start = line.startLocation ? `starts at ${line.startLocation}` : '';
+                if (start && bo) return <> {start} and {bo}</>;
+                if (start) return <> {start}</>;
+                if (bo) return <> {bo}</>;
+                return null;
+              })()}
+            </span>
+          );
+        })}
+      </span>
+    );
+  }
 
   if (typeof eventType === 'string' && eventType.startsWith('bo_')) {
     const def = registry?.[eventType];
@@ -694,7 +775,7 @@ const renderSummaryMapStack = ({
               key={overlay.key}
               points={overlay.points}
               className="workflow-event-map-base-polygon"
-              style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.ownerColor }}
+              style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.teamColor || overlay.ownerColor, strokeWidth: overlay.strokeWidth || 0.4 }}
             >
               <title>{overlay.ownerName}</title>
             </polygon>
@@ -1338,20 +1419,28 @@ const DEFENSIVE_BUILDING_KEYS = new Set([
 ]);
 
 const DEFAULT_SUMMARY_FILTERS = {
+  attack: false,
+  expansion: false,
+  leaves: false,
   nuke: false,
   drop: false,
   recall: false,
   becameRace: false,
   rush: false,
+  alliance: false,
   scout: false,
 };
 
 const SUMMARY_TOPIC_PATTERNS = {
+  attack: /\battacks?\b/i,
+  expansion: /\bexpands?\b|\bexpansion\b/i,
+  leaves: /\bleaves the game\b|\bstops playing\b/i,
   nuke: /\bnuke|nuclear\b/i,
   drop: /\bdrop|dropship|shuttle\b/i,
   recall: /\brecall\b/i,
   becameRace: /\b(became|becomes)\s+(terran|zerg)\b|\bbecame_(terran|zerg)\b/i,
   rush: /\brush|all[\s-]?in|cheese\b/i,
+  alliance: /\bform(s)? an alliance\b|\ballies with\b|\balliance\b/i,
   scout: /\bscouts?\b|\bscout\b/i,
 };
 
@@ -3443,6 +3532,13 @@ function App() {
       if (normalizeEventType(event?.type) === 'takeover') {
         return false;
       }
+      // Scouts are intentionally not surfaced: a scout's timing is misleading
+      // (instantaneous for Zerg overlords, late for P/T) and we can't tell if
+      // it actually arrived. Dropped per issue #159 — the BO openers carry the
+      // early-game signal instead.
+      if (normalizeEventType(event?.type) === 'scout') {
+        return false;
+      }
       return summaryTextMatches(gameEventSearchText(event, markerRegistry));
     });
     const deduped = [];
@@ -3472,12 +3568,16 @@ function App() {
   ), [topicFilteredGameEvents, mainEventsPlayerEnabledById]);
   const gameEventTopicAvailability = useMemo(() => {
     const base = {
+      attack: false,
+      expansion: false,
+      leaves: false,
       nuke: false,
       drop: false,
       recall: false,
       scout: false,
       becameRace: false,
       rush: false,
+      alliance: false,
     };
     const allEvents = Array.isArray(mainGame?.game_events) ? mainGame.game_events : [];
     for (const event of allEvents) {
@@ -3485,12 +3585,16 @@ function App() {
       const nt = normalizeEventType(event?.type);
       if (nt === 'takeover') continue;
       const text = gameEventSearchText(event, markerRegistry);
+      if (nt === 'attack') base.attack = true;
+      if (nt === 'expansion') base.expansion = true;
+      if (nt === 'leave_game' || nt === 'player_stopped_playing') base.leaves = true;
       if (SUMMARY_TOPIC_PATTERNS.nuke.test(text)) base.nuke = true;
       if (SUMMARY_TOPIC_PATTERNS.drop.test(text)) base.drop = true;
       if (SUMMARY_TOPIC_PATTERNS.recall.test(text)) base.recall = true;
       if (nt === 'scout' || SUMMARY_TOPIC_PATTERNS.scout.test(text)) base.scout = true;
       if (SUMMARY_TOPIC_PATTERNS.becameRace.test(text) || nt === 'became_terran' || nt === 'became_zerg') base.becameRace = true;
       if (SUMMARY_TOPIC_PATTERNS.rush.test(text)) base.rush = true;
+      if (nt === 'late_alliance') base.alliance = true;
     }
     return base;
   }, [mainGame?.game_events, markerRegistry]);
@@ -3535,6 +3639,30 @@ function App() {
     const preferredIdx = firstRowVisibleIdx >= 0 ? firstRowVisibleIdx : 0;
     setMainSelectedGameEventKey(gameEventTopicKey(preferredIdx));
   }, [topicFilteredGameEvents, mainEventsPlayerEnabledById, mainSelectedGameEventKey]);
+  const mainGameTeamByPlayerID = useMemo(() => {
+    const m = new Map();
+    (Array.isArray(mainGamePlayers) ? mainGamePlayers : []).forEach((p) => {
+      if (p?.player_id != null) m.set(String(p.player_id), p.team);
+    });
+    return m;
+  }, [mainGamePlayers]);
+  // Team-colour polygon borders apply only when there's a real team (≥2 players
+  // sharing one). 1v1 / 1v1v1 / FFA — every player on their own team — keep the
+  // plain player-colour border. Guard on ≥2 distinct teams too so a replay with
+  // no team info (everyone on team 0) isn't mistaken for one big team.
+  const isTeamGame = useMemo(() => {
+    const counts = new Map();
+    (Array.isArray(mainGamePlayers) ? mainGamePlayers : []).forEach((p) => {
+      counts.set(p?.team, (counts.get(p?.team) || 0) + 1);
+    });
+    if (counts.size < 2) return false;
+    return [...counts.values()].some((n) => n >= 2);
+  }, [mainGamePlayers]);
+  const polygonStrokeFor = (ownerColor, team) => (
+    isTeamGame && team != null
+      ? { teamColor: getTeamColor(team), strokeWidth: 0.9 }
+      : { teamColor: ownerColor, strokeWidth: 0.4 }
+  );
   const selectedMainGameOwnershipPolygons = useMemo(() => {
     const ownership = Array.isArray(selectedMainGameEvent?.ownership) ? selectedMainGameEvent.ownership : [];
     return ownership
@@ -3548,15 +3676,17 @@ function App() {
           .join(' ');
         if (!points) return null;
         const ownerColor = playerColorToCss(entry.owner.color);
+        const team = mainGameTeamByPlayerID.get(String(entry.owner.player_id));
         return {
           key: `ownership-${idx}-${entry.base?.name || 'base'}`,
           points,
           ownerName: entry.owner.name,
           ownerColor,
+          ...polygonStrokeFor(ownerColor, team),
         };
       })
       .filter(Boolean);
-  }, [selectedMainGameEvent, mainEventMapBounds]);
+  }, [selectedMainGameEvent, mainEventMapBounds, mainGameTeamByPlayerID, isTeamGame]);
   const selectedMainGameLegend = useMemo(() => {
     return (Array.isArray(mainGamePlayers) ? mainGamePlayers : [])
       .map((player) => ({
@@ -3576,22 +3706,64 @@ function App() {
       if (!ev?.actor) return;
       const polygon = Array.isArray(ev?.base?.polygon) ? ev.base.polygon : [];
       if (polygon.length < 3) return;
-      const points = polygon
+      const percentPoints = polygon
         .map((point) => mapPointToPercent(point, bounds))
-        .filter(Boolean)
-        .map((point) => `${point.x},${point.y}`)
-        .join(' ');
+        .filter(Boolean);
+      const points = percentPoints.map((point) => `${point.x},${point.y}`).join(' ');
       if (!points) return;
       const pid = eventActorID(ev);
+      const centroid = percentPoints.reduce(
+        (acc2, p) => ({ x: acc2.x + p.x / percentPoints.length, y: acc2.y + p.y / percentPoints.length }),
+        { x: 0, y: 0 },
+      );
+      const team = pid != null ? mainGameTeamByPlayerID.get(String(pid)) : undefined;
+      const ownerColor = playerColorToCss(ev.actor.color);
       acc.push({
         key: `sum-start-poly-${pid != null ? pid : idx}`,
         points,
+        centroid,
+        playerID: pid,
         ownerName: String(ev.actor.name || '').trim() || 'Player',
-        ownerColor: playerColorToCss(ev.actor.color),
+        ownerColor,
+        ...polygonStrokeFor(ownerColor, team),
       });
     });
     return acc;
-  }, [mainGame?.game_events, mainEventMapBounds]);
+  }, [mainGame?.game_events, mainEventMapBounds, mainGameTeamByPlayerID, isTeamGame]);
+  // The BO openers event sits at 0:00 with no persisted ownership snapshot, so
+  // draw the starting-location polygons directly from the player_start events.
+  // Every other event keeps using its ownership snapshot.
+  const selectedMainGameMapPolygons = useMemo(() => (
+    normalizeEventType(selectedMainGameEvent?.type) === 'bo_openers'
+      ? summaryMapStartPolygons
+      : selectedMainGameOwnershipPolygons
+  ), [selectedMainGameEvent, summaryMapStartPolygons, selectedMainGameOwnershipPolygons]);
+  // Per-start-location labels for the consolidated BO openers event: race icon
+  // + crown + name on line 1, BO name(s) on line 2, painted on each player's
+  // starting polygon. Only computed when that event is selected.
+  const selectedMainGameBOLabels = useMemo(() => {
+    if (normalizeEventType(selectedMainGameEvent?.type) !== 'bo_openers') return [];
+    const lines = boOpenerLines(selectedMainGameEvent);
+    if (lines.length === 0) return [];
+    const lineByPlayer = new Map(lines.map((line) => [String(line.playerID), line]));
+    return summaryMapStartPolygons
+      .map((poly) => {
+        const line = poly.playerID != null ? lineByPlayer.get(String(poly.playerID)) : null;
+        if (!line || !poly.centroid) return null;
+        return {
+          key: `bo-label-${poly.key}`,
+          x: poly.centroid.x,
+          y: poly.centroid.y,
+          name: line.name,
+          color: playerColorToCss(line.color),
+          rawColor: line.color,
+          race: line.race,
+          isWinner: line.isWinner,
+          boNames: line.boNames,
+        };
+      })
+      .filter(Boolean);
+  }, [selectedMainGameEvent, summaryMapStartPolygons]);
   const mainGameFeaturingPillsList = useMemo(
     () => buildMainGameFeaturingPills(mainGame, markerDefinitions),
     [mainGame, markerDefinitions],
@@ -5489,115 +5661,96 @@ function App() {
 
                 {mainGameTab === 'events' && (
                   <div className="workflow-card workflow-card-recent-games">
-                    <div className="workflow-section-top-row">
-                      <div className="workflow-events-filter-cluster workflow-events-topic-filters">
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.nuke ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.nuke}
-                            checked={mainSummaryFilters.nuke}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, nuke: e.target.checked }))}
-                          />
-                          nuke
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.drop ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.drop}
-                            checked={mainSummaryFilters.drop}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, drop: e.target.checked }))}
-                          />
-                          drop
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.recall ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.recall}
-                            checked={mainSummaryFilters.recall}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, recall: e.target.checked }))}
-                          />
-                          recall
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.scout ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.scout}
-                            checked={mainSummaryFilters.scout}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, scout: e.target.checked }))}
-                          />
-                          scout
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.becameRace ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.becameRace}
-                            checked={mainSummaryFilters.becameRace}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, becameRace: e.target.checked }))}
-                          />
-                          became race
-                        </label>
-                        <label className={`workflow-summary-filter-check${!gameEventTopicAvailability.rush ? ' workflow-summary-filter-check--disabled' : ''}`}>
-                          <input
-                            type="checkbox"
-                            disabled={!gameEventTopicAvailability.rush}
-                            checked={mainSummaryFilters.rush}
-                            onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, rush: e.target.checked }))}
-                          />
-                          rush
-                        </label>
+                    <div className="workflow-events-controls">
+                      <div className="workflow-events-filters">
+                      <div className="workflow-events-filter-row" role="group" aria-label="Filter events by type">
+                        {[
+                          { key: 'attack', label: 'Attack' },
+                          { key: 'expansion', label: 'Expansion' },
+                          { key: 'drop', label: 'Drop' },
+                          { key: 'rush', label: 'Rush' },
+                          { key: 'leaves', label: 'Leaves' },
+                          { key: 'recall', label: 'Recall' },
+                          { key: 'nuke', label: 'Nuke' },
+                          { key: 'becameRace', label: 'Became race' },
+                          { key: 'alliance', label: 'Alliance' },
+                        ].map(({ key, label }) => {
+                          const available = gameEventTopicAvailability[key];
+                          const active = mainSummaryFilters[key];
+                          return (
+                            <label
+                              key={key}
+                              className={`workflow-events-filter-chip${active ? ' workflow-events-filter-chip--active' : ''}${!available ? ' workflow-events-filter-chip--disabled' : ''}`}
+                            >
+                              <input
+                                type="checkbox"
+                                disabled={!available}
+                                checked={active}
+                                onChange={(e) => setMainSummaryFilters((prev) => ({ ...prev, [key]: e.target.checked }))}
+                              />
+                              {label}
+                            </label>
+                          );
+                        })}
                       </div>
-                      {!hasTeamInfo ? (
-                        <div className="workflow-section-warning">
-                          ⚠️ {mainGame?.team_info_incomplete ? 'Team information is incomplete' : 'This replay has no team information'}. Expect issues like attack events firing between teammates.
+                      {mainGamePlayers.length > 0 ? (
+                        <div className="workflow-events-filter-row workflow-events-player-filters" role="group" aria-label="Filter events by player">
+                          {mainGamePlayers.map((player) => {
+                            const enabled = mainEventsPlayerEnabledById[String(player.player_id)] !== false;
+                            return (
+                              <label
+                                key={`event-filter-${player.player_id}`}
+                                className={`workflow-events-player-chip${enabled ? '' : ' workflow-events-player-chip--off'}`}
+                                style={legendTextStyle(player.color, playerColorToCss(player.color))}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={enabled}
+                                  onChange={(e) => setMainEventsPlayerEnabledById((prev) => ({
+                                    ...prev,
+                                    [String(player.player_id)]: e.target.checked,
+                                  }))}
+                                />
+                                <span>{player.name}</span>
+                              </label>
+                            );
+                          })}
+                          <button
+                            type="button"
+                            className="workflow-legend-bulk-btn"
+                            onClick={() => setMainEventsPlayerEnabledById(
+                              Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), false])),
+                            )}
+                          >
+                            None
+                          </button>
+                          <button
+                            type="button"
+                            className="workflow-legend-bulk-btn"
+                            onClick={() => setMainEventsPlayerEnabledById(
+                              Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), true])),
+                            )}
+                          >
+                            All
+                          </button>
                         </div>
                       ) : null}
-                      <div className="workflow-section-warning">
-                        ⚠️ Event narratives are derived from imperfect replay signals: expect some errors.
+                      </div>
+                      <div className="workflow-events-warnings">
+                        {!hasTeamInfo ? (
+                          <div className="workflow-section-warning workflow-events-warning">
+                            ⚠️ {mainGame?.team_info_incomplete ? 'Team information is incomplete' : 'This replay has no team information'}. Expect issues like attack events firing between teammates.
+                          </div>
+                        ) : null}
+                        <div className="workflow-section-warning workflow-events-warning">
+                          ⚠️ Event narratives are derived from imperfect replay signals: expect some errors.
+                        </div>
                       </div>
                     </div>
                     <div className="workflow-events-layout">
                         <div className="workflow-event-map-panel" ref={setMainEventMapPanelEl}>
                           {mainMapVisualAvailable ? (
                             <>
-                              {mainGamePlayers.length > 0 ? (
-                                <div className="workflow-event-map-legend workflow-event-map-legend--filters" role="group" aria-label="Filter events by player">
-                                  {mainGamePlayers.map((player) => (
-                                    <label
-                                      key={`event-filter-${player.player_id}`}
-                                      className="workflow-event-legend-filter-item"
-                                      style={legendTextStyle(player.color, playerColorToCss(player.color))}
-                                    >
-                                      <input
-                                        type="checkbox"
-                                        checked={mainEventsPlayerEnabledById[String(player.player_id)] !== false}
-                                        onChange={(e) => setMainEventsPlayerEnabledById((prev) => ({
-                                          ...prev,
-                                          [String(player.player_id)]: e.target.checked,
-                                        }))}
-                                      />
-                                      <span>{player.name}</span>
-                                    </label>
-                                  ))}
-                                  <button
-                                    type="button"
-                                    className="workflow-legend-bulk-btn"
-                                    onClick={() => setMainEventsPlayerEnabledById(
-                                      Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), false])),
-                                    )}
-                                  >
-                                    None
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className="workflow-legend-bulk-btn"
-                                    onClick={() => setMainEventsPlayerEnabledById(
-                                      Object.fromEntries(mainGamePlayers.map((p) => [String(p.player_id), true])),
-                                    )}
-                                  >
-                                    All
-                                  </button>
-                                </div>
-                              ) : null}
                               <div className="workflow-event-map-frame">
                                 <img src={mainMapVisualURL} alt={`${mainGame.map_name} event overlay`} className="workflow-event-map-image" />
                                 {selectedMainGameEvent ? (
@@ -5632,12 +5785,12 @@ function App() {
                                         <polygon points="0 0, 5 2.5, 0 5" fill="context-stroke" />
                                       </marker>
                                     </defs>
-                                    {selectedMainGameOwnershipPolygons.map((overlay) => (
+                                    {selectedMainGameMapPolygons.map((overlay) => (
                                       <polygon
                                         key={overlay.key}
                                         points={overlay.points}
                                         className="workflow-event-map-base-polygon"
-                                        style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.ownerColor }}
+                                        style={{ fill: `${overlay.ownerColor}66`, stroke: overlay.teamColor || overlay.ownerColor, strokeWidth: overlay.strokeWidth || 0.4 }}
                                       />
                                     ))}
                                     {selectedMainGameArrow ? (
@@ -5838,6 +5991,25 @@ function App() {
                                     }}
                                   />
                                 ) : null}
+                                {selectedMainGameBOLabels.map((label) => {
+                                  const raceIcon = getRaceIcon(label.race);
+                                  return (
+                                    <div
+                                      key={label.key}
+                                      className="workflow-event-map-bo-label"
+                                      style={{ left: `${label.x}%`, top: `${label.y}%` }}
+                                    >
+                                      <div className="workflow-event-map-bo-label-name" style={legendTextStyle(String(label.rawColor || ''), label.color)}>
+                                        {raceIcon ? <img src={raceIcon} alt={label.race || 'race'} className="unit-icon-inline workflow-event-map-bo-label-race" /> : null}
+                                        {label.isWinner ? <span className="workflow-crown" title="Winner">👑</span> : null}
+                                        {label.name}
+                                      </div>
+                                      {label.boNames.length > 0 ? (
+                                        <div className="workflow-event-map-bo-label-bo">{label.boNames.join(' / ')}</div>
+                                      ) : null}
+                                    </div>
+                                  );
+                                })}
                               </div>
                             </>
                           ) : (
@@ -5895,7 +6067,7 @@ function App() {
                                     className={`workflow-event-row ${selected ? 'workflow-event-row-selected' : ''}`}
                                     onClick={() => setMainSelectedGameEventKey(eventKey)}
                                   >
-                                    <span>{formatDuration(event.second)}</span>
+                                    <span className="workflow-event-row-time">{formatDuration(event.second)}</span>
                                     <span className="workflow-event-row-body">
                                       <span>{renderGameEventDescription(event, markerRegistry, mainEventRaceByPlayerID)}</span>
                                       {(iconEntries.length > 0 || castEntries.length > 0) ? (

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -3416,6 +3416,94 @@ body {
   gap: 10px;
 }
 
+/* Game Events filter bar: two stacked rows (event types, then players) on the
+   left, with the warning(s) on the right spanning both rows. Sits above the
+   map/list grid so the map and the events list top-align. */
+.workflow-events-controls {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.workflow-events-filters {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.workflow-events-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Borderless toggle chips — a soft fill marks the active/hovered state. */
+.workflow-events-filter-chip,
+.workflow-events-player-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  user-select: none;
+  transition: background 120ms ease, opacity 120ms ease;
+}
+
+.workflow-events-filter-chip input,
+.workflow-events-player-chip input {
+  margin: 0;
+  cursor: inherit;
+}
+
+.workflow-events-filter-chip:hover,
+.workflow-events-player-chip:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.workflow-events-filter-chip--active,
+.workflow-events-filter-chip--active:hover {
+  background: rgba(100, 150, 255, 0.18);
+  color: #fff;
+}
+
+.workflow-events-filter-chip--disabled,
+.workflow-events-filter-chip--disabled:hover {
+  opacity: 0.32;
+  cursor: not-allowed;
+  background: transparent;
+}
+
+/* Player chips keep their player colour (set inline). Disabled = filtered out. */
+.workflow-events-player-chip--off {
+  opacity: 0.4;
+}
+
+/* Warnings column: to the right of the filter rows, vertically centred so a
+   single notice reads as spanning both rows. */
+.workflow-events-warnings {
+  flex: 0 0 auto;
+  width: clamp(220px, 30%, 420px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 8px;
+}
+
+.workflow-events-controls .workflow-events-warning {
+  margin: 0;
+  flex: none;
+  max-width: none;
+  width: 100%;
+}
+
 .workflow-event-map-panel {
   display: flex;
   flex-direction: column;
@@ -3504,6 +3592,62 @@ body {
   fill: rgba(100, 150, 255, 0.25);
   stroke: rgba(120, 180, 255, 0.95);
   stroke-width: 0.4;
+}
+
+/* Consolidated BO openers event: per-start-location label painted on each
+   player's starting polygon. Race icon + crown + name on the first line, BO
+   name(s) on the second. Centered on the polygon centroid via the inline
+   left/top percent + translate(-50%, -50%). */
+.workflow-event-map-bo-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1px;
+  text-align: center;
+  line-height: 1.15;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.95), 0 0 2px rgba(0, 0, 0, 0.95);
+  white-space: nowrap;
+}
+
+.workflow-event-map-bo-label-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.workflow-event-map-bo-label-race {
+  width: 14px;
+  height: 14px;
+}
+
+.workflow-event-map-bo-label-bo {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+/* BO openers event row: one line per player stacked vertically. */
+.workflow-bo-openers {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.workflow-bo-openers-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.workflow-bo-openers-race {
+  width: 15px;
+  height: 15px;
 }
 
 .workflow-event-map-attack-line {
@@ -3692,17 +3836,27 @@ body {
 
 .workflow-event-row {
   display: grid;
-  grid-template-columns: 80px 1fr;
-  gap: 10px;
-  align-items: start;
-  padding: 6px 8px;
-  background: rgba(255, 255, 255, 0.03);
+  grid-template-columns: 56px 1fr;
+  gap: 12px;
+  align-items: baseline;
+  padding: 5px 8px;
+  background: transparent;
   border-radius: 6px;
-  border: 1px solid transparent;
+  border: none;
   width: 100%;
   text-align: left;
   color: inherit;
   cursor: pointer;
+}
+
+.workflow-event-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.workflow-event-row-time {
+  color: rgba(255, 255, 255, 0.45);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
 }
 
 .workflow-event-row-body {
@@ -3746,23 +3900,22 @@ body {
   font-weight: 600;
 }
 
-.workflow-event-row-selected {
-  border-color: rgba(100, 150, 255, 0.55);
-  background: rgba(100, 150, 255, 0.16);
+.workflow-event-row-selected,
+.workflow-event-row-selected:hover {
+  background: rgba(100, 150, 255, 0.12);
 }
 
 .workflow-events-section-header {
-  margin: 8px 0 2px;
-  padding: 2px 6px;
-  font-size: 0.74rem;
+  margin: 12px 0 2px;
+  padding: 0 8px;
+  font-size: 0.7rem;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.7);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.4);
 }
 
 .workflow-events-section-header:first-child {
-  margin-top: 0;
+  margin-top: 2px;
 }
 
 @keyframes workflow-event-overlay-appear {

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -4655,6 +4655,16 @@ body {
   gap: 12px;
 }
 
+/* Type hierarchy: the two section headings read as the page-level tier — larger
+   and heavier than the matchup-card labels nested under them, which in turn sit
+   above the uppercase sub-labels. Without this the headings and card labels are
+   the same size and the nesting isn't legible. */
+.workflow-card-player-special > .workflow-card-title,
+.workflow-card-player-matchups > .workflow-card-title {
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
 .workflow-player-matchup-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
@@ -4687,7 +4697,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 1.02rem;
+  font-size: 0.95rem;
 }
 
 .workflow-player-matchup-card-meta {

--- a/internal/parser/replay.go
+++ b/internal/parser/replay.go
@@ -259,7 +259,13 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 	// tags, which command extraction above discards) and plan the tag-based
 	// build dedup: provable worker one-at-a-time drops + never-produced
 	// production buildings. The plan is applied inside the early filter.
-	buildDedupPlan := builddedup.Compute(unittags.Analyze(rep), data.Players)
+	unitTagEvidence := unittags.Analyze(rep)
+	buildDedupPlan := builddedup.Compute(unitTagEvidence, data.Players)
+
+	// Maintain base ownership from unit production: a Train/Morph proves the
+	// producing building (and thus its base) is still alive, so it refreshes
+	// ownership where movement/build commands alone would let the base time out.
+	patternOrchestrator.SetProductionSignals(unitTagEvidence)
 
 	// Run the early-game spam filter before pattern detection so the
 	// orchestrator only sees commands the filter believes were real.

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -1271,8 +1271,8 @@ func allMarkers() []Marker {
 			Race:          RaceTerran,
 			Custom:        func() CustomEvaluator { return &cliffDropEvaluator{} },
 			RuleDeadline:  endOfReplaySentinel,
-			SummaryPlayer: &Pill{Label: "Cliff drop at min {minute}", IconKey: "dropship"},
-			SummaryReplay: &Pill{Label: "Cliff drop at min {minute}", IconKey: "dropship"},
+			SummaryPlayer: &Pill{Label: "Cliff drop", IconKey: "dropship"},
+			SummaryReplay: &Pill{Label: "Cliff drop", IconKey: "dropship"},
 			GamesList:     &Pill{Label: "Cliff drop", IconKey: "dropship"},
 		},
 		{
@@ -1313,6 +1313,22 @@ func allMarkers() []Marker {
 			RuleDeadline:  endOfReplaySentinel,
 			SummaryPlayer: &Pill{Label: "10+ Scouts", IconKey: "scout", Style: PillStyleStrong, Title: "10+ Scouts"},
 			GamesList:     &Pill{Label: "10+ Scouts", IconKey: "scout", Style: PillStyleStrong, Title: "10+ Scouts"},
+		},
+		{
+			// Wraiths: air-heavy Terran play. The "mass air" threshold scales
+			// with team format — 3+ Wraiths reads as a deliberate air opener in
+			// a 1v1, whereas team games need 10+ (like 10+ Scouts) before the
+			// count is signal rather than incidental harass. The format-aware
+			// threshold lives in the evaluator (ctx.Replay.TeamFormat).
+			Name:          "Wraiths",
+			PatternName:   "Wraiths",
+			FeatureKey:    "wraiths",
+			Kind:          KindMarker,
+			Race:          RaceTerran,
+			Custom:        func() CustomEvaluator { return &wraithCountEvaluator{} },
+			RuleDeadline:  endOfReplaySentinel,
+			SummaryPlayer: &Pill{Label: "Wraiths", IconKey: "wraith", Style: PillStyleStrong, Title: "Wraiths"},
+			GamesList:     &Pill{Label: "Wraiths", IconKey: "wraith", Style: PillStyleStrong, Title: "Wraiths"},
 		},
 		{
 			Name:             "Never upgraded",
@@ -1394,7 +1410,7 @@ func allMarkers() []Marker {
 			// Suppressed on the summary player row when the backend already emits a
 			// drop game_event (the frontend de-dupes via trustGameEventsForDrops);
 			// we still expose the pill for the Events-list / raw consumers.
-			SummaryPlayer: &Pill{Label: "Made drops at min {minute}"},
+			SummaryPlayer: &Pill{Label: "Made drops"},
 		},
 		{
 			Name:          "Made recalls",
@@ -1404,7 +1420,7 @@ func allMarkers() []Marker {
 			Race:          RaceProtoss,
 			Custom:        func() CustomEvaluator { return &firstCastEvaluator{subject: "Recall"} },
 			RuleDeadline:  endOfReplaySentinel,
-			SummaryPlayer: &Pill{Label: "Recalls at min {minute}", IconKey: "arbiter"},
+			SummaryPlayer: &Pill{Label: "Recalls", IconKey: "arbiter"},
 			GamesList:     &Pill{Label: "Recalls", IconKey: "arbiter"},
 		},
 		{
@@ -1415,7 +1431,7 @@ func allMarkers() []Marker {
 			Race:          RaceTerran,
 			Custom:        func() CustomEvaluator { return &worldstateFirstEventEvaluator{eventType: "nuke"} },
 			RuleDeadline:  endOfReplaySentinel,
-			SummaryPlayer: &Pill{Label: "Threw Nukes at {minute} mins"},
+			SummaryPlayer: &Pill{Label: "Threw Nukes", IconKey: "ghost"},
 			GamesList:     &Pill{Label: "Nukes", IconKey: "ghost"},
 		},
 		{
@@ -1426,7 +1442,7 @@ func allMarkers() []Marker {
 			Custom:       func() CustomEvaluator { return &worldstateFirstEventEvaluator{eventType: "became_terran"} },
 			RuleDeadline: endOfReplaySentinel,
 			SummaryPlayer: &Pill{
-				Label:   "Terran at {minute} mins",
+				Label:   "Became Terran",
 				IconKey: "darkarchon",
 				Style:   PillStyleStrong,
 				Title:   "Became Terran",
@@ -1440,7 +1456,7 @@ func allMarkers() []Marker {
 			Custom:       func() CustomEvaluator { return &worldstateFirstEventEvaluator{eventType: "became_zerg"} },
 			RuleDeadline: endOfReplaySentinel,
 			SummaryPlayer: &Pill{
-				Label:   "Zerg at {minute} mins",
+				Label:   "Became Zerg",
 				IconKey: "darkarchon",
 				Style:   PillStyleStrong,
 				Title:   "Became Zerg",

--- a/internal/patterns/markers/evaluators.go
+++ b/internal/patterns/markers/evaluators.go
@@ -79,6 +79,40 @@ func (e *firstCastEvaluator) Finalize(_ CustomEvalContext) CustomResult {
 }
 
 // -----------------------------------------------------------------------------
+// wraithCountEvaluator: air-heavy Terran marker with a team-format-aware
+// threshold. 1v1 needs 3+ Wraiths (a deliberate air opener); team games need
+// 10+ before the count is signal rather than incidental harass (same rationale
+// as 10+ Scouts). DetectedAtSecond is the second the threshold was crossed.
+// -----------------------------------------------------------------------------
+
+type wraithCountEvaluator struct {
+	count      int
+	secByCount []int // secByCount[i] = second the (i+1)-th Wraith was produced
+}
+
+func (e *wraithCountEvaluator) Observe(f cmdenrich.EnrichedCommand) {
+	if f.Kind != cmdenrich.KindMakeUnit || f.Subject != models.GeneralUnitWraith {
+		return
+	}
+	e.count++
+	e.secByCount = append(e.secByCount, f.Second)
+}
+
+func (e *wraithCountEvaluator) Finalize(ctx CustomEvalContext) CustomResult {
+	threshold := 10
+	if ctx.Replay != nil && ctx.Replay.TeamFormat == "1v1" {
+		threshold = 3
+	}
+	if e.count < threshold {
+		return CustomResult{}
+	}
+	return CustomResult{
+		Matched:          true,
+		DetectedAtSecond: e.secByCount[threshold-1],
+	}
+}
+
+// -----------------------------------------------------------------------------
 // viewportMultitaskingEvaluator: migrates ViewportMultitaskingPlayerDetector.
 // Tracks viewport-level coordinate jumps in the middle window of the replay.
 // Emits a formatted switches-per-minute string (ValueString), matching the

--- a/internal/patterns/orchestrator.go
+++ b/internal/patterns/orchestrator.go
@@ -1,11 +1,12 @@
 package patterns
 
 import (
-	"github.com/marianogappa/screpdb/internal/patterns/markers"
 	"github.com/marianogappa/screpdb/internal/models"
 	"github.com/marianogappa/screpdb/internal/patterns/core"
 	"github.com/marianogappa/screpdb/internal/patterns/detectors"
+	"github.com/marianogappa/screpdb/internal/patterns/markers"
 	"github.com/marianogappa/screpdb/internal/patterns/worldstate"
+	"github.com/marianogappa/screpdb/internal/unittags"
 )
 
 // ReplayLevelDetectorFactory creates a replay-level detector
@@ -175,6 +176,28 @@ func (o *Orchestrator) AppendReplayEvents(events []worldstate.ReplayEvent) {
 // ReplayEvents/Entries instead.
 func (o *Orchestrator) WorldStateEngine() *worldstate.Engine {
 	return o.worldState
+}
+
+// SetProductionSignals threads selection-derived production-location evidence
+// into the worldstate engine so base ownership is maintained by unit production
+// (see worldstate.ProductionSignal). Must be called before results are read.
+func (o *Orchestrator) SetProductionSignals(ev *unittags.Evidence) {
+	if o.worldState == nil || ev == nil {
+		return
+	}
+	var signals []worldstate.ProductionSignal
+	for pid, pe := range ev.Players {
+		for _, s := range pe.ProductionSignals {
+			signals = append(signals, worldstate.ProductionSignal{
+				PlayerID: pid,
+				Sec:      s.Sec,
+				X:        s.X,
+				Y:        s.Y,
+				Anchored: s.Anchored,
+			})
+		}
+	}
+	o.worldState.SetProductionSignals(signals)
 }
 
 // ConvertResultsToDatabaseIDs converts pattern results from replay player IDs to database player IDs

--- a/internal/patterns/worldstate/attack_filter_debug.go
+++ b/internal/patterns/worldstate/attack_filter_debug.go
@@ -38,7 +38,7 @@ func (e *Engine) ReportAttackFilter() AttackFilterReport {
 	if e.replay != nil {
 		durationSec = e.replay.DurationSeconds
 	}
-	ownership := BuildOwnership(e.stream, e.polygonGeoms, starts, durationSec)
+	ownership := BuildOwnership(e.stream, e.polygonGeoms, starts, e.productionSignals, durationSec)
 	candidates := BuildAttacks(e.stream, e.polygonGeoms, ownership, e.teams)
 
 	sort.SliceStable(candidates, func(i, j int) bool {

--- a/internal/patterns/worldstate/engine.go
+++ b/internal/patterns/worldstate/engine.go
@@ -179,6 +179,18 @@ type Engine struct {
 	leaveSec       map[byte]int
 	lastCmdSec     map[byte]int
 	finalized      bool
+
+	// productionSignals feeds BuildOwnership: per-player Train/Morph location
+	// datapoints that refresh base ownership. nil when the caller never set them
+	// (e.g. the debug map-layout endpoint) — ownership then behaves as before.
+	productionSignals []ProductionSignal
+}
+
+// SetProductionSignals supplies the per-player production-location signals used
+// to maintain base ownership (see ProductionSignal). Must be called before
+// Finalize. Source is internal/unittags, threaded via the orchestrator.
+func (e *Engine) SetProductionSignals(signals []ProductionSignal) {
+	e.productionSignals = signals
 }
 
 func NewEngine(replay *models.Replay, players []*models.Player, mapCtx *models.ReplayMapContext) *Engine {
@@ -355,7 +367,7 @@ func (e *Engine) Finalize() {
 			durationSec = e.replay.DurationSeconds
 		}
 
-		ownership = BuildOwnership(e.stream, e.polygonGeoms, starts, durationSec)
+		ownership = BuildOwnership(e.stream, e.polygonGeoms, starts, e.productionSignals, durationSec)
 		candidates = BuildAttacks(e.stream, e.polygonGeoms, ownership, e.teams)
 
 		// Run the drops pass and feed its candidates back into the shared

--- a/internal/patterns/worldstate/ownership_pass.go
+++ b/internal/patterns/worldstate/ownership_pass.go
@@ -17,10 +17,10 @@ import (
 //     bug where pure movement/attack commands didn't refresh ownership).
 //   - Any KindMakeBuilding by another player into a polygon is a
 //     contested-takeover signal. Takeover happens when:
-//       (a) ≥ minContestedBuildSignalsOnStart (3) signals in the last
-//           contestedInvadeBuildWindowSec (180) AND polygon is starting; OR
-//       (b) the build is a resource building (CC/Nexus/Hatchery), regardless
-//           of starting flag (decisive ownership flip).
+//     (a) ≥ minContestedBuildSignalsOnStart (3) signals in the last
+//     contestedInvadeBuildWindowSec (180) AND polygon is starting; OR
+//     (b) the build is a resource building (CC/Nexus/Hatchery), regardless
+//     of starting flag (decisive ownership flip).
 //     AND the current owner has been quiet for ≥ contestedSwitchSec (45s).
 //     Takeover timestamp = earliest signal in the window.
 //   - If a polygon's owner has been quiet for > ownershipTimeoutSec
@@ -28,7 +28,6 @@ import (
 //     ownership reverts to neutral with reason "timeout".
 //   - Town hall placed by a player into a non-starting polygon they own
 //     (and haven't expanded to before) emits an "expansion" reason.
-//
 const (
 	ownershipTimeoutSec             = 180
 	contestedSwitchSec              = 45
@@ -52,6 +51,21 @@ type OwnEvent struct {
 type PolyOwnership struct {
 	PolyID int
 	Events []OwnEvent
+}
+
+// ProductionSignal is one "the producing building is alive here" datapoint fed
+// into the ownership pass: a player trained/morphed a unit at second Sec from a
+// building at tile (X, Y) when Anchored, or from a building whose location could
+// not be pinned (the spawn-seeded starting town hall, or a producer tag matched
+// to no Build) when not — those resolve to the player's start base. A signal
+// only REFRESHES the inactivity clock of a base the player still owns; it never
+// claims, contests, or resurrects a base (see BuildOwnership). Derived from
+// selection-tag tracking in internal/unittags; X, Y are build-placement tiles.
+type ProductionSignal struct {
+	PlayerID byte
+	Sec      int
+	X, Y     int
+	Anchored bool
 }
 
 // PolygonGeom is the minimum the state machine needs from a polygon:
@@ -97,7 +111,7 @@ func IsResourceBuilding(name string) bool {
 //
 // All time comparisons are in seconds (ec.Second). Frame is incidental and
 // only used for ordering inside EnrichFromCommands.
-func BuildOwnership(stream []cmdenrich.EnrichedCommand, polys []PolygonGeom, players []PlayerStart, durationSec int) []PolyOwnership {
+func BuildOwnership(stream []cmdenrich.EnrichedCommand, polys []PolygonGeom, players []PlayerStart, prodSignals []ProductionSignal, durationSec int) []PolyOwnership {
 	timelines := make([][]OwnEvent, len(polys))
 	for i := range timelines {
 		timelines[i] = []OwnEvent{{Sec: 0, Owner: neutralPID, Reason: "init"}}
@@ -161,7 +175,35 @@ func BuildOwnership(stream []cmdenrich.EnrichedCommand, polys []PolygonGeom, pla
 		}
 	}
 
+	// Production signals refresh the inactivity clock of a base the player still
+	// owns — a Train/Morph proves the producing building (and thus the base) is
+	// alive. Processed in time order, interleaved with the command stream: each
+	// signal behaves like a refresh-only command at its own second (timeout
+	// evaluated first, then refresh-if-still-owned). It never claims a neutral
+	// polygon, contests an opponent, or resurrects a base that already reverted
+	// — only lastOwningSec is touched, so takeover/expansion logic is untouched.
+	signals := append([]ProductionSignal(nil), prodSignals...)
+	sort.Slice(signals, func(i, j int) bool { return signals[i].Sec < signals[j].Sec })
+	sigIdx := 0
+	drainSignals := func(upTo int) {
+		for sigIdx < len(signals) && signals[sigIdx].Sec <= upTo {
+			sig := signals[sigIdx]
+			sigIdx++
+			flushTimeouts(sig.Sec)
+			pi := -1
+			if sig.Anchored {
+				pi = pointInPolyGeom(polys, sig.X*32+16, sig.Y*32+16)
+			} else if sp, ok := startPolyByPlayer[sig.PlayerID]; ok {
+				pi = sp
+			}
+			if pi >= 0 && owner[pi] == sig.PlayerID {
+				lastOwningSec[pi][sig.PlayerID] = sig.Sec
+			}
+		}
+	}
+
 	for _, ec := range stream {
+		drainSignals(ec.Second)
 		flushTimeouts(ec.Second)
 
 		if ec.X == nil || ec.Y == nil {
@@ -284,6 +326,10 @@ func BuildOwnership(stream []cmdenrich.EnrichedCommand, polys []PolygonGeom, pla
 			timelines[pi] = append(timelines[pi], OwnEvent{Sec: takeoverSec, Owner: p, Reason: "takeover"})
 		}
 	}
+
+	// Drain production signals after the last command — a player whose final
+	// activity is a Train/Morph (no later movement/build) must still refresh.
+	drainSignals(1 << 30)
 
 	// Intentionally NO end-of-replay flushTimeouts call. The legacy
 	// emit-as-you-go semantics let players keep ownership of their main

--- a/internal/patterns/worldstate/testdata/recalls_golden.json
+++ b/internal/patterns/worldstate/testdata/recalls_golden.json
@@ -22,20 +22,23 @@
         "count": 1,
         "source_label": "center base",
         "target_label": "7",
-        "target_via": "p"
+        "target_via": "p",
+        "target_owner_pid": 2
       },
       {
         "second": 1757,
         "count": 1,
         "target_label": "7",
-        "target_via": "p"
+        "target_via": "p",
+        "target_owner_pid": 2
       },
       {
         "second": 1758,
         "count": 1,
         "source_label": "12's natural",
         "target_label": "7",
-        "target_via": "p"
+        "target_via": "p",
+        "target_owner_pid": 2
       },
       {
         "second": 2078,

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -90,7 +90,12 @@ func TestSQLiteStorage_IngestionAndQueries(t *testing.T) {
 		// (Wraith/Goliath TvZ, Bio TvZ-or-non-1v1), so a few off-matchup Terran
 		// players whose composition matches a gated BO get no opener row — the
 		// deliberate coverage gap documented on tNamed.
-		"replay_events": 207,
+		//
+		// Down from 207 after unit-production began maintaining base ownership:
+		// a Train/Morph proves the producing building's base is alive, so
+		// location_inactive (timeout) events dropped 35→21 (-14) and one attack
+		// on a now-owned base surfaced (+1), for a net -13.
+		"replay_events": 194,
 	}
 	actualCounts, err := collectCounts(store, keys(expectedCounts))
 	if err != nil {

--- a/internal/unittags/unittags.go
+++ b/internal/unittags/unittags.go
@@ -13,6 +13,8 @@
 package unittags
 
 import (
+	"sort"
+
 	"github.com/icza/screp/rep"
 	"github.com/icza/screp/rep/repcmd"
 )
@@ -41,6 +43,26 @@ var addonParent = map[string]string{
 	"Comsat Station": "Command Center", "Nuclear Silo": "Command Center",
 }
 
+// larvaMorphUnits are the units that morph from a Hatchery/Lair/Hive's larvae.
+// Unlike Terran/Protoss trains, a larva-morph selects the larvae, not the
+// town hall — so the producing hall is recovered from the selection that
+// immediately preceded the larvae select (see the town-hall attribution in
+// Analyze). Non-larva morphs (Lurker, Guardian, Devourer, building morphs) are
+// deliberately absent: they select the morphing unit, not a town hall.
+var larvaMorphUnits = map[string]bool{
+	"Drone": true, "Zergling": true, "Hydralisk": true, "Mutalisk": true,
+	"Overlord": true, "Defiler": true, "Ultralisk": true, "Queen": true,
+	"Scourge": true, "Infested Terran": true,
+}
+
+// zergTownHall is the synthetic producer-building key under which Zerg town-hall
+// (Hatchery/Lair/Hive) larva production is recorded in Producers. Larva morphs
+// are attributed to the town-hall unit tag selected just before the larvae, so
+// the same tag→Build-location correlation used for Terran/Protoss applies. The
+// key is "Hatchery" so it correlates against the player's Hatchery Build
+// placements (Lair/Hive are tag-preserving morphs of an existing Hatchery).
+const zergTownHall = "Hatchery"
+
 // WorkerBuild records one Build command issued with a single worker selected.
 type WorkerBuild struct {
 	PlayerID byte
@@ -62,6 +84,20 @@ type Build struct {
 type Production struct {
 	FirstSec int
 	Units    int
+	// Secs is the second of every Train/Morph event from this building tag, in
+	// stream order. Used by the ownership pass to refresh base ownership at each
+	// production moment (a producing building proves the base is still alive).
+	Secs []int
+}
+
+// ProductionSignal is one "the producing building is alive here" datapoint:
+// a Train/Morph at second Sec from a building whose location is the build tile
+// (X, Y) when Anchored, or the player's start base when not (the spawn-seeded
+// starting town hall, or a producer whose tag matched no Build command).
+type ProductionSignal struct {
+	Sec      int
+	X, Y     int // build placement tile; meaningful only when Anchored
+	Anchored bool
 }
 
 // PlayerEvidence is the per-player evidence extracted from selection state.
@@ -74,6 +110,10 @@ type PlayerEvidence struct {
 	Producers map[string]map[uint16]*Production
 	// Addons maps building type -> set of tags proven to exist by an add-on.
 	Addons map[string]map[uint16]bool
+	// ProductionSignals is the derived, time-ordered list of production-location
+	// datapoints (see ProductionSignal). Populated by attributeProductionLocations
+	// at the end of Analyze.
+	ProductionSignals []ProductionSignal
 }
 
 // Evidence holds per-player evidence keyed by replay PlayerID.
@@ -91,6 +131,12 @@ func Analyze(r *rep.Replay) *Evidence {
 	type selState struct {
 		cur    []uint16
 		groups map[byte][]uint16
+		// prevSingle is the single unit tag selected immediately before the
+		// current selection, when the prior selection held exactly one unit.
+		// A Zerg larva morph selects larvae, not the town hall, so the hall is
+		// recovered from this prior single-select (the macro-cycle hatch tap).
+		prevSingle      uint16
+		prevSingleValid bool
 	}
 	states := map[byte]*selState{}
 	get := func(pid byte) (*selState, *PlayerEvidence) {
@@ -105,6 +151,29 @@ func Analyze(r *rep.Replay) *Evidence {
 		return states[pid], ev.Players[pid]
 	}
 
+	// snap records the single-ness of the current selection before it is
+	// replaced, so a following larva morph can attribute to the prior hall tap.
+	snap := func(s *selState) {
+		if len(s.cur) == 1 {
+			s.prevSingle, s.prevSingleValid = s.cur[0], true
+		} else {
+			s.prevSingleValid = false
+		}
+	}
+
+	recordProduction := func(pe *PlayerEvidence, bldg string, tag uint16, sec int) {
+		if pe.Producers[bldg] == nil {
+			pe.Producers[bldg] = map[uint16]*Production{}
+		}
+		p := pe.Producers[bldg][tag]
+		if p == nil {
+			p = &Production{FirstSec: sec}
+			pe.Producers[bldg][tag] = p
+		}
+		p.Units++
+		p.Secs = append(p.Secs, sec)
+	}
+
 	for _, c := range r.Commands.Cmds {
 		b := c.BaseCmd()
 		if b == nil || b.Type == nil {
@@ -116,14 +185,17 @@ func Analyze(r *rep.Replay) *Evidence {
 		switch b.Type.ID {
 		case repcmd.TypeIDSelect, repcmd.TypeIDSelect121:
 			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
 				s.cur = tagsOf(sc.UnitTags)
 			}
 		case repcmd.TypeIDSelectAdd, repcmd.TypeIDSelectAdd121:
 			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
 				s.cur = unionTags(s.cur, tagsOf(sc.UnitTags))
 			}
 		case repcmd.TypeIDSelectRemove, repcmd.TypeIDSelectRemove121:
 			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
 				s.cur = removeTags(s.cur, tagsOf(sc.UnitTags))
 			}
 		case repcmd.TypeIDHotkey:
@@ -132,8 +204,10 @@ func Analyze(r *rep.Replay) *Evidence {
 				case "Assign":
 					s.groups[hc.Group] = append([]uint16(nil), s.cur...)
 				case "Select":
+					snap(s)
 					s.cur = append([]uint16(nil), s.groups[hc.Group]...)
 				case "Add":
+					snap(s)
 					s.cur = unionTags(s.cur, s.groups[hc.Group])
 				}
 			}
@@ -160,26 +234,88 @@ func Analyze(r *rep.Replay) *Evidence {
 			}
 		case repcmd.TypeIDTrain, repcmd.TypeIDUnitMorph:
 			tc, ok := c.(*repcmd.TrainCmd)
-			if !ok || tc.Unit == nil || len(s.cur) != 1 {
+			if !ok || tc.Unit == nil {
 				continue
 			}
-			bldg, ok := producerBuilding[tc.Unit.Name]
-			if !ok {
+			name := tc.Unit.Name
+			if bldg, ok := producerBuilding[name]; ok {
+				// Terran/Protoss: the producing building IS the single-selected
+				// unit (Train operates on the selected production structure).
+				if len(s.cur) == 1 {
+					recordProduction(pe, bldg, s.cur[0], sec)
+				}
 				continue
 			}
-			tag := s.cur[0]
-			if pe.Producers[bldg] == nil {
-				pe.Producers[bldg] = map[uint16]*Production{}
+			if larvaMorphUnits[name] && s.prevSingleValid {
+				// Zerg larva morph: attribute to the town-hall tag tapped just
+				// before the larvae select (see prevSingle).
+				recordProduction(pe, zergTownHall, s.prevSingle, sec)
 			}
-			p := pe.Producers[bldg][tag]
-			if p == nil {
-				p = &Production{FirstSec: sec}
-				pe.Producers[bldg][tag] = p
-			}
-			p.Units++
 		}
 	}
+
+	for _, pe := range ev.Players {
+		attributeProductionLocations(pe)
+	}
 	return ev
+}
+
+// attributeProductionLocations derives PlayerEvidence.ProductionSignals: it maps
+// each producing building tag to a build placement (so production refreshes the
+// right base), then emits one signal per production second. Tags that match no
+// Build command — the spawn-seeded starting town hall, or extras left unmatched
+// — emit Anchored:false signals the ownership pass resolves to the start base.
+func attributeProductionLocations(pe *PlayerEvidence) {
+	var signals []ProductionSignal
+	for bldg, tags := range pe.Producers {
+		loc := matchProducerTagsToBuilds(tags, pe.Builds[bldg])
+		for tag, p := range tags {
+			b, anchored := loc[tag]
+			for _, sec := range p.Secs {
+				sig := ProductionSignal{Sec: sec, Anchored: anchored}
+				if anchored {
+					sig.X, sig.Y = b.X, b.Y
+				}
+				signals = append(signals, sig)
+			}
+		}
+	}
+	sort.Slice(signals, func(i, j int) bool { return signals[i].Sec < signals[j].Sec })
+	pe.ProductionSignals = signals
+}
+
+// matchProducerTagsToBuilds greedily assigns each producing tag (earliest first
+// producer wins) to the earliest unclaimed Build placed at or before that tag's
+// first production — a building cannot produce before it is commanded. Returns
+// the assigned Build per matched tag; unmatched tags are absent from the map
+// (the starting town hall has no Build, and surplus tags fall back to the
+// start base in the ownership pass).
+func matchProducerTagsToBuilds(tags map[uint16]*Production, builds []Build) map[uint16]Build {
+	type tagFirst struct {
+		tag      uint16
+		firstSec int
+	}
+	ordered := make([]tagFirst, 0, len(tags))
+	for tag, p := range tags {
+		ordered = append(ordered, tagFirst{tag: tag, firstSec: p.FirstSec})
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].firstSec < ordered[j].firstSec })
+
+	sorted := append([]Build(nil), builds...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Sec < sorted[j].Sec })
+	claimed := make([]bool, len(sorted))
+
+	out := map[uint16]Build{}
+	for _, t := range ordered {
+		for j := range sorted {
+			if !claimed[j] && sorted[j].Sec <= t.firstSec {
+				claimed[j] = true
+				out[t.tag] = sorted[j]
+				break
+			}
+		}
+	}
+	return out
 }
 
 func tagsOf(ut []repcmd.UnitTag) []uint16 {


### PR DESCRIPTION
Reworks the early-game event overlays and markers: cleans up the summary pills (drops the "at N mins" suffix, ghost-icon Nukes, "Became Terran/Zerg"), adds a matchup-aware Wraiths marker, makes unit production maintain base ownership (so producing players no longer falsely time out), and clarifies the player-summary title hierarchy. Closes #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)