### PR TITLE
feat: Enrich production/research commands with inferred coordinates (closes #175)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -684,7 +684,7 @@ Standalone constants the detectors depend on — dedup windows, muta/turret burs
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| Algorithm version | 30 | Detection algorithm revision; incremented to trigger re-detection. |
+| Algorithm version | 31 | Detection algorithm revision; incremented to trigger re-detection. |
 | Build dedup gap (s) | 3 | Repeat Build orders of the same building at the same tile, closer than this, are one event (double-tap / misclick); different-tile placements are kept. |
 | Build dedup max second (s) | 240 | Past this second, dedup stops and every Build is observed as-is (a tile can be legitimately rebuilt on later). |
 | Mutalisk burst window (s) | 30 | Window within which the Mutalisk morphs must cluster. |

--- a/internal/parser/replay.go
+++ b/internal/parser/replay.go
@@ -181,8 +181,14 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 	commandRegistry := commands.NewCommandRegistry()
 	startTime := rep.Header.StartTime.Unix()
 
+	// Infer pixel coordinates for production / research / cancel commands that
+	// the raw stream leaves spatially blank, by binding each to the producing
+	// building (recovered from selection state) and that building's placement.
+	// Keyed by index into rep.Commands.Cmds, applied to each command below. #175
+	commandCoords := unittags.Coordinates(rep, data.Players)
+
 	if rep.Commands != nil {
-		for _, cmd := range rep.Commands.Cmds {
+		for i, cmd := range rep.Commands.Cmds {
 			base := cmd.BaseCmd()
 			if int(base.PlayerID) >= len(data.Players) {
 				continue
@@ -196,6 +202,11 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 				command.Frame = int32(base.Frame)
 				command.Replay = data.Replay
 				command.Player = playerIDToPlayer[base.PlayerID]
+
+				if cc, ok := commandCoords[i]; ok && command.X == nil && command.Y == nil {
+					x, y := cc.X, cc.Y
+					command.X, command.Y = &x, &y
+				}
 
 				// Edge case: ChatCmd doesn't populate PlayerID, but populates SenderSlotID.
 				// Guard the type assertion: a future screp change (or an oddly-typed

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -40,7 +40,16 @@ import (
 // expert_actuals payload. Bumped so replays analyzed under v29 (which stored an
 // empty payload for these BOs) re-analyze and populate the Build Orders chart's
 // actual-vs-expert markers.
-const AlgorithmVersion = 30
+//
+// 31: Coordinate enrichment (issue #175). Production / research / cancel
+// commands (Train, Unit Morph, Tech, Upgrade, Building Morph, Cancel Train) —
+// previously spatially blank — now carry their producing building's inferred
+// pixel location (internal/unittags.Coordinates), recovered via selection-tag
+// state and, for Zerg larva, frequency-confirmed Hatchery tags. These coords
+// flow through ownership (a producing building further refreshes its base's
+// inactivity clock) and inflate Viewport Multitasking; the recall destination
+// inference excludes them. Re-ingest so stored coords/events reflect the change.
+const AlgorithmVersion = 31
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -19,7 +19,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":8.868778280542985}"
+        "value": "{\"switches_per_minute\":16.561085972850677}"
       },
       {
         "replay_player_id": 1,
@@ -49,7 +49,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":13.755656108597284}"
+        "value": "{\"switches_per_minute\":17.013574660633484}"
       }
     ]
   },
@@ -73,7 +73,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":16.315789473684212}"
+        "value": "{\"switches_per_minute\":20}"
       },
       {
         "replay_player_id": 1,
@@ -93,7 +93,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":15.789473684210527}"
+        "value": "{\"switches_per_minute\":20.263157894736842}"
       }
     ]
   },
@@ -112,7 +112,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":21.53846153846154}"
+        "value": "{\"switches_per_minute\":24.871794871794872}"
       },
       {
         "replay_player_id": 1,
@@ -132,7 +132,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":11.794871794871796}"
+        "value": "{\"switches_per_minute\":15.512820512820513}"
       }
     ]
   },
