### PR TITLE
docs(readme): tidy header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # screpdb
 
+screpdb is an advanced Starcraft replay reporting tool.
+
 [![Release](https://img.shields.io/github/v/release/marianogappa/screpdb)](https://github.com/marianogappa/screpdb/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/marianogappa/screpdb)](go.mod)
-<!-- ingest-bench-start -->
 [![Ingestion throughput](https://img.shields.io/badge/ingestion-4.7%20replays%2Fsec-brightgreen)](.github/workflows/bench-ingest.yml)
+
+<!-- ingest-bench-start -->
 <sub>212.43 ms/replay · corpus: 150 replays · GitHub-hosted 2-core runner · updated automatically on merge to main</sub>
 <!-- ingest-bench-end -->
-
-screpdb is an advanced Starcraft replay reporting tool.
 
 ## Features
 ### Filtering/finding replays by high-level semantic features

--- a/scripts/update-readme-bench.sh
+++ b/scripts/update-readme-bench.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Rewrites the ingestion-throughput badge in README.md between the
+# Rewrites the ingestion-throughput badge and its detail note in README.md.
+# The badge lives in the badge row; the note lives between the
 # <!-- ingest-bench-start --> / <!-- ingest-bench-end --> markers.
 #
 # Usage: scripts/update-readme-bench.sh <replays_per_sec> <ms_per_replay> <corpus_replays>
@@ -16,8 +17,9 @@ badge="[![Ingestion throughput](https://img.shields.io/badge/ingestion-${rps}%20
 note="<sub>${mspr} ms/replay · corpus: ${corpus} replays · GitHub-hosted 2-core runner · updated automatically on merge to main</sub>"
 
 awk -v badge="$badge" -v note="$note" '
-  /<!-- ingest-bench-start -->/ { print; print badge; print note; skip = 1; next }
-  /<!-- ingest-bench-end -->/   { skip = 0 }
+  /^\[!\[Ingestion throughput\]/ { print badge; next }
+  /<!-- ingest-bench-start -->/  { print; print note; skip = 1; next }
+  /<!-- ingest-bench-end -->/    { skip = 0 }
   skip                          { next }
   { print }
 ' "$readme" >"$readme.tmp"


### PR DESCRIPTION
Reorder the README header so the description leads, all badges sit in one row, and the ingestion benchmark detail sits on a line below.