### PR TITLE
UI responsiveness: cap content at filter-bar width + games-list polish (closes #176)

### DIFF
--- a/internal/dashboard/endpoint_main_games_players_list.go
+++ b/internal/dashboard/endpoint_main_games_players_list.go
@@ -279,16 +279,11 @@ func (d *Dashboard) populateWorkflowGameListFeaturing(items []workflowGameListIt
 	replayIDs := make([]int64, 0, len(items))
 	itemIndexByReplayID := map[int64]int{}
 	featureSets := map[int64]map[string]struct{}{}
-	// secondsByKey caches detected_second per (replayID, featureKey) for
-	// pills whose label includes a {timestamp} placeholder (mutalisk_timing /
-	// turret_timing). Empty for keys whose label is static.
-	secondsByKey := map[int64]map[string]int64{}
 	mapKindByReplayID := map[int64]string{}
 	for i, item := range items {
 		replayIDs = append(replayIDs, item.ReplayID)
 		itemIndexByReplayID[item.ReplayID] = i
 		featureSets[item.ReplayID] = map[string]struct{}{}
-		secondsByKey[item.ReplayID] = map[string]int64{}
 		mapKindByReplayID[item.ReplayID] = item.MapKind
 	}
 	if len(replayIDs) == 0 {
@@ -304,12 +299,8 @@ func (d *Dashboard) populateWorkflowGameListFeaturing(items []workflowGameListIt
 		// (row presence alone = match; no value-column truthiness check needed).
 		featureKey := strings.TrimSpace(strings.ToLower(row.PatternName))
 		switch featureKey {
-		case "carriers", "battlecruisers", "ten_plus_scouts",
-			"mutalisk_timing", "turret_timing", "cliff_drop":
+		case "carriers", "battlecruisers", "ten_plus_scouts", "cliff_drop":
 			featureSets[replayID][featureKey] = struct{}{}
-			if featureKey == "mutalisk_timing" || featureKey == "turret_timing" {
-				secondsByKey[replayID][featureKey] = row.DetectedSecond
-			}
 		case "made_recalls":
 			featureSets[replayID]["recalls"] = struct{}{}
 		case "threw_nukes":
@@ -359,11 +350,7 @@ func (d *Dashboard) populateWorkflowGameListFeaturing(items []workflowGameListIt
 			if _, has := set[cfg.Key]; !has {
 				continue
 			}
-			label := cfg.Label
-			if sec, ok := secondsByKey[replayID][cfg.Key]; ok && sec > 0 {
-				label = fmt.Sprintf("%s %d:%02d", cfg.Label, sec/60, sec%60)
-			}
-			labels = append(labels, label)
+			labels = append(labels, cfg.Label)
 		}
 		items[idx].Featuring = labels
 	}
@@ -537,6 +524,7 @@ func (d *Dashboard) workflowGamesListFilterOptions() (workflowGamesListFilterOpt
 			IconKeys:  feature.IconKeys,
 			IconLabel: feature.IconLabel,
 			Emoji:     feature.Emoji,
+			Race:      feature.Race,
 		})
 	}
 	for _, matchup := range workflowMatchupFilters {

--- a/internal/dashboard/endpoint_main_view_types.go
+++ b/internal/dashboard/endpoint_main_view_types.go
@@ -160,6 +160,7 @@ type workflowGamesListFilterOption struct {
 	IconLabel string   `json:"icon_label,omitempty"`
 	Emoji     string   `json:"emoji,omitempty"`
 	Group     string   `json:"group,omitempty"`
+	Race      string   `json:"race,omitempty"`
 }
 
 type workflowGamesListFilterOptions struct {
@@ -203,12 +204,13 @@ var workflowFeaturingFilters = []struct {
 	IconKeys  []string
 	IconLabel string
 	Emoji     string
+	// Race ("zerg"/"terran"/"protoss") groups the "bo" chips under per-race
+	// disclosures on the games-list filter bar. Empty for "marker" chips.
+	Race string
 }{
 	// NOTE: the former Terran style markers (mech / sk_terran / one_one_one /
 	// mech_transition) are now first-class composition BOs — see the "bo" group
 	// below (issue #155).
-	{Key: "mutalisk_timing", Label: "Mutalisk timing", Group: "marker", IconKey: "mutalisk", IconLabel: "timing"},
-	{Key: "turret_timing", Label: "Turret timing", Group: "marker", IconKey: "missileturret", IconLabel: "Timing"},
 	{Key: "cannon_rush", Label: "Cannon Rush", Group: "marker", IconKey: "photoncannon", IconLabel: "Rush"},
 	{Key: "bunker_rush", Label: "Bunker Rush", Group: "marker", IconKey: "bunker", IconLabel: "Rush"},
 	{Key: "zergling_rush", Label: "Zergling Rush", Group: "marker", IconKey: "zergling", IconLabel: "Rush"},
@@ -233,42 +235,42 @@ var workflowFeaturingFilters = []struct {
 	// Build order pills — keys & labels kept in sync with internal/markers.
 	// Suppressed in render for Money maps (game-list + replay-summary
 	// featuring strips); BO tab and per-player summary pills still show.
-	{Key: "bo_4_pool", Label: "4 Pool", Group: "bo"},
-	{Key: "bo_9_pool", Label: "9 Pool", Group: "bo"},
-	{Key: "bo_9_overpool", Label: "9 Overpool", Group: "bo"},
-	{Key: "bo_12_pool", Label: "12 Pool", Group: "bo"},
-	{Key: "bo_9_pool_hatch", Label: "9 Pool into Hatchery", Group: "bo"},
-	{Key: "bo_9_hatch", Label: "9 Hatch", Group: "bo"},
-	{Key: "bo_10_hatch", Label: "10 Hatch", Group: "bo"},
-	{Key: "bo_11_hatch", Label: "11 Hatch", Group: "bo"},
-	{Key: "bo_12_hatch", Label: "12 Hatch", Group: "bo"},
-	{Key: "bo_1_gate_core", Label: "1 Gate Core", Group: "bo"},
-	{Key: "bo_2_gate", Label: "2 Gate", Group: "bo"},
-	{Key: "bo_nexus_first", Label: "Nexus First", Group: "bo"},
-	{Key: "bo_gate_expand", Label: "Gate Expand", Group: "bo"},
-	{Key: "bo_forge_expa", Label: "Forge Expand", Group: "bo"},
-	{Key: "bo_t_wraith", Label: "Wraith", Group: "bo"},
-	{Key: "bo_t_goliath", Label: "Goliath", Group: "bo"},
-	{Key: "bo_t_bio_1rax", Label: "1-Rax Bio", Group: "bo"},
-	{Key: "bo_t_bio_2rax", Label: "2-Rax Bio", Group: "bo"},
-	{Key: "bo_t_bio_3rax", Label: "3-Rax Bio", Group: "bo"},
-	{Key: "bo_t_bio_4rax", Label: "4-Rax Bio", Group: "bo"},
-	{Key: "bo_t_bio_5rax", Label: "5-Rax Bio", Group: "bo"},
-	{Key: "bo_t_bio_6rax", Label: "6+ Rax Bio", Group: "bo"},
-	{Key: "bo_t_111_mech", Label: "1-1-1 into Mech", Group: "bo"},
-	{Key: "bo_t_mech_2fac", Label: "2-Fac Mech", Group: "bo"},
-	{Key: "bo_t_mech_3fac", Label: "3-Fac Mech", Group: "bo"},
-	{Key: "bo_t_mech_4fac", Label: "4-Fac Mech", Group: "bo"},
-	{Key: "bo_t_mech_5fac", Label: "5-Fac Mech", Group: "bo"},
-	{Key: "bo_t_mech_6fac", Label: "6+ Fac Mech", Group: "bo"},
-	{Key: "bo_t_tankless_2fac", Label: "2-Fac Tankless Mech", Group: "bo"},
-	{Key: "bo_t_tankless_3fac", Label: "3-Fac Tankless Mech", Group: "bo"},
-	{Key: "bo_t_tankless_4fac", Label: "4-Fac Tankless Mech", Group: "bo"},
-	{Key: "bo_t_tankless_5fac", Label: "5-Fac Tankless Mech", Group: "bo"},
-	{Key: "bo_t_tankless_6fac", Label: "6+ Fac Tankless Mech", Group: "bo"},
-	{Key: "bo_t_111", Label: "1-1-1", Group: "bo"},
-	{Key: "bo_cc_first", Label: "CC First", Group: "bo"},
-	{Key: "bo_bbs", Label: "BBS", Group: "bo"},
+	{Key: "bo_4_pool", Label: "4 Pool", Group: "bo", Race: "zerg"},
+	{Key: "bo_9_pool", Label: "9 Pool", Group: "bo", Race: "zerg"},
+	{Key: "bo_9_overpool", Label: "9 Overpool", Group: "bo", Race: "zerg"},
+	{Key: "bo_12_pool", Label: "12 Pool", Group: "bo", Race: "zerg"},
+	{Key: "bo_9_pool_hatch", Label: "9 Pool into Hatchery", Group: "bo", Race: "zerg"},
+	{Key: "bo_9_hatch", Label: "9 Hatch", Group: "bo", Race: "zerg"},
+	{Key: "bo_10_hatch", Label: "10 Hatch", Group: "bo", Race: "zerg"},
+	{Key: "bo_11_hatch", Label: "11 Hatch", Group: "bo", Race: "zerg"},
+	{Key: "bo_12_hatch", Label: "12 Hatch", Group: "bo", Race: "zerg"},
+	{Key: "bo_1_gate_core", Label: "1 Gate Core", Group: "bo", Race: "protoss"},
+	{Key: "bo_2_gate", Label: "2 Gate", Group: "bo", Race: "protoss"},
+	{Key: "bo_nexus_first", Label: "Nexus First", Group: "bo", Race: "protoss"},
+	{Key: "bo_gate_expand", Label: "Gate Expand", Group: "bo", Race: "protoss"},
+	{Key: "bo_forge_expa", Label: "Forge Expand", Group: "bo", Race: "protoss"},
+	{Key: "bo_t_wraith", Label: "Wraith", Group: "bo", Race: "terran"},
+	{Key: "bo_t_goliath", Label: "Goliath", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_1rax", Label: "1-Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_2rax", Label: "2-Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_3rax", Label: "3-Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_4rax", Label: "4-Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_5rax", Label: "5-Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_bio_6rax", Label: "6+ Rax Bio", Group: "bo", Race: "terran"},
+	{Key: "bo_t_111_mech", Label: "1-1-1 into Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_mech_2fac", Label: "2-Fac Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_mech_3fac", Label: "3-Fac Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_mech_4fac", Label: "4-Fac Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_mech_5fac", Label: "5-Fac Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_mech_6fac", Label: "6+ Fac Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_tankless_2fac", Label: "2-Fac Tankless Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_tankless_3fac", Label: "3-Fac Tankless Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_tankless_4fac", Label: "4-Fac Tankless Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_tankless_5fac", Label: "5-Fac Tankless Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_tankless_6fac", Label: "6+ Fac Tankless Mech", Group: "bo", Race: "terran"},
+	{Key: "bo_t_111", Label: "1-1-1", Group: "bo", Race: "terran"},
+	{Key: "bo_cc_first", Label: "CC First", Group: "bo", Race: "terran"},
+	{Key: "bo_bbs", Label: "BBS", Group: "bo", Race: "terran"},
 }
 
 var workflowDurationFilterBuckets = []struct {

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -4525,6 +4525,11 @@ function App() {
     });
   };
 
+  // When every game on the page is a 2-player (1v1) match, the Players column
+  // is narrow and the table leaves lots of horizontal slack. Bump the type/icon
+  // sizes up from the compact 8-player defaults to use that space.
+  const mainGamesAllTwoPlayer = mainGames.length > 0
+    && mainGames.every((game) => (Array.isArray(game?.players) ? game.players.length : 0) <= 2);
   const mainGamesTotalPages = Math.max(1, Math.ceil((Number(mainGamesTotal) || 0) / MAIN_GAMES_PAGE_SIZE));
   const mainGamesFrom = mainGames.length === 0 ? 0 : ((mainGamesPage - 1) * MAIN_GAMES_PAGE_SIZE) + 1;
   const mainGamesTo = mainGames.length === 0
@@ -4857,7 +4862,7 @@ function App() {
               <div className="loading">Loading games...</div>
             ) : (
               <>
-                <table className="data-table workflow-table workflow-games-list-table">
+                <table className={`data-table workflow-table workflow-games-list-table${mainGamesAllTwoPlayer ? ' workflow-games-list-table--roomy' : ''}`}>
                   <thead>
                     <tr>
                       <th>Played</th>

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -5029,7 +5029,7 @@ function App() {
                   <div className="loading">Loading players...</div>
                 ) : (
                   <>
-                    <table className="data-table workflow-table">
+                    <table className="data-table workflow-table workflow-players-list-table">
                       <thead>
                         <tr>
                           <th className="workflow-sortable" onClick={() => setMainPlayersSort('name')}>Name {mainPlayersSortIndicator('name')}</th>

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -1902,7 +1902,7 @@ function App() {
     matchup: [],
     mapKind: [],
   });
-  const [mainGamesShowBOFilters, setMainGamesShowBOFilters] = useState(false);
+  const [mainGamesBORaceOpen, setMainGamesBORaceOpen] = useState('');
   const [mainGameDetailLoading, setMainGameDetailLoading] = useState(false);
   const [mainPlayerLoading, setMainPlayerLoading] = useState(false);
   const [selectedReplayId, setSelectedReplayId] = useState(() => initialMainRoute.replayId);
@@ -4789,29 +4789,40 @@ function App() {
                 })}
               </div>
               <div className="workflow-filter-group">
-                <button
-                  type="button"
-                  className={`workflow-filter-pill workflow-filter-pill-disclosure ${mainGamesShowBOFilters ? 'workflow-filter-pill-active' : ''}`}
-                  onClick={() => setMainGamesShowBOFilters((prev) => !prev)}
-                  aria-expanded={mainGamesShowBOFilters}
-                >
-                  Build orders {mainGamesShowBOFilters ? '▾' : '▸'}
-                </button>
-                {mainGamesShowBOFilters && (mainGamesFilterOptions.featuring || [])
-                  .filter((option) => (option.group || '') === 'bo')
-                  .map((option) => {
-                    const active = (mainGamesFilters.featuring || []).includes(option.key);
-                    return (
+                {['zerg', 'terran', 'protoss'].map((race) => {
+                  const raceBOs = (mainGamesFilterOptions.featuring || [])
+                    .filter((option) => (option.group || '') === 'bo' && (option.race || '') === race);
+                  if (raceBOs.length === 0) return null;
+                  const open = mainGamesBORaceOpen === race;
+                  const raceIcon = getWorkerIconForRace(race);
+                  const raceLabel = race.charAt(0).toUpperCase() + race.slice(1);
+                  return (
+                    <React.Fragment key={`wf-bo-race-${race}`}>
                       <button
-                        key={`wf-feature-bo-${option.key}`}
                         type="button"
-                        className={`workflow-filter-pill ${active ? 'workflow-filter-pill-active' : ''}`}
-                        onClick={() => toggleMainGameMultiFilter('featuring', option.key)}
+                        className={`workflow-filter-pill workflow-filter-pill-disclosure workflow-filter-pill-icon ${open ? 'workflow-filter-pill-active' : ''}`}
+                        onClick={() => setMainGamesBORaceOpen((prev) => (prev === race ? '' : race))}
+                        aria-expanded={open}
                       >
-                        {option.label}
+                        {raceIcon ? <img src={raceIcon} alt="" className="workflow-filter-pill-icon-img" /> : null}
+                        <span className="workflow-filter-pill-icon-label">{raceLabel} BOs {open ? '▾' : '▸'}</span>
                       </button>
-                    );
-                  })}
+                      {open && raceBOs.map((option) => {
+                        const active = (mainGamesFilters.featuring || []).includes(option.key);
+                        return (
+                          <button
+                            key={`wf-feature-bo-${option.key}`}
+                            type="button"
+                            className={`workflow-filter-pill ${active ? 'workflow-filter-pill-active' : ''}`}
+                            onClick={() => toggleMainGameMultiFilter('featuring', option.key)}
+                          >
+                            {option.label}
+                          </button>
+                        );
+                      })}
+                    </React.Fragment>
+                  );
+                })}
               </div>
             </div>
             <div className="workflow-summary-filter-row workflow-games-filter-row">
@@ -4865,11 +4876,11 @@ function App() {
                 <table className={`data-table workflow-table workflow-games-list-table${mainGamesAllTwoPlayer ? ' workflow-games-list-table--roomy' : ''}`}>
                   <thead>
                     <tr>
-                      <th>Played</th>
-                      <th>Players</th>
-                      <th>Map</th>
-                      <th>Duration</th>
-                      <th>Featuring</th>
+                      <th><span title="Played" aria-label="Played" role="img">📅</span></th>
+                      <th><span title="Players" aria-label="Players" role="img">🧑‍🤝‍🧑</span></th>
+                      <th><span title="Map" aria-label="Map" role="img">🗺️</span></th>
+                      <th><span title="Duration" aria-label="Duration" role="img">⏱️</span></th>
+                      <th><span title="Featuring" aria-label="Featuring" role="img">⭐</span></th>
                     </tr>
                   </thead>
                   <tbody>

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -2208,6 +2208,17 @@ body {
    rows. The Featuring column wraps first when space runs out (its pill container
    already flex-wraps); the Players column stays nowrap so the row doesn't grow
    vertically just to break the matchup over two lines. */
+/* Scale the games-list type with available width. The whole UI is capped at the
+   filter-bar width (~1540px), so once the viewport reaches that the rows have
+   their full width and slack to spare — grow the text up to the filter-bar font
+   size (0.78rem) so 8-player rows aren't needlessly tiny. Below the cap the
+   viewport is the constraint, so shrink back toward the compact size that keeps
+   an 8-player matchup on one line. Children below are em-relative so they scale
+   with this. (0.9em pill × 0.867rem ≈ 0.78rem = the filter font.) */
+.workflow-games-list-table {
+  font-size: clamp(0.8125rem, calc(0.8125rem + (100vw - 1300px) * 0.0037), 0.867rem);
+}
+
 .workflow-games-list-table td,
 .workflow-games-list-table th {
   padding: 5px 6px;
@@ -2318,6 +2329,12 @@ body {
   background: transparent;
   font-size: 16px;
   font-weight: 400;
+}
+
+/* Players list header: drop the grey header-cell background, matching the
+   games list. */
+.workflow-players-list-table th {
+  background: transparent;
 }
 
 .workflow-sortable {

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -49,7 +49,7 @@ body {
 .dashboard-container {
   position: relative;
   z-index: 1;
-  padding: 20px;
+  padding: 20px 10px;
   max-width: 1540px;
   margin: 0 auto;
 }
@@ -2201,20 +2201,22 @@ body {
   cursor: pointer;
 }
 
-/* Games list compactness: trim padding/font/icon sizes so an 8-player matchup
-   row fits on one visual line at 14''. The Featuring column wraps first when
-   space runs out (its pill container already flex-wraps), the Players column
-   stays nowrap so the row doesn't grow vertically just to break the matchup
-   over two lines. */
+/* Games list compactness: trim inter-column/pill spacing so an 8-player matchup
+   row stays compact. Spacing is kept tight (rather than the font tiny) so the
+   freed horizontal space — together with narrow viewport-edge padding on
+   .dashboard-container — pays for a legible type/icon size even on 8-player
+   rows. The Featuring column wraps first when space runs out (its pill container
+   already flex-wraps); the Players column stays nowrap so the row doesn't grow
+   vertically just to break the matchup over two lines. */
 .workflow-games-list-table td,
 .workflow-games-list-table th {
-  padding: 5px 8px;
+  padding: 5px 6px;
 }
 
 .workflow-games-list-table td.workflow-games-list-played,
 .workflow-games-list-table td.workflow-games-list-map,
 .workflow-games-list-table td.workflow-games-list-duration {
-  font-size: 0.8em;
+  font-size: 0.85em;
   white-space: nowrap;
 }
 
@@ -2224,19 +2226,19 @@ body {
 }
 
 .workflow-games-list-table .workflow-team-player-pill {
-  padding: 0.02em 0.3em 0.04em;
-  font-size: 0.82em;
+  padding: 0.02em 0.26em 0.04em;
+  font-size: 0.9em;
   line-height: 1.5;
-  gap: 0.12em;
+  gap: 0.1em;
 }
 
 .workflow-games-list-table .workflow-team-player-pill .workflow-race-icon {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
 }
 
 .workflow-games-list-table .workflow-team-player-pill .workflow-crown {
-  font-size: 0.8em;
+  font-size: 0.85em;
 }
 
 /* Keep each player name on a single line inside its pill — long names with
@@ -2248,16 +2250,16 @@ body {
 }
 
 .workflow-games-list-table .workflow-team-matchup {
-  column-gap: 0.18rem;
-  row-gap: 0.18rem;
+  column-gap: 0.14rem;
+  row-gap: 0.14rem;
 }
 
 .workflow-games-list-table .workflow-team-side {
-  gap: 0.12rem;
+  gap: 0.1rem;
 }
 
 .workflow-games-list-table .workflow-team-vs {
-  font-size: 0.78em;
+  font-size: 0.82em;
 }
 
 .workflow-games-list-table .workflow-feature-pill {
@@ -2307,6 +2309,15 @@ body {
   padding: 2px 8px;
   font-size: 0.82rem;
   min-height: 24px;
+}
+
+/* Games-list header: drop the grey header-cell background (sit on the page
+   background) and show the column names as emoji glyphs, sized up for legibility
+   since the table font is small. */
+.workflow-games-list-table th {
+  background: transparent;
+  font-size: 16px;
+  font-weight: 400;
 }
 
 .workflow-sortable {

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -38,11 +38,20 @@ body {
   pointer-events: none;
 }
 
+/* Width cap so the dashboard doesn't stretch edge-to-edge on wide desktops.
+   Set to the games filter bar's natural single-line width (its widest row is
+   ~1469px) plus container/row chrome: the filter bar is the widest fixed-width
+   element, so the whole UI — nav, filters, table, footer — shares this width and
+   centers, keeping them aligned. Narrower content (a 1v1 games table, ~800px)
+   fills the width rather than collapsing (see the --roomy font bump); the
+   8-player table conforms by wrapping its Featuring column, as it already does
+   at smaller widths. Below this width the viewport is the cap (full width). */
 .dashboard-container {
   position: relative;
   z-index: 1;
   padding: 20px;
-  max-width: 100%;
+  max-width: 1540px;
+  margin: 0 auto;
 }
 
 .dashboard-header {
@@ -2259,6 +2268,45 @@ body {
 
 .workflow-games-list-table .workflow-pattern-pills {
   gap: 3px;
+}
+
+/* Roomy variant: applied (from App.jsx) only when every game on the page is a
+   2-player match, where the compact 8-player sizing wastes the available space.
+   Bumps padding/type/icons back up for readability. Must follow the compact
+   rules above (equal specificity → later wins). */
+.workflow-games-list-table--roomy td,
+.workflow-games-list-table--roomy th {
+  padding: 9px 12px;
+}
+
+.workflow-games-list-table--roomy td.workflow-games-list-played,
+.workflow-games-list-table--roomy td.workflow-games-list-map,
+.workflow-games-list-table--roomy td.workflow-games-list-duration {
+  font-size: 0.95em;
+}
+
+.workflow-games-list-table--roomy .workflow-team-player-pill {
+  padding: 0.1em 0.5em 0.12em;
+  font-size: 1em;
+}
+
+.workflow-games-list-table--roomy .workflow-team-player-pill .workflow-race-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.workflow-games-list-table--roomy .workflow-team-player-pill .workflow-crown {
+  font-size: 0.95em;
+}
+
+.workflow-games-list-table--roomy .workflow-team-vs {
+  font-size: 0.92em;
+}
+
+.workflow-games-list-table--roomy .workflow-feature-pill {
+  padding: 2px 8px;
+  font-size: 0.82rem;
+  min-height: 24px;
 }
 
 .workflow-sortable {


### PR DESCRIPTION
Caps the dashboard at the games filter-bar width and centers it so the nav, filters, table and footer stay aligned across desktop widths (no edge-to-edge stretch on 2560/3440), plus games-list polish: per-race build-order filters, emoji column headers, removed header-cell backgrounds, and viewport-responsive row type that enlarges 8-player rows up to the filter font size when there is slack (with a roomy bump for all-1v1 pages).

Closes #176.
