### PR TITLE
fix(gui): host tray in Medium launcher so it appears under the Low sandbox

### DIFF
--- a/cmd/windows-dashboard/launcher_windows.go
+++ b/cmd/windows-dashboard/launcher_windows.go
@@ -4,19 +4,32 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log"
 	"os"
 
 	"github.com/marianogappa/screpdb/internal/appdata"
+	"github.com/marianogappa/screpdb/internal/crashreport"
+	"github.com/marianogappa/screpdb/internal/dashboardrun"
 	"github.com/marianogappa/screpdb/internal/selfupdate"
+	"github.com/marianogappa/screpdb/internal/tray"
 	"github.com/marianogappa/screpdb/internal/winsandbox"
+	"github.com/pkg/browser"
+	"github.com/spf13/pflag"
 )
 
 // runLauncher is the Medium-integrity parent process (issue #237). It prepares
-// the Low-writable app-data dir, serves the watch-me broker, and supervises the
-// Low-integrity worker: on a normal exit it exits too; on the update exit code
-// it performs the (Medium-only) self-update swap and relaunches the worker.
-// It returns the process exit code. The worker inherits os.Args verbatim.
+// the Low-writable app-data dir, serves the watch-me/open-url broker, hosts the
+// system-tray icon, and supervises the Low-integrity worker: on a normal exit it
+// exits too; on the update exit code it performs the (Medium-only) self-update
+// swap and relaunches the worker. It returns the process exit code. The worker
+// inherits os.Args verbatim.
+//
+// The tray must live here, not in the worker: a Low-integrity process cannot
+// register a notification-area icon — UIPI drops its Shell_NotifyIcon call up to
+// the (Medium) Explorer — so the icon silently never appears. The launcher, at
+// Medium, also opens the browser directly for "Open dashboard".
 func runLauncher() int {
 	dir, err := appdata.Dir()
 	if err != nil {
@@ -43,14 +56,64 @@ func runLauncher() int {
 		return 1
 	}
 
+	// The worker re-parses flags authoritatively; the launcher only needs the
+	// port and headless flag to wire the tray's "Open dashboard" action.
+	var opts dashboardrun.Options
+	fs := pflag.NewFlagSet("screpdb-launcher", pflag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	dashboardrun.RegisterFlags(fs, &opts)
+	_ = fs.Parse(os.Args[1:])
+	serverURL := fmt.Sprintf("http://localhost:%d", opts.Port)
+
+	// Supervise the worker off the main goroutine; systray owns the main thread.
+	exitCode := make(chan int, 1)
+	workerDone := make(chan struct{})
+	go func() {
+		defer crashreport.Guard()
+		exitCode <- superviseWorker(ctx, self, dir)
+		close(workerDone)
+		tray.Quit() // worker exited on its own → drop the tray so the launcher exits
+	}()
+
+	err = tray.Run(tray.Config{
+		Title:   "screpdb",
+		Tooltip: "screpdb dashboard",
+		Icon:    tray.DefaultIcon(),
+		OnOpen: func() {
+			if opts.Headless {
+				return
+			}
+			if err := browser.OpenURL(serverURL); err != nil {
+				log.Printf("launcher: failed to open dashboard: %v", err)
+			}
+		},
+		OnQuit: func() {
+			cancel()     // terminate the worker (SpawnWorkerLow honors ctx)
+			<-workerDone // hold the tray open until the worker is actually gone
+		},
+	})
+	if err != nil {
+		log.Printf("launcher: tray error: %v", err)
+	}
+	cancel() // tray gone → make sure the worker is torn down before we exit
+	return <-exitCode
+}
+
+// superviseWorker runs (and re-runs, across self-updates) the Low-integrity
+// worker until it exits for good, and returns the launcher's exit code. It
+// returns 0 when ctx was cancelled (an intentional tray "Quit").
+func superviseWorker(ctx context.Context, self, dir string) int {
 	extraEnv := []string{winsandbox.WorkerEnv + "=1"}
 	for {
 		// SCREPDB_WORKER=1 tells the child to run the dashboard rather than
 		// relaunch itself; the working dir is the Low-writable app-data root.
-		code, err := winsandbox.SpawnWorkerLow(self, os.Args[1:], extraEnv, dir)
+		code, err := winsandbox.SpawnWorkerLow(ctx, self, os.Args[1:], extraEnv, dir)
 		if err != nil {
 			log.Printf("launcher: failed to spawn Low-integrity worker: %v", err)
 			return 1
+		}
+		if ctx.Err() != nil {
+			return 0 // intentional shutdown: the tray "Quit" cancelled ctx.
 		}
 		if code != winsandbox.ExitCodeUpdate {
 			return code

--- a/cmd/windows-dashboard/main.go
+++ b/cmd/windows-dashboard/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -14,7 +12,6 @@ import (
 	"github.com/marianogappa/screpdb/internal/crashreport"
 	"github.com/marianogappa/screpdb/internal/dashboardrun"
 	"github.com/marianogappa/screpdb/internal/iofacade"
-	"github.com/marianogappa/screpdb/internal/tray"
 	"github.com/marianogappa/screpdb/internal/winsandbox"
 	"github.com/spf13/pflag"
 )
@@ -25,9 +22,9 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
 	// On Windows, the first (Medium-integrity) process is the launcher: it
-	// prepares the Low-writable app-data dir and relaunches this binary as a
-	// Low-integrity worker (issue #237). ShouldLaunch is false once we are the
-	// worker, and always false off Windows.
+	// prepares the Low-writable app-data dir, hosts the tray, opens the browser,
+	// and relaunches this binary as a Low-integrity worker (issue #237).
+	// ShouldLaunch is false once we are the worker, and always false off Windows.
 	if winsandbox.ShouldLaunch() {
 		if logPath, err := appdata.Path("screpdb-launcher.log"); err == nil {
 			if logFile, err := iofacade.Create(logPath); err == nil {
@@ -46,6 +43,19 @@ func main() {
 		}
 	}
 
+	// The Low-integrity worker cannot open a browser itself (issue #237), so the
+	// crash reporter's "open the prefilled issue" step is routed to the Medium
+	// launcher via the broker, same as the dashboard auto-open.
+	if winsandbox.IsWorker() {
+		crashreport.SetOpener(func(issueURL string) error {
+			dir, err := appdata.Dir()
+			if err != nil {
+				return err
+			}
+			return winsandbox.BrokerOpenURL(dir, issueURL)
+		})
+	}
+
 	var opts dashboardrun.Options
 	fs := pflag.NewFlagSet("windows-dashboard", pflag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -55,56 +65,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	if !tray.Supported() {
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
-		if err := cmd.RunDashboardWithContext(ctx, opts); err != nil {
-			log.Println(err)
-			os.Exit(1)
-		}
-		return
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// The tray runs inside this Low-integrity worker, so "Open dashboard" cannot
-	// open the browser directly (issue #237); it hands the URL to the Medium
-	// launcher via the broker, same as the initial auto-open.
-	var onOpen func()
-	if !opts.Headless {
-		if dir, err := appdata.Dir(); err == nil {
-			serverURL := fmt.Sprintf("http://localhost:%d", opts.Port)
-			onOpen = func() {
-				if err := winsandbox.BrokerOpenURL(dir, serverURL); err != nil {
-					log.Printf("tray: failed to open dashboard: %v", err)
-				}
-			}
-		}
-	}
-
-	errCh := make(chan error, 1)
-	go func() {
-		defer crashreport.Guard()
-		errCh <- cmd.RunDashboardWithContext(ctx, opts)
-	}()
-
-	go func() {
-		defer crashreport.Guard()
-		if err := <-errCh; err != nil && !errors.Is(err, context.Canceled) {
-			log.Printf("dashboard exited with error: %v", err)
-		}
-		cancel()
-		tray.Quit()
-	}()
-
-	if err := tray.Run(tray.Config{
-		Title:   "screpdb",
-		Tooltip: "screpdb dashboard",
-		Icon:    tray.DefaultIcon(),
-		OnOpen:  onOpen,
-		OnQuit:  cancel,
-	}); err != nil {
+	// The tray lives in the Medium launcher; the worker only serves the dashboard.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := cmd.RunDashboardWithContext(ctx, opts); err != nil {
 		log.Println(err)
 		os.Exit(1)
 	}

--- a/internal/crashreport/crashreport.go
+++ b/internal/crashreport/crashreport.go
@@ -31,6 +31,24 @@ var openBrowserDefault atomic.Bool
 // entrypoint should call it once at startup, before spawning goroutines.
 func SetOpenBrowser(open bool) { openBrowserDefault.Store(open) }
 
+// issueOpener overrides how the prefilled issue URL is opened. It holds a
+// func(string) error. The zero value falls back to browser.OpenURL, which is
+// correct for a Medium-integrity process; the Low-integrity Windows worker
+// cannot open a browser itself (issue #237), so its entrypoint sets an opener
+// that routes through the Medium launcher's broker.
+var issueOpener atomic.Value
+
+// SetOpener overrides how crash reports open the prefilled issue URL. An
+// entrypoint should call it once at startup, before spawning goroutines.
+func SetOpener(open func(string) error) { issueOpener.Store(open) }
+
+func openIssue(issueURL string) error {
+	if v := issueOpener.Load(); v != nil {
+		return v.(func(string) error)(issueURL)
+	}
+	return browser.OpenURL(issueURL)
+}
+
 // Guard is deferred at the top of every long-lived goroutine:
 //
 //	go func() {
@@ -141,7 +159,7 @@ func Handle(recovered any, stack []byte, openBrowser bool) {
 	fmt.Fprintln(os.Stderr, rule)
 
 	if openBrowser {
-		_ = browser.OpenURL(issueURL)
+		_ = openIssue(issueURL)
 	}
 }
 

--- a/internal/tray/tray_windows.go
+++ b/internal/tray/tray_windows.go
@@ -4,6 +4,7 @@ package tray
 
 import (
 	_ "embed"
+	"sync"
 
 	"github.com/getlantern/systray"
 	"github.com/marianogappa/screpdb/internal/crashreport"
@@ -61,13 +62,18 @@ func Run(config Config) error {
 			if config.OnQuit != nil {
 				config.OnQuit()
 			}
-			systray.Quit()
+			quit()
 		}()
 	}, func() {})
 
 	return nil
 }
 
-func Quit() {
-	systray.Quit()
-}
+// quitOnce guards systray.Quit: the launcher tears the tray down from both the
+// "Quit" click and the worker-exited path, and calling systray.Quit twice can
+// panic on its closed channel.
+var quitOnce sync.Once
+
+func quit() { quitOnce.Do(systray.Quit) }
+
+func Quit() { quit() }

--- a/internal/winsandbox/broker_windows.go
+++ b/internal/winsandbox/broker_windows.go
@@ -229,11 +229,12 @@ func handleSeeRequest(req brokerRequest) brokerResponse {
 }
 
 func handleOpenURLRequest(req brokerRequest) brokerResponse {
-	// Only ever open a loopback dashboard URL. This keeps the Low sandbox
-	// meaningful: a compromised worker cannot hand the Medium launcher an
-	// arbitrary string for ShellExecute to turn into a launched program or a
-	// non-http protocol handler.
-	if err := validateLoopbackURL(req.URL); err != nil {
+	// Only ever open a URL the worker legitimately needs the Medium launcher to
+	// open for it: the loopback dashboard, or a prefilled screpdb GitHub issue
+	// from the crash reporter. This keeps the Low sandbox meaningful — a
+	// compromised worker cannot hand the launcher an arbitrary string for
+	// ShellExecute to turn into a launched program or a non-http protocol handler.
+	if err := validateBrokerURL(req.URL); err != nil {
 		return brokerResponse{Error: err.Error()}
 	}
 	if err := browser.OpenURL(req.URL); err != nil {
@@ -242,23 +243,22 @@ func handleOpenURLRequest(req brokerRequest) brokerResponse {
 	return brokerResponse{Success: true}
 }
 
-func validateLoopbackURL(raw string) error {
+func validateBrokerURL(raw string) error {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return fmt.Errorf("invalid url: %w", err)
 	}
-	if u.Scheme != "http" {
-		return fmt.Errorf("refusing to open non-http url scheme %q", u.Scheme)
-	}
-	switch u.Hostname() {
-	case "localhost", "127.0.0.1":
-	default:
-		return fmt.Errorf("refusing to open non-loopback host %q", u.Hostname())
-	}
-	if port := u.Port(); port != "" {
-		if _, err := strconv.Atoi(port); err != nil {
-			return fmt.Errorf("invalid port %q", port)
+	switch {
+	case u.Scheme == "http" && (u.Hostname() == "localhost" || u.Hostname() == "127.0.0.1"):
+		if port := u.Port(); port != "" {
+			if _, err := strconv.Atoi(port); err != nil {
+				return fmt.Errorf("invalid port %q", port)
+			}
 		}
+		return nil
+	case u.Scheme == "https" && u.Hostname() == "github.com" && strings.HasPrefix(u.Path, "/marianogappa/screpdb"):
+		return nil
+	default:
+		return fmt.Errorf("refusing to open url %q", raw)
 	}
-	return nil
 }

--- a/internal/winsandbox/containment_integration_windows_test.go
+++ b/internal/winsandbox/containment_integration_windows_test.go
@@ -12,6 +12,7 @@
 package winsandbox
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func TestLowIntegrityContainment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Executable: %v", err)
 	}
-	code, err := SpawnWorkerLow(self, nil, []string{selfTestEnv + "=" + appDir, WorkerEnv + "=1"}, appDir)
+	code, err := SpawnWorkerLow(context.Background(), self, nil, []string{selfTestEnv + "=" + appDir, WorkerEnv + "=1"}, appDir)
 	if err != nil {
 		t.Fatalf("SpawnWorkerLow: %v", err)
 	}

--- a/internal/winsandbox/spawn_windows.go
+++ b/internal/winsandbox/spawn_windows.go
@@ -3,9 +3,11 @@
 package winsandbox
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -25,8 +27,10 @@ func ShouldLaunch() bool { return !IsWorker() }
 // entries ("KEY=VALUE") are added to the child's environment (WorkerEnv is set
 // by the caller). workDir becomes the child's working directory — set it to the
 // Low-writable app-data root so the worker's cwd-relative bootstrap never tries
-// to write into the Medium install directory.
-func SpawnWorkerLow(exePath string, args, extraEnv []string, workDir string) (int, error) {
+// to write into the Medium install directory. Cancelling ctx terminates the
+// worker (the tray "Quit" path): a spawned Low process is not a child job, so it
+// would otherwise outlive the launcher.
+func SpawnWorkerLow(ctx context.Context, exePath string, args, extraEnv []string, workDir string) (int, error) {
 	var procToken windows.Token
 	if err := windows.OpenProcessToken(
 		windows.CurrentProcess(),
@@ -88,8 +92,27 @@ func SpawnWorkerLow(exePath string, args, extraEnv []string, workDir string) (in
 	defer windows.CloseHandle(pi.Thread)
 	defer windows.CloseHandle(pi.Process)
 
-	if _, err := windows.WaitForSingleObject(pi.Process, windows.INFINITE); err != nil {
-		return 0, fmt.Errorf("wait for worker: %w", err)
+	// Terminate the worker when the launcher cancels ctx (tray "Quit"). We join
+	// this goroutine (wg.Wait) before the deferred CloseHandle runs, so it can
+	// never fire a TerminateProcess against an already-closed, possibly recycled
+	// handle.
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ctx.Done():
+			_ = windows.TerminateProcess(pi.Process, 1)
+		case <-done:
+		}
+	}()
+
+	_, waitErr := windows.WaitForSingleObject(pi.Process, windows.INFINITE)
+	close(done)
+	wg.Wait()
+	if waitErr != nil {
+		return 0, fmt.Errorf("wait for worker: %w", waitErr)
 	}
 	var code uint32
 	if err := windows.GetExitCodeProcess(pi.Process, &code); err != nil {

--- a/internal/winsandbox/stub_nonwindows.go
+++ b/internal/winsandbox/stub_nonwindows.go
@@ -21,7 +21,9 @@ func ShouldLaunch() bool { return false }
 func SetLowLabel(string) error { return errUnsupported }
 
 // SpawnWorkerLow is a no-op stub off Windows.
-func SpawnWorkerLow(string, []string, []string, string) (int, error) { return 0, errUnsupported }
+func SpawnWorkerLow(context.Context, string, []string, []string, string) (int, error) {
+	return 0, errUnsupported
+}
 
 // StartBroker is a no-op stub off Windows.
 func StartBroker(context.Context, string) (func(), error) { return func() {}, errUnsupported }


### PR DESCRIPTION
A Low-integrity worker cannot register a notification-area icon (UIPI drops the `Shell_NotifyIcon` call up to Explorer) or open a browser, so the tray never appeared and left no way to quit; this moves the tray to the Medium launcher (which opens the browser directly and terminates the worker on Quit) and routes the worker's crash-report link through the broker.