@@ -175,7 +175,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":8.544303797468354}"
+        "value": "{\"switches_per_minute\":12.341772151898734}"
       },
       {
         "replay_player_id": 1,
@@ -195,7 +195,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":15.18987341772152}"
+        "value": "{\"switches_per_minute\":30.189873417721518}"
       }
     ]
   },
@@ -214,7 +214,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":15.661764705882353}"
+        "value": "{\"switches_per_minute\":18.08823529411765}"
       },
       {
         "replay_player_id": 1,
@@ -234,7 +234,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":15.441176470588236}"
+        "value": "{\"switches_per_minute\":31.764705882352942}"
       }
     ]
   },
@@ -253,7 +253,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":13.987730061349692}"
+        "value": "{\"switches_per_minute\":15.690184049079754}"
       },
       {
         "replay_player_id": 1,
@@ -283,7 +283,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":12.607361963190183}"
+        "value": "{\"switches_per_minute\":14.493865030674845}"
       }
     ]
   },
@@ -321,7 +321,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":33.442622950819676}"
+        "value": "{\"switches_per_minute\":47.21311475409836}"
       }
     ]
   },
@@ -350,7 +350,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":19.666666666666668}"
+        "value": "{\"switches_per_minute\":23}"
       },
       {
         "replay_player_id": 1,
@@ -365,7 +365,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Viewport Multitasking",
-        "value": "{\"switches_per_minute\":19.5}"
+        "value": "{\"switches_per_minute\":24.333333333333332}"
       }
     ]
   }

