### PR TITLE
fix(scoop): unstick stale v1.3.0 manifest and bump via PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
@@ -52,18 +53,23 @@ jobs:
         working-directory: dist
         run: sha256sum * > SHA256SUMS
 
-      # Regenerate the Scoop manifest from the freshly built binaries and commit
-      # it to the default branch so `scoop update screpdb` picks up the release.
-      # Best-effort: never fail the release if branch protection blocks the push
-      # (the manifest can also be regenerated locally with the same script).
+      # Regenerate the Scoop manifest from the freshly built binaries so
+      # `scoop update screpdb` picks up the release. Branch protection rejects a
+      # direct push to the default branch (the bot is not a bypass actor), which
+      # silently froze the manifest at an old release for many cycles. Open a PR
+      # instead — it respects branch protection and, if the bump is ever blocked,
+      # surfaces as a visible PR rather than a swallowed error. Auto-merge is
+      # requested best-effort; it lands automatically wherever the repo allows it.
       - name: Update Scoop manifest
         if: github.ref_type == 'tag'
-        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+          BRANCH="chore/scoop-bump-${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # dist/SHA256SUMS is untracked, so it survives the checkout.
@@ -74,9 +80,18 @@ jobs:
             echo "Scoop manifest already up to date."
             exit 0
           fi
+          git checkout -b "$BRANCH"
           git add bucket/screpdb.json
           git commit -m "chore(scoop): bump manifest to ${VERSION}"
-          git push origin "$DEFAULT_BRANCH"
+          git push --force-with-lease origin "$BRANCH"
+          if gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null | grep -q OPEN; then
+            echo "PR for $BRANCH already open."
+          else
+            gh pr create --base "$DEFAULT_BRANCH" --head "$BRANCH" \
+              --title "chore(scoop): bump manifest to ${VERSION}" \
+              --body "Automated Scoop manifest bump for v${VERSION} so \`scoop install\`/\`scoop update screpdb\` resolves the current release."
+          fi
+          gh pr merge "$BRANCH" --auto --squash || echo "::warning::Could not enable auto-merge; merge the Scoop bump PR manually."
 
       # Bump the Homebrew formula in the dedicated marianogappa/homebrew-screpdb
       # tap so `brew upgrade screpdb` picks up the release. Requires a

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ See [CHANGELOG.md](CHANGELOG.md) for release notes.
 <details>
 <summary><strong>Windows</strong> — recommended: install with Scoop</summary>
 
-**👉 Recommended: install with [Scoop](https://scoop.sh).** Open **PowerShell** and paste these two commands:
+**👉 Recommended: install with [Scoop](https://scoop.sh).** Open **PowerShell** and paste these commands:
 
 ```powershell
+scoop install git   # required by 'scoop bucket add' (skip if you already have git)
 scoop bucket add screpdb https://github.com/marianogappa/screpdb
 scoop install screpdb
 ```

--- a/bucket/screpdb.json
+++ b/bucket/screpdb.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.3.0",
+    "version": "1.20.0",
     "description": "Advanced StarCraft: Brood War replay reporting tool (CLI + local dashboard).",
     "homepage": "https://github.com/marianogappa/screpdb",
     "license": "MIT",
@@ -10,12 +10,12 @@
     "architecture": {
         "64bit": {
             "url": [
-                "https://github.com/marianogappa/screpdb/releases/download/v1.3.0/screpdb-windows-amd64.exe",
-                "https://github.com/marianogappa/screpdb/releases/download/v1.3.0/screpdb-gui-windows-amd64.exe"
+                "https://github.com/marianogappa/screpdb/releases/download/v1.20.0/screpdb-windows-amd64.exe",
+                "https://github.com/marianogappa/screpdb/releases/download/v1.20.0/screpdb-gui-windows-amd64.exe"
             ],
             "hash": [
-                "6b4191aa91d1879326e643b33dd1140f7d1797e322e1c538bcd784e61f0b6ab1",
-                "0a8fd767afcaecd30839158895284b4ad47f1a06c13dcfa235245084bd6fc58c"
+                "33e6175ffafa40696a73ef19c3db7218a4e404ca29df8ba5d806f9f971e62217",
+                "9329af049b5abe0d17fa6ba144b1d62042fca347d28860f4ba1329c67ce8866b"
             ],
             "bin": [
                 [


### PR DESCRIPTION
The Scoop manifest was pinned to v1.3.0 (predating the `screpdb-gui` asset), so the recommended `scoop install screpdb` 404'd on the GUI binary; this regenerates it for v1.20.0, replaces the CI auto-bump's branch-protection-blocked direct push with a PR, and documents the `scoop install git` prerequisite.