### PR TITLE
feat: flag team stacking sustained to game end below the 5-min bar

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -777,7 +777,7 @@ Standalone constants the detectors depend on — dedup windows, muta/turret burs
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| Algorithm version | 54 | Detection algorithm revision; incremented to trigger re-detection. |
+| Algorithm version | 55 | Detection algorithm revision; incremented to trigger re-detection. |
 | Build dedup gap (s) | 3 | Repeat Build orders of the same building at the same tile, closer than this, are one event (double-tap / misclick); different-tile placements are kept. |
 | Build dedup max second (s) | 240 | Past this second, dedup stops and every Build is observed as-is (a tile can be legitimately rebuilt on later). |
 | Mutalisk burst window (s) | 30 | Window within which the Mutalisk morphs must cluster. |

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -6879,7 +6879,7 @@ function App() {
                   <div className="workflow-timing-charts">
                     {mainGame?.team_stacking ? (
                       <div className="workflow-section-warning">
-                        😈 Team stacking detected — uneven non-solo team sizes lasted over {Math.round((mainGame.alliance_stacking_threshold_seconds || 300) / 60)} minutes.
+                        😈 Team stacking detected — uneven non-solo team sizes were sustained (over {Math.round((mainGame.alliance_stacking_threshold_seconds || 300) / 60)} minutes, or until game end).
                       </div>
                     ) : null}
                     <AllianceTimeline

--- a/internal/parser/alliances.go
+++ b/internal/parser/alliances.go
@@ -13,6 +13,13 @@ import (
 // catch deliberate ganging-up.
 const StackingThresholdSec = 300
 
+// StackingEndOfGameThresholdSec is the shorter floor applied when a stacking
+// band never dissolves — it runs contiguously to game end. A stack that stays
+// intact until the game is over is a decisive gang-up (often the winning
+// coalition's), not the transient mid-game re-alliance the 5-minute threshold
+// exists to filter, so it earns the flag sooner.
+const StackingEndOfGameThresholdSec = 120
+
 // InactivityWindowSec / InactivityMinActions define the "effectively dead"
 // threshold used to filter ghost players out of the stacking topology check.
 // A player whose recent action rate falls below 20 commands/min and never
@@ -267,10 +274,14 @@ func AnalyzeAlliances(players []*models.Player, commands []*models.Command, dura
 		for j < len(snapshots) && snapshots[j].Stacking {
 			j++
 		}
+		threshold := StackingThresholdSec
 		if j < len(snapshots) {
 			end = snapshots[j].Sec
+		} else {
+			// Band runs to game end: never dissolved, so apply the shorter floor.
+			threshold = StackingEndOfGameThresholdSec
 		}
-		if end-snap.Sec > StackingThresholdSec {
+		if end-snap.Sec > threshold {
 			stackingFlag = true
 			bandStartSec = snap.Sec
 			bandTeams = cloneTeams(snap.Teams)

--- a/internal/parser/alliances_test.go
+++ b/internal/parser/alliances_test.go
@@ -231,6 +231,78 @@ func TestAnalyzeAlliances_TransientImbalance_BelowThreshold(t *testing.T) {
 	}
 }
 
+// A 3v2 that forms late and never dissolves (runs to game end) fires the flag
+// once it clears the shorter end-of-game floor, even though it never reaches the
+// full 5-minute bar. Mirrors the real (8)Big Game Hunters case where the winning
+// coalition stacked up ~4 minutes before the game ended.
+func TestAnalyzeAlliances_StackingToGameEnd_AboveFloorFires(t *testing.T) {
+	a, b, c, d, e := p(1, 1), p(2, 2), p(3, 3), p(4, 4), p(5, 5)
+	players := []*models.Player{a, b, c, d, e}
+	cmds := []*models.Command{
+		allianceCmd(10, a, 1, 2, 3),
+		allianceCmd(10, b, 1, 2, 3),
+		allianceCmd(10, c, 1, 2, 3),
+		allianceCmd(10, d, 4, 5),
+		allianceCmd(10, e, 4, 5),
+	}
+	// 3v2 holds from sec=10 to game end at 200 → 190s band: under the 300s bar
+	// but over the 120s end-of-game floor.
+	res := AnalyzeAlliances(players, cmds, 200, emptyActivity())
+
+	if !res.TeamStackingFlag {
+		t.Fatalf("expected stacking flag: 3v2 held to game end for 190s (> end-of-game floor)")
+	}
+	if res.StackingBandStartSec != 10 {
+		t.Fatalf("expected stacking band to start at sec=10, got %d", res.StackingBandStartSec)
+	}
+}
+
+// A stack that runs to game end but for less than the 2-minute floor is still
+// treated as a transient endgame ally and does not fire.
+func TestAnalyzeAlliances_StackingToGameEnd_BelowFloorNoFire(t *testing.T) {
+	a, b, c, d, e := p(1, 1), p(2, 2), p(3, 3), p(4, 4), p(5, 5)
+	players := []*models.Player{a, b, c, d, e}
+	cmds := []*models.Command{
+		allianceCmd(100, a, 1, 2, 3),
+		allianceCmd(100, b, 1, 2, 3),
+		allianceCmd(100, c, 1, 2, 3),
+		allianceCmd(100, d, 4, 5),
+		allianceCmd(100, e, 4, 5),
+	}
+	// 3v2 forms at sec=100 and holds to game end at 200 → 100s band, under the
+	// 120s floor.
+	res := AnalyzeAlliances(players, cmds, 200, emptyActivity())
+
+	if res.TeamStackingFlag {
+		t.Fatalf("expected no stacking flag for a 100s end-of-game band (< floor)")
+	}
+}
+
+// The shorter floor applies ONLY to bands that run to game end. A band above the
+// floor but below the full threshold that dissolves mid-game must not fire.
+func TestAnalyzeAlliances_MidGameBand_AboveFloorDissolves_NoFire(t *testing.T) {
+	a, b, c, d, e := p(1, 1), p(2, 2), p(3, 3), p(4, 4), p(5, 5)
+	players := []*models.Player{a, b, c, d, e}
+	cmds := []*models.Command{
+		allianceCmd(10, a, 1, 2, 3),
+		allianceCmd(10, b, 1, 2, 3),
+		allianceCmd(10, c, 1, 2, 3),
+		allianceCmd(10, d, 4, 5),
+		allianceCmd(10, e, 4, 5),
+		// At sec=200 the 3-team breaks: c goes solo → 2v2v1 (balanced).
+		allianceCmd(200, a, 1, 2),
+		allianceCmd(200, b, 1, 2),
+		allianceCmd(200, c, 3),
+	}
+	// 3v2 band is sec=10..200 = 190s (> floor, < threshold) but dissolves before
+	// game end at 1200 → floor must not apply.
+	res := AnalyzeAlliances(players, cmds, 1200, emptyActivity())
+
+	if res.TeamStackingFlag {
+		t.Fatalf("expected no stacking flag: 190s mid-game band that dissolved before end")
+	}
+}
+
 func TestAnalyzeAlliances_ComputerExcluded(t *testing.T) {
 	human1 := p(1, 1)
 	human2 := p(2, 2)

--- a/internal/patterns/core/types.go
+++ b/internal/patterns/core/types.go
@@ -231,7 +231,12 @@ import (
 // Muta uses no grace window (timing attack); Hydra/Lurker keep +30s. Replaces
 // the round-10 hydra opener family and the fixed-360s "2/3 Hatch Muta/Lurker"
 // markers. Re-ingest so Zerg tech builds re-count.
-const AlgorithmVersion = 54
+//
+// 55: Team-stacking flag now uses a shorter 2-minute floor for a stacking band
+// that never dissolves (runs contiguously to game end) — a stack that stays
+// intact until the game is over is a decisive gang-up, not a transient
+// mid-game re-alliance, so it earns the 😈 marker below the usual 5-min bar.
+const AlgorithmVersion = 55
 
 // DetectorLevel indicates at which level a pattern detector operates
 type DetectorLevel string


### PR DESCRIPTION
A stacking band that never dissolves (runs contiguously to game end) now flags at a shorter 2-minute floor instead of the full 5-minute threshold, since a stack held until the game is over is a decisive gang-up rather than a transient re-alliance.