--- a/internal/patterns/worldstate/events_compose.go
+++ b/internal/patterns/worldstate/events_compose.go
@@ -301,6 +301,14 @@ func (e *Engine) inferRecallTargetByPostActivity(cl recallCluster) (int, bool) {
 		if ec.Kind == cmdenrich.KindCast && ec.Subject == "Recall" {
 			continue
 		}
+		// Production / research commands carry their producing building's
+		// inferred location (issue #175), but a recall destination is where
+		// the recalled army went — macro at a Barracks/Hatchery is not a
+		// destination signal, so it must not sway the activity clustering.
+		switch ec.Kind {
+		case cmdenrich.KindMakeUnit, cmdenrich.KindTech, cmdenrich.KindUpgrade:
+			continue
+		}
 		x, y := *ec.X, *ec.Y
 		// Build positions are in tile-space; convert to pixels (mirror
 		// BuildAttacks).

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -96,7 +96,10 @@ func TestSQLiteStorage_IngestionAndQueries(t *testing.T) {
 		// location_inactive (timeout) events dropped 35→21 (-14) and one attack
 		// on a now-owned base surfaced (+1), for a net -13. Then -1 (issue #163):
 		// a player who did only non-HP upgrades no longer trips Never-researched.
-		"replay_events": 193,
+		// Then -2 (issue #175): inferred production/research coordinates now flow
+		// through the ownership pass, so a producing building further refreshes
+		// its base's inactivity clock — netting two fewer events.
+		"replay_events": 191,
 	}
 	actualCounts, err := collectCounts(store, keys(expectedCounts))
 	if err != nil {

--- a/internal/unittags/coords.go
+++ b/internal/unittags/coords.go
@@ -1,0 +1,383 @@
+package unittags
+
+import (
+	"sort"
+
+	"github.com/icza/screp/rep"
+	"github.com/icza/screp/rep/repcmd"
+	"github.com/marianogappa/screpdb/internal/models"
+)
+
+// CmdCoord is an inferred location for a command that the raw replay stream
+// leaves spatially blank. X, Y are PIXEL coordinates (tile*32 + 16), matching
+// the coordinate space worldstate uses for every non-building Kind, so the
+// enriched value flows through cmdenrich unchanged.
+type CmdCoord struct {
+	X, Y int
+}
+
+// hatchFreqThreshold is the minimum number of larva-morph attributions a tag
+// must collect (as the single unit selected immediately before the larvae) to
+// be accepted as a Hatchery/Lair/Hive when it is not already proven by a
+// Lair/Hive building-morph. Empirically real town halls accumulate tens of
+// morphs across a game while stray single-selects appear once or twice; the
+// threshold rejects that noise. See issue #175.
+const hatchFreqThreshold = 3
+
+// townHalls are the buildings that exist from frame 0 without a Build command,
+// so an unmatched producing tag of these types resolves to the player's start
+// location rather than being dropped. (Lair/Hive are tag-preserving morphs of
+// a Hatchery, so they correlate against Hatchery builds and start under it.)
+var townHalls = map[string]bool{
+	models.GeneralUnitNexus:         true,
+	models.GeneralUnitCommandCenter: true,
+	models.GeneralUnitHatchery:      true,
+}
+
+// researchParent maps a Terran add-on that researches a tech to the building a
+// player actually single-selects to issue that research — the add-on hangs off
+// its parent and the parent's tag is the one observed in the selection. Used so
+// add-on techs (Siege Mode, Spider Mines, Yamato, Lockdown, …) resolve against
+// the parent's Build placement. Non-add-on research buildings map to themselves
+// implicitly.
+var researchParent = map[string]string{
+	models.GeneralUnitMachineShop:  models.GeneralUnitFactory,
+	models.GeneralUnitControlTower: models.GeneralUnitStarport,
+	models.GeneralUnitPhysicsLab:   models.GeneralUnitScienceFacility,
+	models.GeneralUnitCovertOps:    models.GeneralUnitScienceFacility,
+}
+
+// morphSourceBuild maps a building-morph target to the Build command whose
+// placement names its location. Hive is a morph of a Lair, which is itself a
+// tag-preserving morph of a Hatchery, so both resolve against Hatchery builds.
+var morphSourceBuild = map[string]string{
+	"Lair":          models.GeneralUnitHatchery,
+	"Hive":          models.GeneralUnitHatchery,
+	"Greater Spire": models.GeneralUnitSpire,
+	"Sunken Colony": models.GeneralUnitCreepColony,
+	"Spore Colony":  models.GeneralUnitCreepColony,
+}
+
+type point struct{ X, Y int }
+
+// ttKey identifies a producing building by type and unit tag. BW recycles unit
+// tags, so the same tag can name a Barracks early and a Factory later; keying
+// locations on (type, tag) keeps those distinct instead of collapsing them.
+type ttKey struct {
+	bldg string
+	tag  uint16
+}
+
+// coordRec is one command awaiting a resolved location.
+type coordRec struct {
+	idx      int    // index into r.Commands.Cmds
+	bldgType string // building type whose tag location applies; "" for tag-only (CancelTrain)
+	tag      uint16
+	sec      int
+}
+
+// playerAcc accumulates one player's evidence during the selection walk.
+type playerAcc struct {
+	builds    map[string][]Build        // building type -> Build placements (tiles)
+	firstSec  map[string]map[uint16]int // building type -> tag -> first event second
+	larvaPrev map[uint16]int            // hatch-tap tag -> larva-morph count
+	hatchSeed map[uint16]bool           // tags proven to be a town hall by a Lair/Hive morph
+	recs      []coordRec
+}
+
+func newPlayerAcc() *playerAcc {
+	return &playerAcc{
+		builds:    map[string][]Build{},
+		firstSec:  map[string]map[uint16]int{},
+		larvaPrev: map[uint16]int{},
+		hatchSeed: map[uint16]bool{},
+	}
+}
+
+func (a *playerAcc) note(bldg string, tag uint16, sec int) {
+	if a.firstSec[bldg] == nil {
+		a.firstSec[bldg] = map[uint16]int{}
+	}
+	if _, seen := a.firstSec[bldg][tag]; !seen {
+		a.firstSec[bldg][tag] = sec
+	}
+}
+
+// Coordinates infers per-command pixel locations for the production / research
+// / cancel commands the raw stream leaves blank, by binding each to the
+// producing building's tag (recovered from selection state) and that tag to its
+// Build placement. A frame-0 town hall has no Build command, so an unmatched
+// town-hall tag falls back to the player's start location. The result is keyed
+// by index into r.Commands.Cmds. See issue #175.
+func Coordinates(r *rep.Replay, players []*models.Player) map[int]CmdCoord {
+	out := map[int]CmdCoord{}
+	if r == nil || r.Commands == nil {
+		return out
+	}
+
+	starts := map[byte]point{}
+	for _, p := range players {
+		if p != nil && p.StartLocationX != nil && p.StartLocationY != nil {
+			starts[p.PlayerID] = point{*p.StartLocationX, *p.StartLocationY}
+		}
+	}
+
+	type selState struct {
+		cur             []uint16
+		groups          map[byte][]uint16
+		prevSingle      uint16
+		prevSingleValid bool
+	}
+	states := map[byte]*selState{}
+	accs := map[byte]*playerAcc{}
+	get := func(pid byte) (*selState, *playerAcc) {
+		if states[pid] == nil {
+			states[pid] = &selState{groups: map[byte][]uint16{}}
+			accs[pid] = newPlayerAcc()
+		}
+		return states[pid], accs[pid]
+	}
+	snap := func(s *selState) {
+		if len(s.cur) == 1 {
+			s.prevSingle, s.prevSingleValid = s.cur[0], true
+		} else {
+			s.prevSingleValid = false
+		}
+	}
+
+	// larvaRec defers a larva morph until the hatchery tag set is known: only
+	// morphs whose hatch-tap tag is a confirmed town hall get a coordinate.
+	type larvaRec struct {
+		pid byte
+		idx int
+		tag uint16
+		sec int
+	}
+	var larvaRecs []larvaRec
+
+	for i, c := range r.Commands.Cmds {
+		b := c.BaseCmd()
+		if b == nil || b.Type == nil {
+			continue
+		}
+		s, a := get(b.PlayerID)
+		sec := int(b.Frame.Seconds())
+
+		switch b.Type.ID {
+		case repcmd.TypeIDSelect, repcmd.TypeIDSelect121:
+			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
+				s.cur = tagsOf(sc.UnitTags)
+			}
+		case repcmd.TypeIDSelectAdd, repcmd.TypeIDSelectAdd121:
+			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
+				s.cur = unionTags(s.cur, tagsOf(sc.UnitTags))
+			}
+		case repcmd.TypeIDSelectRemove, repcmd.TypeIDSelectRemove121:
+			if sc, ok := c.(*repcmd.SelectCmd); ok {
+				snap(s)
+				s.cur = removeTags(s.cur, tagsOf(sc.UnitTags))
+			}
+		case repcmd.TypeIDHotkey:
+			if hc, ok := c.(*repcmd.HotkeyCmd); ok && hc.HotkeyType != nil {
+				switch hc.HotkeyType.Name {
+				case "Assign":
+					s.groups[hc.Group] = append([]uint16(nil), s.cur...)
+				case "Select":
+					snap(s)
+					s.cur = append([]uint16(nil), s.groups[hc.Group]...)
+				case "Add":
+					snap(s)
+					s.cur = unionTags(s.cur, s.groups[hc.Group])
+				}
+			}
+		case repcmd.TypeIDBuild:
+			if bc, ok := c.(*repcmd.BuildCmd); ok && bc.Unit != nil {
+				a.builds[bc.Unit.Name] = append(a.builds[bc.Unit.Name], Build{
+					Frame: int32(b.Frame), Sec: sec, X: int(bc.Pos.X), Y: int(bc.Pos.Y),
+				})
+			}
+		case repcmd.TypeIDTrain, repcmd.TypeIDUnitMorph:
+			tc, ok := c.(*repcmd.TrainCmd)
+			if !ok || tc.Unit == nil {
+				continue
+			}
+			name := tc.Unit.Name
+			if bldg, ok := producerBuilding[name]; ok {
+				if len(s.cur) == 1 {
+					a.note(bldg, s.cur[0], sec)
+					a.recs = append(a.recs, coordRec{idx: i, bldgType: bldg, tag: s.cur[0], sec: sec})
+				}
+				continue
+			}
+			if larvaMorphUnits[name] && s.prevSingleValid {
+				a.larvaPrev[s.prevSingle]++
+				larvaRecs = append(larvaRecs, larvaRec{pid: b.PlayerID, idx: i, tag: s.prevSingle, sec: sec})
+			}
+		case repcmd.TypeIDBuildingMorph:
+			if bm, ok := c.(*repcmd.BuildingMorphCmd); ok && bm.Unit != nil && len(s.cur) == 1 {
+				if src, ok := morphSourceBuild[bm.Unit.Name]; ok {
+					a.note(src, s.cur[0], sec)
+					a.recs = append(a.recs, coordRec{idx: i, bldgType: src, tag: s.cur[0], sec: sec})
+					if bm.Unit.Name == "Lair" || bm.Unit.Name == "Hive" {
+						a.hatchSeed[s.cur[0]] = true
+					}
+				}
+			}
+		case repcmd.TypeIDTech:
+			if tc, ok := c.(*repcmd.TechCmd); ok && tc.Tech != nil && len(s.cur) == 1 {
+				if meta, ok := models.LookupTech(tc.Tech.Name); ok {
+					bldg := selectableResearchBuilding(meta.BuildingSubject)
+					a.note(bldg, s.cur[0], sec)
+					a.recs = append(a.recs, coordRec{idx: i, bldgType: bldg, tag: s.cur[0], sec: sec})
+				}
+			}
+		case repcmd.TypeIDUpgrade:
+			if uc, ok := c.(*repcmd.UpgradeCmd); ok && uc.Upgrade != nil && len(s.cur) == 1 {
+				if meta, ok := models.LookupUpgrade(uc.Upgrade.Name); ok {
+					bldg := selectableResearchBuilding(meta.BuildingSubject)
+					a.note(bldg, s.cur[0], sec)
+					a.recs = append(a.recs, coordRec{idx: i, bldgType: bldg, tag: s.cur[0], sec: sec})
+				}
+			}
+		case repcmd.TypeIDCancelTrain:
+			// The cancelling building is single-selected; its tag is recovered
+			// here and resolved against whatever location it earned from other
+			// evidence (it produced or researched something). No type is known
+			// from the cancel itself, so bldgType is left blank.
+			if len(s.cur) == 1 {
+				a.recs = append(a.recs, coordRec{idx: i, tag: s.cur[0], sec: sec})
+			}
+		}
+	}
+
+	// Fold confirmed larva morphs into Hatchery evidence (Phase A → B): a hatch
+	// tap is trusted only when its tag is Lair/Hive-proven or crosses the
+	// frequency threshold, so a stray single-select before larvae is ignored.
+	for _, lr := range larvaRecs {
+		a := accs[lr.pid]
+		if !a.hatchSeed[lr.tag] && a.larvaPrev[lr.tag] < hatchFreqThreshold {
+			continue
+		}
+		a.note(models.GeneralUnitHatchery, lr.tag, lr.sec)
+		a.recs = append(a.recs, coordRec{idx: lr.idx, bldgType: models.GeneralUnitHatchery, tag: lr.tag, sec: lr.sec})
+	}
+
+	for pid, a := range accs {
+		loc := resolveTagLocations(a, starts[pid])
+		for _, rec := range a.recs {
+			key := ttKey{bldg: rec.bldgType, tag: rec.tag}
+			if rec.bldgType == "" {
+				// CancelTrain names no building type; pick the producing type
+				// whose tag was most recently first-seen at or before the
+				// cancel (tags recycle, so the latest incarnation wins).
+				key.bldg = a.latestTypeForTag(rec.tag, rec.sec)
+				if key.bldg == "" {
+					continue
+				}
+			}
+			p, ok := loc[key]
+			if !ok {
+				continue
+			}
+			out[rec.idx] = CmdCoord{X: p.X*32 + 16, Y: p.Y*32 + 16}
+		}
+	}
+	return out
+}
+
+// latestTypeForTag returns the building type under which tag was first seen at
+// or before sec, preferring the most recent first-seen (BW recycles tags). Ties
+// break on type name for determinism. Returns "" when the tag names no producer.
+func (a *playerAcc) latestTypeForTag(tag uint16, sec int) string {
+	best := ""
+	bestSec := -1
+	for bldg, tags := range a.firstSec {
+		fs, ok := tags[tag]
+		if !ok || fs > sec {
+			continue
+		}
+		if fs > bestSec || (fs == bestSec && bldg < best) {
+			bestSec = fs
+			best = bldg
+		}
+	}
+	return best
+}
+
+// resolveTagLocations maps every (building-type, tag) to a build tile: each
+// building type's tags are greedily matched to its Build placements (earliest
+// producer to earliest preceding Build), and unmatched town-hall tags fall back
+// to the player's start location. Keyed on (type, tag) so a recycled tag that
+// named two different buildings keeps a distinct location for each.
+func resolveTagLocations(a *playerAcc, start point) map[ttKey]point {
+	loc := map[ttKey]point{}
+	for bldg, tags := range a.firstSec {
+		matched := matchTagsToBuilds(tags, a.builds[bldg])
+		isTownHall := townHalls[bldg]
+		for tag := range tags {
+			if b, ok := matched[tag]; ok {
+				loc[ttKey{bldg, tag}] = point{b.X, b.Y}
+			} else if isTownHall && (start != point{}) {
+				// Start location is already in pixels; store as a tile so the
+				// caller's uniform tile→pixel step lands back on it.
+				loc[ttKey{bldg, tag}] = point{(start.X - 16) / 32, (start.Y - 16) / 32}
+			}
+		}
+	}
+	return loc
+}
+
+// matchTagsToBuilds greedily assigns each tag (earliest first-event first) to
+// the earliest unclaimed Build placed at or before that event — a building
+// cannot produce before it is commanded.
+func matchTagsToBuilds(firstSec map[uint16]int, builds []Build) map[uint16]Build {
+	type tf struct {
+		tag uint16
+		sec int
+	}
+	ordered := make([]tf, 0, len(firstSec))
+	for tag, sec := range firstSec {
+		ordered = append(ordered, tf{tag, sec})
+	}
+	// Tie-break on tag so map iteration order can't make the greedy assignment
+	// (and thus the inferred coordinate) non-deterministic between ingests.
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].sec != ordered[j].sec {
+			return ordered[i].sec < ordered[j].sec
+		}
+		return ordered[i].tag < ordered[j].tag
+	})
+
+	sorted := append([]Build(nil), builds...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Sec != sorted[j].Sec {
+			return sorted[i].Sec < sorted[j].Sec
+		}
+		if sorted[i].X != sorted[j].X {
+			return sorted[i].X < sorted[j].X
+		}
+		return sorted[i].Y < sorted[j].Y
+	})
+	claimed := make([]bool, len(sorted))
+
+	out := map[uint16]Build{}
+	for _, t := range ordered {
+		for j := range sorted {
+			if !claimed[j] && sorted[j].Sec <= t.sec {
+				claimed[j] = true
+				out[t.tag] = sorted[j]
+				break
+			}
+		}
+	}
+	return out
+}
+
+func selectableResearchBuilding(researchBuilding string) string {
+	if parent, ok := researchParent[researchBuilding]; ok {
+		return parent
+	}
+	return researchBuilding
+}

