### PR TITLE
fix(ingest): fix nil-player panic; make panics produce crash reports without killing the dashboard (#234)

### DIFF
--- a/cmd/windows-dashboard/main.go
+++ b/cmd/windows-dashboard/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 func main() {
+	crashreport.SetOpenBrowser(true)
 	defer crashreport.Recover(true)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
@@ -54,11 +55,12 @@ func main() {
 
 	errCh := make(chan error, 1)
 	go func() {
-		defer crashreport.Recover(true)
+		defer crashreport.Guard()
 		errCh <- cmd.RunDashboardWithContext(ctx, opts)
 	}()
 
 	go func() {
+		defer crashreport.Guard()
 		if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
 			log.Printf("dashboard exited with error: %v", err)
 		}

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -12,12 +12,44 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/marianogappa/screpdb/internal/buildinfo"
 	"github.com/marianogappa/screpdb/internal/iofacade"
 	"github.com/pkg/browser"
 )
+
+// openBrowserDefault records whether crash reports should open the prefilled
+// GitHub issue in a browser. GUI builds (no visible console) set this true at
+// startup via SetOpenBrowser; CLI builds leave it false. Goroutine guards read
+// it so they can report consistently without each knowing the build flavor.
+var openBrowserDefault atomic.Bool
+
+// SetOpenBrowser sets the process-wide browser preference for crash reports. An
+// entrypoint should call it once at startup, before spawning goroutines.
+func SetOpenBrowser(open bool) { openBrowserDefault.Store(open) }
+
+// Guard is deferred at the top of every long-lived goroutine:
+//
+//	go func() {
+//		defer crashreport.Guard()
+//		...
+//	}()
+//
+// A panic in a goroutine cannot be caught by a deferred Recover in main — Go
+// unwinds only the panicking goroutine's stack — so an unguarded goroutine
+// panic kills the whole process with a bare stack trace the GUI user never sees
+// (issue #234). Guard writes a crash report, surfaces the prefilled issue link
+// (opening the browser per SetOpenBrowser), and exits the process.
+func Guard() {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	Handle(recovered, debug.Stack(), openBrowserDefault.Load())
+	os.Exit(2)
+}
 
 // newIssueURL is the GitHub endpoint that opens a blank issue editor. We
 // pre-fill the title/body via query params rather than pointing at a specific

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -51,6 +51,36 @@ func Guard() {
 	os.Exit(2)
 }
 
+// GuardNonFatal is deferred at the top of a goroutine that must NOT take down
+// the process on panic — e.g. a single ingest run, whose death should leave the
+// dashboard serving. On a panic it reports the crash (via Report) and runs the
+// optional cleanup so the caller can mark its work failed, then lets the
+// goroutine unwind normally. Unlike Guard it never exits. Deferred as:
+//
+//	defer crashreport.GuardNonFatal(func() { d.finishIngest(err) })
+func GuardNonFatal(cleanup func()) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	ReportPanic(recovered, debug.Stack())
+	if cleanup != nil {
+		cleanup()
+	}
+}
+
+// ReportPanic writes a crash report for an already-recovered panic and surfaces
+// the prefilled issue link (opening the browser per SetOpenBrowser) WITHOUT
+// exiting. Use it for inline recovery where the surrounding loop should skip
+// the failed item and keep going (the caller captures the stack in its own
+// recover).
+func ReportPanic(recovered any, stack []byte) {
+	if recovered == nil {
+		return
+	}
+	Handle(recovered, stack, openBrowserDefault.Load())
+}
+
 // newIssueURL is the GitHub endpoint that opens a blank issue editor. We
 // pre-fill the title/body via query params rather than pointing at a specific
 // issue-form template so the link keeps working regardless of template changes

--- a/internal/crashreport/crashreport_test.go
+++ b/internal/crashreport/crashreport_test.go
@@ -84,6 +84,26 @@ func TestWriteCreatesReportInWorkingDir(t *testing.T) {
 	}
 }
 
