### PR TITLE
fix(gui): open dashboard browser from Medium launcher, add tray item

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -13,6 +13,7 @@ import (
 	"github.com/marianogappa/screpdb/internal/dashboard"
 	"github.com/marianogappa/screpdb/internal/dashboardrun"
 	"github.com/marianogappa/screpdb/internal/selfupdate"
+	"github.com/marianogappa/screpdb/internal/winsandbox"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -80,13 +81,32 @@ func RunDashboardWithContext(ctx context.Context, opts dashboardrun.Options) err
 		log.Printf("Self-update relaunch complete; refresh the existing browser tab to load the new version.")
 	default:
 		log.Printf("Opening browser to %s...", serverURL)
-		if err := browser.OpenURL(serverURL); err != nil {
+		if err := openDashboardBrowser(serverURL); err != nil {
 			log.Printf("Warning: failed to open browser: %v", err)
 		}
+		// A successful open call does not guarantee a window appeared (on Windows
+		// ShellExecute reports success even when nothing launches), so always tell
+		// the user where to go if it didn't.
+		log.Printf("If no browser window opened, open %s manually.", serverURL)
 	}
 
 	<-ctx.Done()
 	return nil
+}
+
+// openDashboardBrowser opens the dashboard in the default browser. The
+// Low-integrity Windows worker cannot do this itself — a ShellExecute from Low
+// integrity silently fails to spawn a window (issue #237) — so it hands the URL
+// to the Medium launcher via the broker. Every other build opens it directly.
+func openDashboardBrowser(serverURL string) error {
+	if winsandbox.IsWorker() {
+		dir, err := appdata.Dir()
+		if err != nil {
+			return fmt.Errorf("resolve app-data dir: %w", err)
+		}
+		return winsandbox.BrokerOpenURL(dir, serverURL)
+	}
+	return browser.OpenURL(serverURL)
 }
 
 func runDashboard(cmd *cobra.Command, args []string) error {

--- a/cmd/windows-dashboard/main.go
+++ b/cmd/windows-dashboard/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -67,6 +68,21 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// The tray runs inside this Low-integrity worker, so "Open dashboard" cannot
+	// open the browser directly (issue #237); it hands the URL to the Medium
+	// launcher via the broker, same as the initial auto-open.
+	var onOpen func()
+	if !opts.Headless {
+		if dir, err := appdata.Dir(); err == nil {
+			serverURL := fmt.Sprintf("http://localhost:%d", opts.Port)
+			onOpen = func() {
+				if err := winsandbox.BrokerOpenURL(dir, serverURL); err != nil {
+					log.Printf("tray: failed to open dashboard: %v", err)
+				}
+			}
+		}
+	}
+
 	errCh := make(chan error, 1)
 	go func() {
 		defer crashreport.Guard()
@@ -86,6 +102,7 @@ func main() {
 		Title:   "screpdb",
 		Tooltip: "screpdb dashboard",
 		Icon:    tray.DefaultIcon(),
+		OnOpen:  onOpen,
 		OnQuit:  cancel,
 	}); err != nil {
 		log.Println(err)

--- a/internal/tray/tray_nonwindows.go
+++ b/internal/tray/tray_nonwindows.go
@@ -8,6 +8,7 @@ type Config struct {
 	Title   string
 	Tooltip string
 	Icon    []byte
+	OnOpen  func()
 	OnQuit  func()
 }
 

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -13,6 +13,7 @@ type Config struct {
 	Title   string
 	Tooltip string
 	Icon    []byte
+	OnOpen  func()
 	OnQuit  func()
 }
 
@@ -41,6 +42,16 @@ func Run(config Config) error {
 		}
 		if len(icon) > 0 {
 			systray.SetIcon(icon)
+		}
+
+		if config.OnOpen != nil {
+			openItem := systray.AddMenuItem("Open dashboard", "Open the screpdb dashboard in your browser")
+			go func() {
+				defer crashreport.Guard()
+				for range openItem.ClickedCh {
+					config.OnOpen()
+				}
+			}()
 		}
 
 		quitItem := systray.AddMenuItem("Quit", "Quit screpdb dashboard")

--- a/internal/winsandbox/broker_windows.go
+++ b/internal/winsandbox/broker_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -14,16 +15,22 @@ import (
 	"time"
 
 	"github.com/marianogappa/screpdb/internal/crashreport"
+	"github.com/pkg/browser"
 )
 
-// The See-replay ("watch me") feature stages a replay into the user's replays
-// folder so StarCraft can load it. That folder is read-only to the Low worker,
-// so the worker asks the Medium launcher to perform the single write via a
-// file-drop broker under the (Low-writable) app-data dir.
+// The Low worker asks the Medium launcher to perform two things it cannot do
+// itself, via a file-drop broker under the (Low-writable) app-data dir:
 //
-// Fixed, non-negotiable destination — the launcher never honors a
-// worker-supplied filename/subpath, so a compromised worker can at worst
-// overwrite this one file with bytes it could already read from app-data.
+//   - See-replay ("watch me"): stage a replay into the user's replays folder so
+//     StarCraft can load it. That folder is read-only to the Low worker.
+//   - open-url: bring up the dashboard in the default browser. A ShellExecute
+//     from a Low-integrity process silently fails to spawn a window (issue #237),
+//     so the Medium launcher opens the browser on the worker's behalf.
+//
+// Both request kinds are locked down so a compromised worker gains nothing: the
+// See-replay destination is fixed, and open-url only ever opens a loopback
+// dashboard URL — never an arbitrary string ShellExecute could turn into a
+// launched program.
 const (
 	brokerDirName     = "broker"
 	seeReplayFolder   = "000_screpdb_watch_me"
@@ -31,17 +38,26 @@ const (
 	requestSuffix     = ".request.json"
 	responseSuffix    = ".response.json"
 
+	kindSeeReplay = "see-replay"
+	kindOpenURL   = "open-url"
+
 	brokerPollInterval = 200 * time.Millisecond
 	clientPollInterval = 50 * time.Millisecond
 	clientTimeout      = 15 * time.Second
 )
 
-type seeRequest struct {
-	Source       string `json:"source"`        // absolute path inside app-data
-	ReplayFolder string `json:"replay_folder"` // current ingest dir (write target parent)
+type brokerRequest struct {
+	Kind string `json:"kind"`
+
+	// See-replay fields.
+	Source       string `json:"source,omitempty"`        // absolute path inside app-data
+	ReplayFolder string `json:"replay_folder,omitempty"` // current ingest dir (write target parent)
+
+	// open-url fields.
+	URL string `json:"url,omitempty"`
 }
 
-type seeResponse struct {
+type brokerResponse struct {
 	Success bool   `json:"success"`
 	Dest    string `json:"dest,omitempty"`
 	Error   string `json:"error,omitempty"`
@@ -49,24 +65,23 @@ type seeResponse struct {
 
 var brokerSeq atomic.Uint64
 
-// BrokerSeeReplay (worker side) drops a request for the launcher to copy source
-// into <replayFolder>/000_screpdb_watch_me/watch_me.rep and waits for the
-// response. Returns the destination path on success.
-func BrokerSeeReplay(appDataDir, source, replayFolder string) (string, error) {
+// brokerRoundtrip (worker side) drops req under appDataDir/broker and waits for
+// the launcher's response.
+func brokerRoundtrip(appDataDir string, req brokerRequest) (brokerResponse, error) {
 	dir := filepath.Join(appDataDir, brokerDirName)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return "", fmt.Errorf("create broker dir: %w", err)
+		return brokerResponse{}, fmt.Errorf("create broker dir: %w", err)
 	}
 	nonce := strconv.Itoa(os.Getpid()) + "-" + strconv.FormatUint(brokerSeq.Add(1), 10)
 	reqPath := filepath.Join(dir, nonce+requestSuffix)
 	respPath := filepath.Join(dir, nonce+responseSuffix)
 
-	body, err := json.Marshal(seeRequest{Source: source, ReplayFolder: replayFolder})
+	body, err := json.Marshal(req)
 	if err != nil {
-		return "", err
+		return brokerResponse{}, err
 	}
 	if err := os.WriteFile(reqPath, body, 0o644); err != nil {
-		return "", fmt.Errorf("write broker request: %w", err)
+		return brokerResponse{}, fmt.Errorf("write broker request: %w", err)
 	}
 	defer os.Remove(reqPath)
 	defer os.Remove(respPath)
@@ -74,23 +89,52 @@ func BrokerSeeReplay(appDataDir, source, replayFolder string) (string, error) {
 	deadline := time.Now().Add(clientTimeout)
 	for {
 		if data, err := os.ReadFile(respPath); err == nil {
-			var resp seeResponse
+			var resp brokerResponse
 			if err := json.Unmarshal(data, &resp); err != nil {
-				return "", fmt.Errorf("decode broker response: %w", err)
+				return brokerResponse{}, fmt.Errorf("decode broker response: %w", err)
 			}
-			if !resp.Success {
-				return "", fmt.Errorf("broker: %s", resp.Error)
-			}
-			return resp.Dest, nil
+			return resp, nil
 		}
 		if time.Now().After(deadline) {
-			return "", fmt.Errorf("broker request timed out after %s", clientTimeout)
+			return brokerResponse{}, fmt.Errorf("broker request timed out after %s", clientTimeout)
 		}
 		time.Sleep(clientPollInterval)
 	}
 }
 
-// StartBroker (launcher side) serves See-replay requests dropped under
+// BrokerSeeReplay (worker side) drops a request for the launcher to copy source
+// into <replayFolder>/000_screpdb_watch_me/watch_me.rep and waits for the
+// response. Returns the destination path on success.
+func BrokerSeeReplay(appDataDir, source, replayFolder string) (string, error) {
+	resp, err := brokerRoundtrip(appDataDir, brokerRequest{
+		Kind:         kindSeeReplay,
+		Source:       source,
+		ReplayFolder: replayFolder,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !resp.Success {
+		return "", fmt.Errorf("broker: %s", resp.Error)
+	}
+	return resp.Dest, nil
+}
+
+// BrokerOpenURL (worker side) asks the Medium launcher to open url in the
+// default browser. url must be a loopback dashboard URL; the launcher rejects
+// anything else.
+func BrokerOpenURL(appDataDir, url string) error {
+	resp, err := brokerRoundtrip(appDataDir, brokerRequest{Kind: kindOpenURL, URL: url})
+	if err != nil {
+		return err
+	}
+	if !resp.Success {
+		return fmt.Errorf("broker: %s", resp.Error)
+	}
+	return nil
+}
+
+// StartBroker (launcher side) serves worker requests dropped under
 // appDataDir/broker until ctx is cancelled or the returned stop func is called.
 // It runs in its own goroutine.
 func StartBroker(ctx context.Context, appDataDir string) (func(), error) {
@@ -126,7 +170,7 @@ func serveBrokerRequests(dir string) {
 		}
 		reqPath := filepath.Join(dir, e.Name())
 		respPath := strings.TrimSuffix(reqPath, requestSuffix) + responseSuffix
-		resp := handleSeeRequest(reqPath)
+		resp := handleBrokerRequest(reqPath)
 		if body, err := json.Marshal(resp); err == nil {
 			_ = os.WriteFile(respPath, body, 0o644)
 		}
@@ -134,41 +178,87 @@ func serveBrokerRequests(dir string) {
 	}
 }
 
-func handleSeeRequest(reqPath string) seeResponse {
+func handleBrokerRequest(reqPath string) brokerResponse {
 	data, err := os.ReadFile(reqPath)
 	if err != nil {
-		return seeResponse{Error: "read request: " + err.Error()}
+		return brokerResponse{Error: "read request: " + err.Error()}
 	}
-	var req seeRequest
+	var req brokerRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return seeResponse{Error: "decode request: " + err.Error()}
+		return brokerResponse{Error: "decode request: " + err.Error()}
 	}
+	switch req.Kind {
+	case kindOpenURL:
+		return handleOpenURLRequest(req)
+	case kindSeeReplay, "":
+		return handleSeeRequest(req)
+	default:
+		return brokerResponse{Error: "unknown broker request kind: " + req.Kind}
+	}
+}
+
+func handleSeeRequest(req brokerRequest) brokerResponse {
 	// Source is the replay to stage (read-down access is always allowed, so the
 	// launcher grants no new read capability); require it to be a regular file.
 	if info, err := os.Stat(req.Source); err != nil || info.IsDir() {
-		return seeResponse{Error: "source is not a readable file"}
+		return brokerResponse{Error: "source is not a readable file"}
 	}
 	replayFolder := strings.TrimSpace(req.ReplayFolder)
 	if replayFolder == "" {
-		return seeResponse{Error: "empty replay folder"}
+		return brokerResponse{Error: "empty replay folder"}
 	}
 	if info, err := os.Stat(replayFolder); err != nil || !info.IsDir() {
-		return seeResponse{Error: "replay folder is not a directory"}
+		return brokerResponse{Error: "replay folder is not a directory"}
 	}
 
 	// The destination is fixed — a compromised worker cannot direct the
 	// Medium launcher to write anywhere but this one file.
 	destDir := filepath.Join(replayFolder, seeReplayFolder)
 	if err := os.MkdirAll(destDir, 0o755); err != nil {
-		return seeResponse{Error: "create dest dir: " + err.Error()}
+		return brokerResponse{Error: "create dest dir: " + err.Error()}
 	}
 	dest := filepath.Join(destDir, seeReplayFilename)
 	input, err := os.ReadFile(req.Source)
 	if err != nil {
-		return seeResponse{Error: "read source: " + err.Error()}
+		return brokerResponse{Error: "read source: " + err.Error()}
 	}
 	if err := os.WriteFile(dest, input, 0o644); err != nil {
-		return seeResponse{Error: "write dest: " + err.Error()}
+		return brokerResponse{Error: "write dest: " + err.Error()}
 	}
-	return seeResponse{Success: true, Dest: dest}
+	return brokerResponse{Success: true, Dest: dest}
+}
+
+func handleOpenURLRequest(req brokerRequest) brokerResponse {
+	// Only ever open a loopback dashboard URL. This keeps the Low sandbox
+	// meaningful: a compromised worker cannot hand the Medium launcher an
+	// arbitrary string for ShellExecute to turn into a launched program or a
+	// non-http protocol handler.
+	if err := validateLoopbackURL(req.URL); err != nil {
+		return brokerResponse{Error: err.Error()}
+	}
+	if err := browser.OpenURL(req.URL); err != nil {
+		return brokerResponse{Error: "open browser: " + err.Error()}
+	}
+	return brokerResponse{Success: true}
+}
+
+func validateLoopbackURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "http" {
+		return fmt.Errorf("refusing to open non-http url scheme %q", u.Scheme)
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1":
+	default:
+		return fmt.Errorf("refusing to open non-loopback host %q", u.Hostname())
+	}
+	if port := u.Port(); port != "" {
+		if _, err := strconv.Atoi(port); err != nil {
+			return fmt.Errorf("invalid port %q", port)
+		}
+	}
+	return nil
 }

--- a/internal/winsandbox/stub_nonwindows.go
+++ b/internal/winsandbox/stub_nonwindows.go
@@ -29,3 +29,7 @@ func StartBroker(context.Context, string) (func(), error) { return func() {}, er
 // BrokerSeeReplay is a no-op stub off Windows; the worker path that calls it
 // only runs on Windows (guarded by IsWorker()).
 func BrokerSeeReplay(string, string, string) (string, error) { return "", errUnsupported }
+
+// BrokerOpenURL is a no-op stub off Windows; the worker path that calls it only
+// runs on Windows (guarded by IsWorker()).
+func BrokerOpenURL(string, string) error { return errUnsupported }


### PR DESCRIPTION
The Low-integrity Windows worker's ShellExecute silently fails to spawn a browser window (issue #237), so the auto-open reported success while nothing appeared; this routes the open (initial auto-open and a new "Open dashboard" tray item) through the broker so the Medium launcher opens it, restricted to loopback dashboard URLs, and always logs the manual URL fallback.