--- a/internal/unittags/coords_test.go
+++ b/internal/unittags/coords_test.go
@@ -1,0 +1,187 @@
+package unittags
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/icza/screp/rep"
+	"github.com/icza/screp/rep/repcmd"
+	"github.com/marianogappa/screpdb/internal/models"
+	"github.com/marianogappa/screpdb/internal/screp"
+)
+
+func TestMatchTagsToBuilds_GreedyEarliestFirst(t *testing.T) {
+	// Two producing tags; the earlier producer claims the earlier build.
+	firstSec := map[uint16]int{
+		0xA: 100, // produced first
+		0xB: 60,  // produced even earlier
+	}
+	builds := []Build{
+		{Sec: 50, X: 10, Y: 10},  // earliest build
+		{Sec: 80, X: 20, Y: 20},  // later build
+		{Sec: 200, X: 30, Y: 30}, // built after both first-events: claimable by neither
+	}
+	got := matchTagsToBuilds(firstSec, builds)
+	if got[0xB] != (Build{Sec: 50, X: 10, Y: 10}) {
+		t.Errorf("tag B (earliest producer) should claim earliest build, got %+v", got[0xB])
+	}
+	if got[0xA] != (Build{Sec: 80, X: 20, Y: 20}) {
+		t.Errorf("tag A should claim the next build placed before its first event, got %+v", got[0xA])
+	}
+	if _, ok := got[0xA]; len(got) != 2 || !ok {
+		t.Errorf("only the two tags should match; the sec=200 build precedes no first-event")
+	}
+}
+
+func TestResolveTagLocations_TownHallFallsBackToStart(t *testing.T) {
+	a := newPlayerAcc()
+	// One Hatchery build (an expansion) and two producing town-hall tags: the
+	// frame-0 hatch (no build, earliest) and the expansion.
+	a.builds[models.GeneralUnitHatchery] = []Build{{Sec: 300, X: 50, Y: 60}}
+	a.firstSec[models.GeneralUnitHatchery] = map[uint16]int{
+		0x1: 10,  // main: produced from the start, before any build → fallback
+		0x2: 320, // expansion: produced after the build → matches it
+	}
+	start := point{X: 50*32 + 16, Y: 70*32 + 16} // pixels
+
+	loc := resolveTagLocations(a, start)
+	if got := loc[ttKey{models.GeneralUnitHatchery, 0x1}]; got != (point{X: 50, Y: 70}) {
+		t.Errorf("unmatched town-hall tag should fall back to start tile, got %+v", got)
+	}
+	if got := loc[ttKey{models.GeneralUnitHatchery, 0x2}]; got != (point{X: 50, Y: 60}) {
+		t.Errorf("expansion tag should match its Build tile, got %+v", got)
+	}
+}
+
+func TestResolveTagLocations_NonTownHallNoFallback(t *testing.T) {
+	a := newPlayerAcc()
+	a.firstSec[models.GeneralUnitBarracks] = map[uint16]int{0x9: 100} // no Build for it
+	loc := resolveTagLocations(a, point{X: 100, Y: 100})
+	if got, ok := loc[ttKey{models.GeneralUnitBarracks, 0x9}]; ok {
+		t.Errorf("a non-town-hall tag with no matching Build must not resolve, got %+v", got)
+	}
+}
+
+func TestResolveTagLocations_RecycledTagKeptDistinct(t *testing.T) {
+	// BW recycles unit tags: tag 0x7 names a Barracks early, then a Factory
+	// later. Each must resolve to its own building, not collapse to one.
+	a := newPlayerAcc()
+	a.builds[models.GeneralUnitBarracks] = []Build{{Sec: 100, X: 10, Y: 10}}
+	a.builds[models.GeneralUnitFactory] = []Build{{Sec: 500, X: 80, Y: 90}}
+	a.firstSec[models.GeneralUnitBarracks] = map[uint16]int{0x7: 110}
+	a.firstSec[models.GeneralUnitFactory] = map[uint16]int{0x7: 510}
+
+	loc := resolveTagLocations(a, point{})
+	if got := loc[ttKey{models.GeneralUnitBarracks, 0x7}]; got != (point{10, 10}) {
+		t.Errorf("Barracks incarnation of recycled tag: got %+v", got)
+	}
+	if got := loc[ttKey{models.GeneralUnitFactory, 0x7}]; got != (point{80, 90}) {
+		t.Errorf("Factory incarnation of recycled tag: got %+v", got)
+	}
+
+	// A CancelTrain at sec 520 must bind to the Factory (latest incarnation).
+	if got := a.latestTypeForTag(0x7, 520); got != models.GeneralUnitFactory {
+		t.Errorf("cancel at 520 should bind to Factory, got %q", got)
+	}
+	// A CancelTrain at sec 200 must bind to the Barracks.
+	if got := a.latestTypeForTag(0x7, 200); got != models.GeneralUnitBarracks {
+		t.Errorf("cancel at 200 should bind to Barracks, got %q", got)
+	}
+}
+
+// enrichableActionIDs are the raw command types Coordinates may enrich.
+var enrichableActionIDs = map[byte]bool{
+	repcmd.TypeIDTrain: true, repcmd.TypeIDUnitMorph: true,
+	repcmd.TypeIDTech: true, repcmd.TypeIDUpgrade: true,
+	repcmd.TypeIDBuildingMorph: true, repcmd.TypeIDCancelTrain: true,
+}
+
+func playersWithStarts(r *rep.Replay) []*models.Player {
+	var ps []*models.Player
+	for i, p := range r.Header.Players {
+		if p == nil {
+			continue
+		}
+		race := ""
+		if p.Race != nil {
+			race = p.Race.Name
+		}
+		mp := &models.Player{PlayerID: p.ID, Race: race}
+		if r.Computed != nil && i < len(r.Computed.PlayerDescs) {
+			if sl := r.Computed.PlayerDescs[i].StartLocation; sl != nil {
+				x, y := int(sl.X), int(sl.Y)
+				mp.StartLocationX, mp.StartLocationY = &x, &y
+			}
+		}
+		ps = append(ps, mp)
+	}
+	return ps
+}
+
+func TestCoordinates_RealReplays(t *testing.T) {
+	fixtures := map[string]string{
+		"SomaTyson.rep":       filepath.Join("..", "testdata", "replays", "SomaTyson.rep"),
+		"SomaJyJ.rep":         filepath.Join("..", "testdata", "replays", "SomaJyJ.rep"),
+		"bgh.rep":             filepath.Join("..", "testdata", "replays", "bgh.rep"),
+		"Somavssnow.rep":      filepath.Join("..", "testdata", "replays", "Somavssnow.rep"),
+		"bo_forge_expand.rep": filepath.Join("..", "builddedup", "testdata", "replays", "bo_forge_expand.rep"),
+	}
+	for name, path := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			r, err := screp.ParseFile(path)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			players := playersWithStarts(r)
+			coords := Coordinates(r, players)
+			if len(coords) == 0 {
+				t.Fatal("expected some inferred coordinates")
+			}
+
+			maxX, maxY := int(r.Header.MapWidth)*32, int(r.Header.MapHeight)*32
+			for idx, c := range coords {
+				if c.X < 0 || c.X > maxX || c.Y < 0 || c.Y > maxY {
+					t.Errorf("idx %d: coord %+v out of map bounds %dx%d", idx, c, maxX, maxY)
+				}
+				if id := r.Commands.Cmds[idx].BaseCmd().Type.ID; !enrichableActionIDs[id] {
+					t.Errorf("idx %d: enriched a non-enrichable command type %#x", idx, id)
+				}
+			}
+
+			// Train commands for produced units (Protoss/Terran) should be
+			// enriched at a high rate — the producing building is single-selected.
+			var trains, trainsWithCoords int
+			for idx, c := range r.Commands.Cmds {
+				tc, ok := c.(*repcmd.TrainCmd)
+				if !ok || tc.Unit == nil {
+					continue
+				}
+				if _, isProducer := producerBuilding[tc.Unit.Name]; !isProducer {
+					continue
+				}
+				trains++
+				if _, has := coords[idx]; has {
+					trainsWithCoords++
+				}
+			}
+			if trains > 0 && trainsWithCoords*2 < trains {
+				t.Errorf("expected most producer-building trains enriched, got %d/%d", trainsWithCoords, trains)
+			}
+
+			// Determinism: repeated runs yield the identical map. Looping
+			// exercises Go's randomized map iteration so a tag/build firstSec
+			// tie can't silently flip a coordinate between ingests.
+			for n := 0; n < 50; n++ {
+				again := Coordinates(r, players)
+				if len(again) != len(coords) {
+					t.Fatalf("non-deterministic: %d vs %d entries", len(again), len(coords))
+				}
+				for idx, c := range coords {
+					if again[idx] != c {
+						t.Fatalf("non-deterministic at idx %d: %+v vs %+v", idx, c, again[idx])
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #175.

Binds Train / Unit Morph / Tech / Upgrade / Building Morph / Cancel Train commands to their producing building's inferred pixel location (recovered from selection-tag state, with Zerg larva morphs resolved via frequency-confirmed Hatchery tags), so they're no longer spatially blank.