### PR TITLE
fix: count non-HP upgrades as researches in Never-researched marker (closes #163)

### DIFF
--- a/internal/cmdenrich/cmdenrich.go
+++ b/internal/cmdenrich/cmdenrich.go
@@ -194,8 +194,9 @@ func Classify(cmd *models.Command) (EnrichedCommand, bool) {
 	// can match on the tech/upgrade name (e.g. "Tank Siege Mode",
 	// "Singularity Charge (Dragoon Range)"). Pre-fix this was empty, so
 	// any phase/composition/timing logic that read Subject for these
-	// kinds silently misclassified them. Existing predicates
-	// (UpgradeExists / TechExists) only key on Kind and are unaffected.
+	// kinds silently misclassified them. The Never-Upgraded /
+	// Never-Researched predicates key on this Subject to split HP
+	// upgrades from research-grade upgrades.
 	if kind == KindTech {
 		subject = strings.TrimSpace(stringPtr(cmd.TechName))
 	}

--- a/internal/models/upgrade_data.go
+++ b/internal/models/upgrade_data.go
@@ -228,3 +228,13 @@ func LookupUpgrade(name string) (UpgradeMeta, bool) {
 	m, ok := upgradeTable[name]
 	return m, ok
 }
+
+// IsHPUpgrade reports whether an upgrade name is a tiered weapon/armor/shield
+// upgrade — the "HP Upgrades" group. These are the only upgrades that count
+// toward the Never-Upgraded marker; every other (one-shot) upgrade is a
+// research and counts toward Never-Researched instead. Unknown names are not
+// treated as HP upgrades.
+func IsHPUpgrade(name string) bool {
+	m, ok := upgradeTable[name]
+	return ok && m.MaxLevel == 3
+}

--- a/internal/patterns/markers/definitions.go
+++ b/internal/patterns/markers/definitions.go
@@ -1335,7 +1335,7 @@ func allMarkers() []Marker {
 			PatternName:      "Never upgraded",
 			FeatureKey:       "never_upgraded",
 			Kind:             KindMarker,
-			Rule:             Not(UpgradeExists()),
+			Rule:             Not(HPUpgradeExists()),
 			RuleDeadline:     endOfReplaySentinel,
 			MinReplaySeconds: 10 * 60, // fallback for non-1v1
 			// 1v1 floor per (own_race, opp_race): p5 of first-Upgrade time
@@ -1361,7 +1361,7 @@ func allMarkers() []Marker {
 			SummaryPlayer: &Pill{
 				Label: "🚫 upgrades",
 				Style: PillStyleNegative,
-				Title: "No Upgrade commands in this replay for this player (suppressed on games shorter than matchup-typical first upgrade).",
+				Title: "No weapon/armor/shield upgrades in this replay for this player (suppressed on games shorter than matchup-typical first upgrade).",
 			},
 		},
 		{
@@ -1369,7 +1369,7 @@ func allMarkers() []Marker {
 			PatternName:      "Never researched",
 			FeatureKey:       "never_researched",
 			Kind:             KindMarker,
-			Rule:             Not(TechExists()),
+			Rule:             Not(Any(TechExists(), NonHPUpgradeExists())),
 			RuleDeadline:     endOfReplaySentinel,
 			MinReplaySeconds: 10 * 60, // fallback for non-1v1 (and ZvZ in 1v1, omitted below for n<20)
 			// 1v1 floor per (own_race, opp_race): p5 of first-Tech time
@@ -1394,7 +1394,7 @@ func allMarkers() []Marker {
 			SummaryPlayer: &Pill{
 				Label: "🚫 researches",
 				Style: PillStyleNegative,
-				Title: "No Tech commands in this replay for this player (suppressed on games shorter than matchup-typical first research).",
+				Title: "No tech or non-HP upgrade commands in this replay for this player (suppressed on games shorter than matchup-typical first research).",
 			},
 		},
 

--- a/internal/patterns/markers/dsl.go
+++ b/internal/patterns/markers/dsl.go
@@ -1,6 +1,9 @@
 package markers
 
-import "github.com/marianogappa/screpdb/internal/cmdenrich"
+import (
+	"github.com/marianogappa/screpdb/internal/cmdenrich"
+	"github.com/marianogappa/screpdb/internal/models"
+)
 
 // This file is the DSL for composing broad-match predicates. Each helper is a
 // small, independently testable rule; Marker definitions in definitions.go
@@ -235,19 +238,33 @@ func (s *produceCountAtLeastState) Observe(f cmdenrich.EnrichedCommand) {
 func (s *produceCountAtLeastState) Decision(int) TriState { return s.done }
 func (s *produceCountAtLeastState) Finalize() TriState    { return s.finalizeDefaultRejected() }
 
-// UpgradeExists matches as soon as any KindUpgrade fact arrives, regardless
-// of subject. Used via Not(...) for the Never-Upgraded marker.
-func UpgradeExists() Predicate {
-	return func() PredicateState { return &upgradeExistsState{} }
+// HPUpgradeExists matches as soon as any tiered weapon/armor/shield upgrade
+// (the "HP Upgrades" group) arrives. Used via Not(...) for the Never-Upgraded
+// marker: only HP upgrades count as "upgrading"; every other upgrade is a
+// research (see NonHPUpgradeExists).
+func HPUpgradeExists() Predicate {
+	return func() PredicateState { return &upgradeExistsState{wantHP: true} }
 }
 
-type upgradeExistsState struct{ commitState }
+// NonHPUpgradeExists matches as soon as any non-HP upgrade (range, speed,
+// energy, capacity/cooldown/damage — every upgrade tab except HP Upgrades)
+// arrives. Combined with TechExists via Any(...) to back the Never-Researched
+// marker: these upgrades are conceptually researches, split across tabs only
+// for chart readability.
+func NonHPUpgradeExists() Predicate {
+	return func() PredicateState { return &upgradeExistsState{wantHP: false} }
+}
+
+type upgradeExistsState struct {
+	commitState
+	wantHP bool
+}
 
 func (s *upgradeExistsState) Observe(f cmdenrich.EnrichedCommand) {
 	if s.done != Pending {
 		return
 	}
-	if f.Kind == cmdenrich.KindUpgrade {
+	if f.Kind == cmdenrich.KindUpgrade && models.IsHPUpgrade(f.Subject) == s.wantHP {
 		s.done = Matched
 	}
 }

--- a/internal/patterns/markers/dsl_test.go
+++ b/internal/patterns/markers/dsl_test.go
@@ -26,6 +26,16 @@ func (b *factsB) P(unit string, second int) *factsB {
 	return b.add(cmdenrich.KindMakeUnit, unit, second)
 }
 
+// U is shorthand for an Upgrade fact (Subject is the upgrade name).
+func (b *factsB) U(name string, second int) *factsB {
+	return b.add(cmdenrich.KindUpgrade, name, second)
+}
+
+// T is shorthand for a Tech fact.
+func (b *factsB) T(name string, second int) *factsB {
+	return b.add(cmdenrich.KindTech, name, second)
+}
+
 func (b *factsB) list() []cmdenrich.EnrichedCommand { return b.facts }
 
 func TestFirstBuildBefore(t *testing.T) {
@@ -199,5 +209,46 @@ func TestPredominant(t *testing.T) {
 	tie := factsBuilder().P("Marine", 200).P("Vulture", 260).list()
 	if Predominant(bio, mech, 600).Eval(tie) {
 		t.Fatalf("1v1 tie should not be predominant")
+	}
+}
+
+func TestHPUpgradeExists_OnlyTieredCount(t *testing.T) {
+	// A tiered weapon/armor/shield upgrade satisfies HPUpgradeExists.
+	tiered := factsBuilder().U("Protoss Ground Weapons", 300).list()
+	if !HPUpgradeExists().Eval(tiered) {
+		t.Fatalf("tiered upgrade should satisfy HPUpgradeExists")
+	}
+	if NonHPUpgradeExists().Eval(tiered) {
+		t.Fatalf("tiered upgrade must not satisfy NonHPUpgradeExists")
+	}
+	// A one-shot upgrade is a research, not an HP upgrade.
+	oneShot := factsBuilder().U("Singularity Charge (Dragoon Range)", 300).list()
+	if HPUpgradeExists().Eval(oneShot) {
+		t.Fatalf("one-shot upgrade must not satisfy HPUpgradeExists")
+	}
+	if !NonHPUpgradeExists().Eval(oneShot) {
+		t.Fatalf("one-shot upgrade should satisfy NonHPUpgradeExists")
+	}
+}
+
+// Never-Researched fires only when there is neither a Tech nor a non-HP
+// upgrade — HP-only games must still be flagged as "never researched".
+func TestNeverResearched_CountsNonHPUpgrades(t *testing.T) {
+	neverResearched := Not(Any(TechExists(), NonHPUpgradeExists()))
+
+	// Only an HP upgrade: still "never researched".
+	hpOnly := factsBuilder().U("Protoss Ground Weapons", 300).list()
+	if !neverResearched.Eval(hpOnly) {
+		t.Fatalf("HP-upgrade-only game should count as never researched")
+	}
+	// A range upgrade (non-HP) counts as a research.
+	withRange := factsBuilder().U("Singularity Charge (Dragoon Range)", 300).list()
+	if neverResearched.Eval(withRange) {
+		t.Fatalf("non-HP upgrade should clear never researched")
+	}
+	// A tech also counts as a research.
+	withTech := factsBuilder().T("Psionic Storm", 300).list()
+	if neverResearched.Eval(withTech) {
+		t.Fatalf("tech should clear never researched")
 	}
 }

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -126,11 +126,6 @@
       },
       {
         "replay_player_id": 1,
-        "pattern_name": "Never researched",
-        "value": "1110"
-      },
-      {
-        "replay_player_id": 1,
         "pattern_name": "Used Hotkey Groups",
         "value": "{\"groups\":[0,1,2,3,4,5,8,9]}"
       },
@@ -361,11 +356,6 @@
         "replay_player_id": 1,
         "pattern_name": "Build Order: Nexus First",
         "value": "{\"expert_actuals\":[{\"second\":46,\"found\":true},{\"second\":105,\"found\":true},{\"second\":125,\"found\":true}]}"
-      },
-      {
-        "replay_player_id": 1,
-        "pattern_name": "Never researched",
-        "value": "976"
       },
       {
         "replay_player_id": 1,

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -94,8 +94,9 @@ func TestSQLiteStorage_IngestionAndQueries(t *testing.T) {
 		// Down from 207 after unit-production began maintaining base ownership:
 		// a Train/Morph proves the producing building's base is alive, so
 		// location_inactive (timeout) events dropped 35→21 (-14) and one attack
-		// on a now-owned base surfaced (+1), for a net -13.
-		"replay_events": 194,
+		// on a now-owned base surfaced (+1), for a net -13. Then -1 (issue #163):
+		// a player who did only non-HP upgrades no longer trips Never-researched.
+		"replay_events": 193,
 	}
 	actualCounts, err := collectCounts(store, keys(expectedCounts))
 	if err != nil {

--- a/internal/testdata/replays/golden.json
+++ b/internal/testdata/replays/golden.json
@@ -33,7 +33,7 @@
       "commands": 13953,
       "patterns": {
         "replay": 2,
-        "player": 37
+        "player": 36
       }
     }
   ]


### PR DESCRIPTION
fixes #163 

Counts every upgrade tab except HP Upgrades (range/speed/energy/capacity, plus Tech) toward the Never-researched marker, and restricts Never-upgraded to HP (tiered weapon/armor/shield) upgrades.

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)