### PR TITLE
fix(earlyfilter,worldstate): stop dropping early workers and misreading proxy bunkers on money maps

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -696,7 +696,7 @@ Standalone constants the detectors depend on — dedup windows, muta/turret burs
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| Algorithm version | 42 | Detection algorithm revision; incremented to trigger re-detection. |
+| Algorithm version | 43 | Detection algorithm revision; incremented to trigger re-detection. |
 | Build dedup gap (s) | 3 | Repeat Build orders of the same building at the same tile, closer than this, are one event (double-tap / misclick); different-tile placements are kept. |
 | Build dedup max second (s) | 240 | Past this second, dedup stops and every Build is observed as-is (a tile can be legitimately rebuilt on later). |
 | Mutalisk burst window (s) | 30 | Window within which the Mutalisk morphs must cluster. |

--- a/internal/earlyfilter/backtrack.go
+++ b/internal/earlyfilter/backtrack.go
@@ -127,6 +127,7 @@ func resolveViolations(
 	violations []violation,
 	commands []*models.Command,
 	verdicts map[int]Verdict,
+	mineralsAfter map[int]int,
 	mustKeep map[int]bool,
 	forceDrop map[int]bool,
 ) bool {
@@ -142,6 +143,15 @@ func resolveViolations(
 				mustKeep[idx] = true
 				progress = true
 			}
+			// Only free minerals by dropping a worker when re-admitting this
+			// Build actually overdraws the account. A dropped worker leaves the
+			// income sim, so doing it when no deficit exists freezes the worker
+			// count and collapses simulated income — which cascades into
+			// dropping every early worker train (the spiral that made an
+			// SCV-from-frame-0 opening read as "no workers until ~4 min").
+			if !backtrackOverdraws(commands, idx, verdicts, mineralsAfter) {
+				continue
+			}
 			// Drop one worker train before the re-admitted Build to free
 			// minerals. Skip if we already dropped enough — the next
 			// iteration will run forward and check whether the budget
@@ -154,6 +164,38 @@ func resolveViolations(
 		}
 	}
 	return progress
+}
+
+// backtrackOverdraws reports whether re-admitting the Build at idx would drive
+// the player's minerals negative at that frame. It only applies to a Build that
+// was dropped in the latest forward pass (a genuinely new re-admission whose
+// cost is about to be charged); a Build already kept/readmitted was affordable
+// and needs no compensating worker drop. Because the dropped Build's cost was
+// not applied, mineralsAfter[idx] is the spendable balance at its frame: if that
+// covers the Build cost, re-admission is affordable.
+func backtrackOverdraws(commands []*models.Command, idx int, verdicts map[int]Verdict, mineralsAfter map[int]int) bool {
+	if verdicts[idx] != VerdictDropped {
+		return false
+	}
+	cmd := commands[idx]
+	if cmd == nil {
+		return false
+	}
+	en, ok := cmdenrich.Classify(cmd)
+	if !ok {
+		return false
+	}
+	econ, ok := cmdenrich.EconOf(en.Subject)
+	if !ok {
+		return false
+	}
+	avail, ok := mineralsAfter[idx]
+	if !ok {
+		// No recorded balance (e.g. command outside the simulated window):
+		// fall back to the original behaviour and free minerals.
+		return true
+	}
+	return avail < econ.Minerals
 }
 
 // buildPrereqChain returns subj plus its transitive PrereqsOf, deepest-first

--- a/internal/earlyfilter/earlyfilter.go
+++ b/internal/earlyfilter/earlyfilter.go
@@ -51,7 +51,7 @@ func Apply(replay *models.Replay, players []*models.Player, mapCtx *models.Repla
 		if len(violations) == 0 {
 			break
 		}
-		if !resolveViolations(violations, commands, verdicts, mustKeep, forceDrop) {
+		if !resolveViolations(violations, commands, verdicts, mineralsAfter, mustKeep, forceDrop) {
 			break
 		}
 	}

--- a/internal/earlyfilter/earlyfilter_test.go
+++ b/internal/earlyfilter/earlyfilter_test.go
@@ -177,6 +177,34 @@ func TestPhotonCannonImpliesForge(t *testing.T) {
 	}
 }
 
