### PR TITLE
fix(ci): stop Release double-run race; make bench README push best-effort

### DIFF
--- a/.github/workflows/bench-ingest.yml
+++ b/.github/workflows/bench-ingest.yml
@@ -99,8 +99,13 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
 
+      # Best-effort: branch protection on main requires a `test` status check
+      # that a bot's direct push can't satisfy, so the push is rejected whenever
+      # the figure actually changes. Don't fail the run over a cosmetic badge
+      # (mirrors the Scoop-manifest step in release.yml).
       - name: Update README figure and commit (main only)
         if: github.event_name == 'push'
+        continue-on-error: true
         run: |
           line="$(grep '^ingest-bench-summary:' bench-current.log)"
           rps="$(echo "$line" | sed -n 's/.*replays_per_sec=\([^ ]*\).*/\1/p')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
+# release-please tags AND publishes a GitHub release in the same instant. Firing
+# on both `push: tags` and `release: published` launched two concurrent Release
+# runs that raced to overwrite the same assets, intermittently 404ing and
+# leaving a binary missing from the release. Trigger only on the published
+# release; on that event github.ref_type/ref_name are still the tag, so the
+# Scoop/Homebrew/minisign steps below behave identically.
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
Trigger the Release workflow only on `release: published` (release-please already publishes) instead of also on `push: tags`, which launched two concurrent runs that raced to overwrite release assets and left a binary missing; and mark the bench-ingest README-figure push `continue-on-error` since branch protection rejects the bot's direct push to main.