+func TestGuardWithoutPanicReturns(t *testing.T) {
+	// Guard must be a no-op when no panic is in flight — calling it directly
+	// (recover() == nil) must return normally and never os.Exit.
+	Guard()
+}
+
+func TestSetOpenBrowserUpdatesDefault(t *testing.T) {
+	prev := openBrowserDefault.Load()
+	t.Cleanup(func() { openBrowserDefault.Store(prev) })
+
+	SetOpenBrowser(true)
+	if !openBrowserDefault.Load() {
+		t.Error("SetOpenBrowser(true) did not set the default")
+	}
+	SetOpenBrowser(false)
+	if openBrowserDefault.Load() {
+		t.Error("SetOpenBrowser(false) did not clear the default")
+	}
+}
+
 func TestFirstLine(t *testing.T) {
 	cases := map[string]string{
 		"":                     "unexpected panic",

--- a/internal/crashreport/crashreport_test.go
+++ b/internal/crashreport/crashreport_test.go
@@ -104,6 +104,27 @@ func TestSetOpenBrowserUpdatesDefault(t *testing.T) {
 	}
 }
 
+func TestGuardNonFatalRecoversAndRunsCleanup(t *testing.T) {
+	// Contain the crash-report file written by the underlying Handle.
+	dir := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	cleaned := false
+	func() {
+		defer GuardNonFatal(func() { cleaned = true })
+		panic("boom")
+	}()
+
+	// Reaching here at all proves the panic did not propagate (non-fatal).
+	if !cleaned {
+		t.Error("GuardNonFatal did not run the cleanup callback")
+	}
+}
+
 func TestFirstLine(t *testing.T) {
 	cases := map[string]string{
 		"":                     "unexpected panic",

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/gorilla/mux"
 	_ "modernc.org/sqlite"
 
+	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/dashboard/apigen"
 	dashboarddb "github.com/marianogappa/screpdb/internal/dashboard/db"
 	dashboardservice "github.com/marianogappa/screpdb/internal/dashboard/service"
@@ -84,8 +86,33 @@ func New(ctx context.Context, sqlitePath string) (*Dashboard, error) {
 	return dashboard, nil
 }
 
+// recoveryMiddleware turns a panic in any HTTP handler into a crash report and
+// a 500, without tearing down the server. net/http already isolates handler
+// panics from the process, but it does so silently — the GUI user has no
+// console, so the report file (and the prefilled issue link logged with it) is
+// their only way to surface the bug. Browser-open is deliberately suppressed
+// here (unlike goroutine Guards): a repeatedly-panicking request must not spawn
+// a new issue tab on every retry.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			if rec == http.ErrAbortHandler {
+				panic(rec) // net/http's own sentinel — let it handle it
+			}
+			crashreport.Handle(rec, debug.Stack(), false)
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
 func (d *Dashboard) setupRouter() *mux.Router {
 	r := mux.NewRouter()
+	r.Use(recoveryMiddleware)
 	swagger, err := apigen.GetSwagger()
 	if err != nil {
 		panic(fmt.Errorf("failed to load embedded OpenAPI spec: %w", err))
@@ -228,6 +255,7 @@ func (d *Dashboard) StartAsync(port int) <-chan error {
 	}
 
 	go func() {
+		defer crashreport.Guard()
 		log.Printf("Server starting on %s...", addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			select {
@@ -242,6 +270,7 @@ func (d *Dashboard) StartAsync(port int) <-chan error {
 	// listener accepts, the dashboard is serving. This makes no outbound
 	// network call (issue #135).
 	go func() {
+		defer crashreport.Guard()
 		if err := netfacade.WaitForLocalListener(addr, 30, 100*time.Millisecond); err != nil {
 			select {
 			case errChan <- err:

--- a/internal/dashboard/endpoint_update.go
+++ b/internal/dashboard/endpoint_update.go
@@ -56,7 +56,7 @@ func (d *Dashboard) handlerUpdateApply(w http.ResponseWriter, _ *http.Request) {
 	// Relaunch after the response reaches the client. On Unix this replaces the
 	// process image; on Windows it spawns the new binary and exits.
 	go func() {
-		defer crashreport.Guard()
+		defer crashreport.GuardNonFatal(nil)
 		time.Sleep(750 * time.Millisecond)
 		log.Printf("self-update applied (%s); relaunching", newVersion)
 		if restartErr := selfupdate.Restart(); restartErr != nil {

--- a/internal/dashboard/endpoint_update.go
+++ b/internal/dashboard/endpoint_update.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/selfupdate"
 )
 
@@ -55,6 +56,7 @@ func (d *Dashboard) handlerUpdateApply(w http.ResponseWriter, _ *http.Request) {
 	// Relaunch after the response reaches the client. On Unix this replaces the
 	// process image; on Windows it spawns the new binary and exits.
 	go func() {
+		defer crashreport.Guard()
 		time.Sleep(750 * time.Millisecond)
 		log.Printf("self-update applied (%s); relaunching", newVersion)
 		if restartErr := selfupdate.Restart(); restartErr != nil {

--- a/internal/dashboard/ingest_session.go
+++ b/internal/dashboard/ingest_session.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/gorilla/websocket"
+	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/ingest"
 )
 
@@ -138,6 +139,7 @@ func (d *Dashboard) handlerIngestLogs(w http.ResponseWriter, r *http.Request) {
 
 	done := make(chan struct{})
 	go func() {
+		defer crashreport.Guard()
 		defer close(done)
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {

--- a/internal/dashboard/ingest_session.go
+++ b/internal/dashboard/ingest_session.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"errors"
 	"net/http"
 	"os"
 
@@ -10,6 +11,11 @@ import (
 )
 
 const maxIngestLogEvents = 4000
+
+// errIngestPanicked marks an ingest run that died to a panic. The panic itself
+// is captured in a crash report; this is the short reason surfaced in the
+// dashboard's ingest status.
+var errIngestPanicked = errors.New("ingestion crashed; a crash report was generated")
 
 type ingestStreamMessage struct {
 	Type     string            `json:"type"`
@@ -139,7 +145,7 @@ func (d *Dashboard) handlerIngestLogs(w http.ResponseWriter, r *http.Request) {
 
 	done := make(chan struct{})
 	go func() {
-		defer crashreport.Guard()
+		defer crashreport.GuardNonFatal(nil)
 		defer close(done)
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {

--- a/internal/dashboard/recovery_middleware_test.go
+++ b/internal/dashboard/recovery_middleware_test.go
@@ -3,12 +3,21 @@ package dashboard
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
 func TestRecoveryMiddleware_PanicBecomes500(t *testing.T) {
 	// A panicking handler must be contained as a 500 rather than crashing the
 	// process. (The crash-report file itself is covered by crashreport's tests.)
+	// chdir so any crash-report file lands in a temp dir, not the package dir.
+	dir := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
 	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("boom in handler")
 	})

--- a/internal/dashboard/recovery_middleware_test.go
+++ b/internal/dashboard/recovery_middleware_test.go
@@ -1,0 +1,37 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecoveryMiddleware_PanicBecomes500(t *testing.T) {
+	// A panicking handler must be contained as a 500 rather than crashing the
+	// process. (The crash-report file itself is covered by crashreport's tests.)
+	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom in handler")
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/whatever", nil)
+
+	recoveryMiddleware(panicking).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 after handler panic, got %d", rec.Code)
+	}
+}
+
+func TestRecoveryMiddleware_PassesThroughNonPanic(t *testing.T) {
+	ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/whatever", nil)
+
+	recoveryMiddleware(ok).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("non-panicking handler should pass through, got %d", rec.Code)
+	}
+}

--- a/internal/dashboard/sample_set.go
+++ b/internal/dashboard/sample_set.go
@@ -98,7 +98,11 @@ func (d *Dashboard) startIngestAsync(cfg ingest.Config) bool {
 		return false
 	}
 	go func() {
-		defer crashreport.Guard()
+		// Survive a panic in the ingest run: report it and mark the run failed
+		// so the dashboard keeps serving (#234). finishIngest is idempotent for
+		// this goroutine — it runs either here on the normal path or in the
+		// guard's cleanup on panic, never both.
+		defer crashreport.GuardNonFatal(func() { d.finishIngest(errIngestPanicked) })
 		runErr := ingest.Run(d.ctx, cfg)
 		if runErr != nil {
 			cfg.Logger.Errorf("Ingestion failed: %v", runErr)

--- a/internal/dashboard/sample_set.go
+++ b/internal/dashboard/sample_set.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/ingest"
 	"github.com/marianogappa/screpdb/internal/sampledata"
 )
@@ -97,6 +98,7 @@ func (d *Dashboard) startIngestAsync(cfg ingest.Config) bool {
 		return false
 	}
 	go func() {
+		defer crashreport.Guard()
 		runErr := ingest.Run(d.ctx, cfg)
 		if runErr != nil {
 			cfg.Logger.Errorf("Ingestion failed: %v", runErr)

--- a/internal/parser/replay.go
+++ b/internal/parser/replay.go
@@ -195,39 +195,47 @@ func ParseReplayWithOptions(filePath string, fileInfo *models.Replay, opts Optio
 	if rep.Commands != nil {
 		for i, cmd := range rep.Commands.Cmds {
 			base := cmd.BaseCmd()
-			if int(base.PlayerID) >= len(data.Players) {
-				continue
-			}
 
 			// Process command using the registry
 			command := commandRegistry.ProcessCommand(cmd, startTime)
-
-			if command != nil {
-				// Set additional fields (registry already sets ReplayID)
-				command.Frame = int32(base.Frame)
-				command.Replay = data.Replay
-				command.Player = playerIDToPlayer[base.PlayerID]
-
-				if cc, ok := commandCoords[i]; ok && command.X == nil && command.Y == nil {
-					x, y := cc.X, cc.Y
-					command.X, command.Y = &x, &y
-				}
-
-				if n, ok := morphSelectionSizes[i]; ok {
-					command.SelectedUnits = n
-				}
-
-				// Edge case: ChatCmd doesn't populate PlayerID, but populates SenderSlotID.
-				// Guard the type assertion: a future screp change (or an oddly-typed
-				// command that still classifies as "Chat") shouldn't panic the parse.
-				if command.ActionType == "Chat" {
-					if chatCommand, ok := cmd.(*repcmd.ChatCmd); ok {
-						command.Player = slotIDToPlayer[chatCommand.SenderSlotID]
-					}
-				}
-
-				data.Commands = append(data.Commands, command)
+			if command == nil {
+				continue
 			}
+
+			// Set additional fields (registry already sets ReplayID)
+			command.Frame = int32(base.Frame)
+			command.Replay = data.Replay
+			command.Player = playerIDToPlayer[base.PlayerID]
+
+			// Edge case: ChatCmd doesn't populate PlayerID, but populates SenderSlotID.
+			// Guard the type assertion: a future screp change (or an oddly-typed
+			// command that still classifies as "Chat") shouldn't panic the parse.
+			if command.ActionType == "Chat" {
+				if chatCommand, ok := cmd.(*repcmd.ChatCmd); ok {
+					command.Player = slotIDToPlayer[chatCommand.SenderSlotID]
+				}
+			}
+
+			// Skip commands we can't attribute to a player. PlayerIDs are not
+			// guaranteed contiguous (observer/computer slots leave gaps), so a
+			// command's PlayerID can be absent from playerIDToPlayer. Every
+			// downstream consumer already ignores nil-Player commands, and the
+			// persistence pass dereferences command.Player — emitting them would
+			// crash ingestion (#234).
+			if command.Player == nil {
+				continue
+			}
+
+			if cc, ok := commandCoords[i]; ok && command.X == nil && command.Y == nil {
+				x, y := cc.X, cc.Y
+				command.X, command.Y = &x, &y
+			}
+
+			if n, ok := morphSelectionSizes[i]; ok {
+				command.SelectedUnits = n
+			}
+
+			data.Commands = append(data.Commands, command)
 		}
 	}
 

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/icza/screp/rep/repcore"
 	_ "modernc.org/sqlite"
 
+	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/fileops"
 	"github.com/marianogappa/screpdb/internal/migrations"
 	"github.com/marianogappa/screpdb/internal/models"
@@ -175,6 +176,7 @@ func (s *SQLiteStorage) StartIngestion(ctx context.Context, hooks IngestionHooks
 	errChan := make(chan error, 1)
 
 	go func() {
+		defer crashreport.Guard()
 		defer close(errChan)
 
 		// Process replays sequentially to handle dependencies

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -624,6 +624,9 @@ func (s *SQLiteStorage) updateEntityIDs(data *models.ReplayData, replayID int64,
 	}
 	for i := range data.Commands {
 		data.Commands[i].ReplayID = replayID
+		if data.Commands[i].Player == nil {
+			continue
+		}
 		data.Commands[i].PlayerID = data.Commands[i].Player.ID
 
 		// TODO Special case: VisionPlayerIDs hold slot ids

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -176,8 +177,21 @@ func (s *SQLiteStorage) StartIngestion(ctx context.Context, hooks IngestionHooks
 	errChan := make(chan error, 1)
 
 	go func() {
-		defer crashreport.Guard()
-		defer close(errChan)
+		// Non-fatal backstop: a panic in the loop plumbing or a hook is
+		// reported and turned into a terminal error on errChan, so the ingest
+		// run ends cleanly and the GUI dashboard keeps serving instead of dying
+		// (#234). Per-replay panics are handled finer-grained below (skip +
+		// continue); this only catches the rarer plumbing case.
+		defer func() {
+			if r := recover(); r != nil {
+				crashreport.ReportPanic(r, debug.Stack())
+				select {
+				case errChan <- fmt.Errorf("ingestion goroutine panicked (a crash report was generated): %v", r):
+				default:
+				}
+			}
+			close(errChan)
+		}()
 
 		// Process replays sequentially to handle dependencies
 		for {
@@ -189,8 +203,18 @@ func (s *SQLiteStorage) StartIngestion(ctx context.Context, hooks IngestionHooks
 					return
 				}
 
-				// Process this replay completely before moving to the next
-				if err := s.storeReplayWithBatching(ctx, data); err != nil {
+				// Process this replay completely before moving to the next.
+				// A panic in here is recovered into a per-replay error so one
+				// malformed replay is skipped instead of crashing the whole
+				// ingest (and, on the GUI build, the dashboard) — #234.
+				err, panicked := s.storeReplayRecovered(ctx, data)
+				if panicked {
+					if hooks.OnStoreError != nil {
+						hooks.OnStoreError(err)
+					}
+					continue
+				}
+				if err != nil {
 					if isDuplicateReplayError(err) {
 						if hooks.OnDuplicateReplay != nil {
 							hooks.OnDuplicateReplay(err)
@@ -221,6 +245,24 @@ func (s *SQLiteStorage) StartIngestion(ctx context.Context, hooks IngestionHooks
 	}()
 
 	return dataChan, errChan
+}
+
+// storeReplayRecovered runs storeReplayWithBatching under a non-fatal panic
+// guard. storeReplayWithBatching wraps its work in a transaction with a
+// deferred Rollback, so a panic leaves the database clean and the caller can
+// safely skip the offending replay and keep ingesting the rest. On a panic it
+// writes a crash report (so the user can file the bug) and returns panicked=true
+// with a descriptive error.
+func (s *SQLiteStorage) storeReplayRecovered(ctx context.Context, data *models.ReplayData) (err error, panicked bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			crashreport.ReportPanic(r, debug.Stack())
+			err = fmt.Errorf("panic while storing replay (this is a bug — please report it at "+
+				"https://github.com/marianogappa/screpdb/issues): %v", r)
+			panicked = true
+		}
+	}()
+	return s.storeReplayWithBatching(ctx, data), false
 }
 
 func isDuplicateReplayError(err error) bool {

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -13,9 +13,34 @@ import (
 	"testing"
 
 	"github.com/marianogappa/screpdb/internal/fileops"
+	"github.com/marianogappa/screpdb/internal/models"
 	"github.com/marianogappa/screpdb/internal/parser"
 	"github.com/marianogappa/screpdb/internal/patterns/core"
 )
+
+// Regression for #234: a command whose Player could not be resolved (PlayerIDs
+// are not guaranteed contiguous) must not panic the persistence pass.
+func TestUpdateEntityIDs_NilCommandPlayer(t *testing.T) {
+	s := &SQLiteStorage{}
+	player := &models.Player{PlayerID: 0, ID: 42}
+	data := &models.ReplayData{
+		Replay:  &models.Replay{},
+		Players: []*models.Player{player},
+		Commands: []*models.Command{
+			{Player: player, PlayerID: 0},
+			{Player: nil, PlayerID: 7},
+		},
+	}
+
+	s.updateEntityIDs(data, 99, map[byte]int64{0: 42})
+
+	if data.Commands[0].PlayerID != 42 {
+		t.Fatalf("resolvable command: got PlayerID %d, want 42", data.Commands[0].PlayerID)
+	}
+	if data.Commands[0].ReplayID != 99 || data.Commands[1].ReplayID != 99 {
+		t.Fatalf("both commands should get replayID 99, got %d and %d", data.Commands[0].ReplayID, data.Commands[1].ReplayID)
+	}
+}
 
 func TestEncodeInt64ArrayJSON_MatchesEncodingJSON(t *testing.T) {
 	cases := [][]int64{

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -18,6 +18,27 @@ import (
 	"github.com/marianogappa/screpdb/internal/patterns/core"
 )
 
+// Regression for #234: a panic while storing one replay must be recovered into
+// a per-replay error (not crash the ingest), so the loop can skip it and keep
+// going. Passing nil data forces a nil dereference inside storeReplayWithBatching.
+func TestStoreReplayRecovered_PanicBecomesError(t *testing.T) {
+	dir := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	s := &SQLiteStorage{}
+	err, panicked := s.storeReplayRecovered(context.Background(), nil)
+	if !panicked {
+		t.Fatalf("expected panicked=true for nil replay data")
+	}
+	if err == nil {
+		t.Fatalf("expected a non-nil error describing the recovered panic")
+	}
+}
+
 // Regression for #234: a command whose Player could not be resolved (PlayerIDs
 // are not guaranteed contiguous) must not panic the persistence pass.
 func TestUpdateEntityIDs_NilCommandPlayer(t *testing.T) {

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 
 	"github.com/getlantern/systray"
+	"github.com/marianogappa/screpdb/internal/crashreport"
 )
 
 type Config struct {
@@ -44,6 +45,7 @@ func Run(config Config) error {
 
 		quitItem := systray.AddMenuItem("Quit", "Quit screpdb dashboard")
 		go func() {
+			defer crashreport.Guard()
 			<-quitItem.ClickedCh
 			if config.OnQuit != nil {
 				config.OnQuit()

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 )
 
 func main() {
+	crashreport.SetOpenBrowser(false)
 	defer crashreport.Recover(false)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
Fixes the #234 ingestion crash (a command with an unresolvable player dereferenced a nil `Player` during persistence — PlayerIDs aren't contiguous when observer/computer slots leave gaps) and closes the larger gap it exposed: a deferred `crashreport.Recover` in `main()` can't catch a panic in another goroutine, so background-goroutine panics killed the process silently. Every long-lived goroutine now produces a crash report + prefilled issue link, and ingest/dashboard goroutines survive panics (storage skips the bad replay and keeps going; sample-set, websocket, self-update, and HTTP handlers recover non-fatally) so the running dashboard is never taken down. Closes #234.