+// TestBacktrackOverdrawsGatesWorkerDrop locks the deficit-gate that stops
+// backtrack from force-dropping income-producing workers to "pay" for a
+// re-admitted building that was actually affordable. Dropping a worker that
+// the player could afford freezes the simulated worker count and collapses
+// income, which previously wiped out an entire early-game worker line (an
+// SCV-from-frame-0 opening read as "no workers until ~4 minutes").
+func TestBacktrackOverdrawsGatesWorkerDrop(t *testing.T) {
+	p := terranPlayer()
+	commands := []*models.Command{makeCmd("Build", models.GeneralUnitBarracks, 88, p)}
+	econ, ok := cmdenrich.EconOf(models.GeneralUnitBarracks)
+	if !ok {
+		t.Fatal("expected econ for Barracks")
+	}
+
+	dropped := map[int]Verdict{0: VerdictDropped}
+	if backtrackOverdraws(commands, 0, dropped, map[int]int{0: econ.Minerals + 1}) {
+		t.Fatalf("affordable re-admission must not free a worker")
+	}
+	if !backtrackOverdraws(commands, 0, dropped, map[int]int{0: econ.Minerals - 1}) {
+		t.Fatalf("unaffordable re-admission must free a worker")
+	}
+
+	kept := map[int]Verdict{0: VerdictKept}
+	if backtrackOverdraws(commands, 0, kept, map[int]int{0: econ.Minerals - 1}) {
+		t.Fatalf("an already-kept build charges nothing new; no worker drop")
+	}
+}
+
 // TestGasGatherSubtractsFromMineralIncome — when a Harvest1 order targets
 // a geyser the player owns a built Refinery on, 3 workers leave the
 // mineral line for ~43s. Mineral count at end should be lower than the

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -138,7 +138,18 @@ import (
 // real buildings elsewhere as "never produced" — which had dropped real later
 // gateways and made a 3-gate build read as 1 Gate Reaver. Re-ingest so building
 // counts (and the openers keyed on them) are correct.
-const AlgorithmVersion = 42
+//
+// 43: earlyfilter backtrack no longer force-drops income-producing worker trains
+// to fund a re-admitted proven-real building unless re-admission actually
+// overdraws minerals at that frame. Dropping affordable workers froze the
+// simulated worker count and collapsed income into a spiral that wiped out an
+// early worker line (an SCV-from-frame-0 opening read as no workers until ~4
+// min) and undercounted build-order supply (a 9 Hatch read as 4 Hatch). Bunker
+// rush detection now bounds its base-snap fallback, so an open-ground proxy /
+// simcity bunker on a money map is no longer misread as a rush on a distant
+// base. Re-ingest so early worker timing, BO supply counts, and bunker-rush
+// events are correct.
+const AlgorithmVersion = 43
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string

--- a/internal/patterns/markers/testdata/markers_golden.json
+++ b/internal/patterns/markers/testdata/markers_golden.json
@@ -560,7 +560,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Build Order: 1 Gate Core",
-        "value": "{\"expert_actuals\":[{\"second\":48,\"found\":true},{\"second\":77,\"found\":true},{\"found\":false},{\"second\":118,\"found\":true}]}"
+        "value": "{\"expert_actuals\":[{\"second\":48,\"found\":true},{\"second\":77,\"found\":true},{\"second\":94,\"found\":true},{\"second\":118,\"found\":true}]}"
       },
       {
         "replay_player_id": 1,
@@ -1393,7 +1393,7 @@
       },
       {
         "replay_player_id": 1,
-        "pattern_name": "Build Order: 4 Hatch",
+        "pattern_name": "Build Order: 9 Hatch",
         "value": "{\"expert_actuals\":[{\"second\":74,\"found\":true},{\"second\":109,\"found\":true}]}"
       },
       {
@@ -1514,11 +1514,6 @@
         "replay_player_id": 5,
         "pattern_name": "Viewport Multitasking",
         "value": "{\"switches_per_minute\":7.772020725388601}"
-      },
-      {
-        "replay_player_id": 6,
-        "pattern_name": "Build Order: 6 Hatch",
-        "value": "{\"expert_actuals\":[{\"second\":84,\"found\":true},{\"second\":164,\"found\":true}]}"
       },
       {
         "replay_player_id": 6,
@@ -1952,7 +1947,7 @@
       {
         "replay_player_id": 1,
         "pattern_name": "Build Order: Forge Expand",
-        "value": "{\"expert_actuals\":[{\"second\":47,\"found\":true},{\"second\":88,\"found\":true},{\"found\":false},{\"second\":132,\"found\":true}]}"
+        "value": "{\"expert_actuals\":[{\"second\":47,\"found\":true},{\"second\":88,\"found\":true},{\"second\":142,\"found\":true},{\"second\":132,\"found\":true}]}"
       },
       {
         "replay_player_id": 1,
@@ -2039,7 +2034,7 @@
     "detections": [
       {
         "replay_player_id": 0,
-        "pattern_name": "Build Order: 7 Pool",
+        "pattern_name": "Build Order: 9 Pool",
         "value": "{\"expert_actuals\":[{\"second\":61,\"found\":true},{\"second\":113,\"found\":true}]}"
       },
       {
@@ -2093,8 +2088,8 @@
     "detections": [
       {
         "replay_player_id": 0,
-        "pattern_name": "Build Order: 8 Pool",
-        "value": "{\"expert_actuals\":[{\"second\":65,\"found\":true},{\"second\":117,\"found\":true}]}"
+        "pattern_name": "Build Order: 9 Pool",
+        "value": "{\"expert_actuals\":[{\"second\":65,\"found\":true},{\"found\":false}]}"
       },
       {
         "replay_player_id": 0,
@@ -2462,7 +2457,7 @@
       {
         "replay_player_id": 0,
         "pattern_name": "Build Order: CC First",
-        "value": "{\"expert_actuals\":[{\"second\":55,\"found\":true},{\"second\":117,\"found\":true},{\"found\":false}]}"
+        "value": "{\"expert_actuals\":[{\"second\":153,\"found\":true},{\"second\":117,\"found\":true},{\"found\":false}]}"
       },
       {
         "replay_player_id": 0,

--- a/internal/patterns/worldstate/engine.go
+++ b/internal/patterns/worldstate/engine.go
@@ -1240,7 +1240,11 @@ func (e *Engine) tryEmitRushBuildEvents(command *models.Command, pid byte, sec i
 		// not-yet-taken natural, which reads as neutral early-game and is
 		// skipped by the enemy-owned lookup above. Fall back to the base
 		// polygon at the build point and resolve its static owner. (#195, cf. #196)
-		enemyBaseIdx = pointToEventBase(x, y, e.bases)
+		//
+		// The radius fallback is bounded: on money maps (BGH) NaturalRadius is
+		// large, so an unbounded snap pulls an open-ground proxy/simcity bunker
+		// onto a base it never threatened. Polygon containment is unaffected.
+		enemyBaseIdx = pointToEventBaseBounded(x, y, e.bases, rushBuildSnapToEnemyBaseCenterPx)
 	}
 	if enemyBaseIdx < 0 && strings.Contains(unitNorm, "photoncannon") {
 		enemyBaseIdx = e.nearestEnemyBaseIdxForRush(pid, x, y, rushBuildSnapToEnemyBaseCenterPx)
@@ -1815,6 +1819,15 @@ func pointInBasePolygon(x float64, y float64, b base) bool {
 }
 
 func pointToEventBase(x float64, y float64, bases []base) int {
+	return pointToEventBaseBounded(x, y, bases, math.MaxFloat64)
+}
+
+// pointToEventBaseBounded is pointToEventBase with the radius fallback capped at
+// maxFallbackPx. Polygon containment (a point genuinely inside a base) is always
+// honoured; only the "just outside a base" radius snap is bounded, so a build in
+// open ground on a money map — where NaturalRadius is large — is not attributed
+// to a distant base it never threatened. Pass math.MaxFloat64 for no cap.
+func pointToEventBaseBounded(x float64, y float64, bases []base, maxFallbackPx float64) int {
 	best := -1
 	bestDist := math.MaxFloat64
 	for i, b := range bases {
@@ -1836,6 +1849,9 @@ func pointToEventBase(x float64, y float64, bases []base) int {
 		opRadius := b.NaturalRadius * commandRadiusMul
 		if opRadius < 120 {
 			opRadius = 120
+		}
+		if opRadius > maxFallbackPx {
+			opRadius = maxFallbackPx
 		}
 		d := dist(x, y, b.CenterX, b.CenterY)
 		if d <= opRadius && d < bestDist {

--- a/internal/patterns/worldstate/engine_test.go
+++ b/internal/patterns/worldstate/engine_test.go
@@ -261,6 +261,76 @@ func TestProcessCommand_BunkerRushRequiresMarineAndEnemyPolygon(t *testing.T) {
 	}
 }
 
+// TestProcessCommand_BunkerInOpenGroundOnMoneyMapIsNotRush guards the BGH
+// false positive: a proxy/simcity bunker placed in open ground (inside no base
+// polygon) must not be snapped onto a distant enemy base just because that
+// base's NaturalRadius is large, as it is on money maps. The bunker here sits
+// ~14 tiles from the enemy start center — beyond the bounded 10-tile snap cap
+// but within the old unbounded NaturalRadius*1.25 fallback that used to fire.
+func TestProcessCommand_BunkerInOpenGroundOnMoneyMapIsNotRush(t *testing.T) {
+	replay := &models.Replay{DurationSeconds: 300, MapWidth: 128, MapHeight: 128}
+	p1 := &models.Player{PlayerID: 1, SlotID: 1, Name: "Terran", Race: "Terran", Team: 1, Type: models.PlayerTypeHuman}
+	p2 := &models.Player{PlayerID: 2, SlotID: 2, Name: "Protoss", Race: "Protoss", Team: 2, Type: models.PlayerTypeHuman}
+	mapCtx := &models.ReplayMapContext{
+		StartLocations: []models.MapStartLocation{
+			{X: tilePixel(8), Y: tilePixel(8), SlotID: 1},
+			{X: tilePixel(40), Y: tilePixel(40), SlotID: 2},
+		},
+		Layout: &models.MapContextLayout{
+			Bases: []models.MapContextBase{
+				{
+					Name:   "start-a",
+					Kind:   "start",
+					Clock:  11,
+					Center: models.MapResourcePosition{X: tilePixel(8), Y: tilePixel(8)},
+					Polygon: []models.MapPolygonPoint{
+						{X: tilePixel(6), Y: tilePixel(6)},
+						{X: tilePixel(10), Y: tilePixel(6)},
+						{X: tilePixel(10), Y: tilePixel(10)},
+						{X: tilePixel(6), Y: tilePixel(10)},
+					},
+				},
+				{
+					// Money-map-style large base: NaturalRadius ≈ 17 tiles, so
+					// the unbounded fallback used to reach ~21 tiles.
+					Name:   "start-b",
+					Kind:   "start",
+					Clock:  5,
+					Center: models.MapResourcePosition{X: tilePixel(40), Y: tilePixel(40)},
+					Polygon: []models.MapPolygonPoint{
+						{X: tilePixel(28), Y: tilePixel(28)},
+						{X: tilePixel(52), Y: tilePixel(28)},
+						{X: tilePixel(52), Y: tilePixel(52)},
+						{X: tilePixel(28), Y: tilePixel(52)},
+					},
+				},
+			},
+		},
+	}
+	engine := NewEngine(replay, []*models.Player{p1, p2}, mapCtx)
+
+	engine.ProcessCommand(&models.Command{
+		Player:               p1,
+		ActionType:           models.ActionTypeTrain,
+		UnitType:             stringPtr(models.GeneralUnitMarine),
+		SecondsFromGameStart: 120,
+	})
+	engine.ProcessCommand(&models.Command{
+		Player:               p1,
+		ActionType:           models.ActionTypeBuild,
+		UnitType:             stringPtr(models.GeneralUnitBunker),
+		X:                    intPtr(26),
+		Y:                    intPtr(40),
+		SecondsFromGameStart: 180,
+	})
+
+	for _, event := range engine.ReplayEvents() {
+		if event.EventType == "bunker_rush" {
+			t.Fatalf("did not expect bunker_rush for an open-ground bunker far from any base")
+		}
+	}
+}
+
 func TestProcessCommand_CannonRushOneVsOneAmbiguousTeams(t *testing.T) {
 	replay := &models.Replay{DurationSeconds: 300, MapWidth: 128, MapHeight: 128}
 	p1 := &models.Player{PlayerID: 1, SlotID: 1, Name: "P1", Race: "Protoss", Team: 0, Type: models.PlayerTypeHuman}

--- a/internal/testdata/replays/golden.json
+++ b/internal/testdata/replays/golden.json
@@ -12,7 +12,7 @@
     {
       "file": "SomaTyson.rep",
       "players": 2,
-      "commands": 9388,
+      "commands": 9398,
       "patterns": {
         "replay": 2,
         "player": 10
@@ -21,7 +21,7 @@
     {
       "file": "Somavssnow.rep",
       "players": 2,
-      "commands": 8968,
+      "commands": 8972,
       "patterns": {
         "replay": 2,
         "player": 11
@@ -30,7 +30,7 @@
     {
       "file": "bgh.rep",
       "players": 8,
-      "commands": 13897,
+      "commands": 13978,
       "patterns": {
         "replay": 2,
         "player": 36


### PR DESCRIPTION
Stops the earlyfilter backtrack from force-dropping affordable worker trains (which froze simulated income and erased early worker production) and bounds the bunker-rush base-snap so an open-ground proxy/simcity bunker on a money map is no longer misread as a rush.