### PR TITLE
feat(dashboard): single-instance startup, Quit button, and uninstall docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,33 @@ cd screpdb
 make build
 ```
 
+## Uninstall
+
+Removing screpdb is two steps: uninstall the binary, then (optionally) delete its data folder. screpdb keeps everything it writes — the database, settings, cache, logs, and crash reports — under a **single folder**, so there's nothing else to hunt down.
+
+**1. Remove the binary**
+
+| Installed with | Command |
+| --- | --- |
+| Scoop (Windows) | `scoop uninstall screpdb` |
+| Homebrew (macOS/Linux) | `brew uninstall screpdb` |
+| One-line installer / manual | Delete the binary you placed (e.g. `~/.local/bin/screpdb`) |
+
+**2. Delete the data folder** (optional — skip this to keep your data for a future reinstall). Package managers deliberately leave it in place, and the `brew`/`scoop` uninstall prints this reminder too:
+
+```bash
+# macOS
+rm -rf "$HOME/Library/Application Support/screpdb"
+
+# Linux
+rm -rf "${XDG_CONFIG_HOME:-$HOME/.config}/screpdb"
+```
+
+```powershell
+# Windows (PowerShell)
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\screpdb"
+```
+
 ## Developer features
 
 <details>

--- a/bucket/screpdb.json
+++ b/bucket/screpdb.json
@@ -7,6 +7,13 @@
         "Run 'screpdb-gui' (or 'screpdb dashboard') to open the local dashboard in your browser.",
         "The binaries are not code-signed; SmartScreen/Defender may warn on first run. See the README."
     ],
+    "post_uninstall": [
+        "Write-Host ''",
+        "Write-Host 'screpdb kept its data (database, settings) at:'",
+        "Write-Host \"  $env:LOCALAPPDATA\\screpdb\"",
+        "Write-Host 'To remove it too, run this (deletes your data):'",
+        "Write-Host \"  Remove-Item -Recurse -Force '$env:LOCALAPPDATA\\screpdb'\""
+    ],
     "architecture": {
         "64bit": {
             "url": [

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marianogappa/screpdb/internal/appdata"
 	"github.com/marianogappa/screpdb/internal/dashboard"
 	"github.com/marianogappa/screpdb/internal/dashboardrun"
+	"github.com/marianogappa/screpdb/internal/netfacade"
 	"github.com/marianogappa/screpdb/internal/selfupdate"
 	"github.com/marianogappa/screpdb/internal/winsandbox"
 	"github.com/pkg/browser"
@@ -46,7 +47,35 @@ func RunDashboardWithContext(ctx context.Context, opts dashboardrun.Options) err
 		// Self-update relaunch: wait for the previous process to release the
 		// listening port (Windows has no exec-in-place) before we bind.
 		time.Sleep(1500 * time.Millisecond)
+	} else {
+		// Single-instance guard: if screpdb is already serving on the requested
+		// port, reconnect to it (open the browser) rather than starting an
+		// invisible second server or failing on a busy port. If the port is held
+		// by a foreign process, fall through to the next free port in range.
+		// Skipped during a self-update relaunch, where we deliberately want to
+		// wait for and rebind the same port.
+		resolvedPort, alreadyRunning, resolveErr := resolveDashboardPort(opts.Port)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if alreadyRunning {
+			serverURL := fmt.Sprintf("http://localhost:%d", resolvedPort)
+			log.Printf("screpdb is already running at %s; opening it instead of starting another instance.", serverURL)
+			if !opts.Headless {
+				if err := openDashboardBrowser(serverURL); err != nil {
+					log.Printf("Warning: failed to open browser: %v", err)
+				}
+			}
+			return nil
+		}
+		opts.Port = resolvedPort
 	}
+
+	// Own the shutdown lifetime so the dashboard "Quit" button can stop us
+	// cleanly: cancelling this context unblocks the <-ctx.Done() below, which on
+	// Windows lets the launcher observe a clean worker exit and drop its tray.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	dbPath, err := appdata.ResolveDBPath(opts.SQLitePath)
 	if err != nil {
@@ -58,6 +87,7 @@ func RunDashboardWithContext(ctx context.Context, opts dashboardrun.Options) err
 	if err != nil {
 		return err
 	}
+	dash.SetShutdownFunc(cancel)
 
 	// Start backend server asynchronously
 	serverURL := fmt.Sprintf("http://localhost:%d", opts.Port)
@@ -92,6 +122,31 @@ func RunDashboardWithContext(ctx context.Context, opts dashboardrun.Options) err
 
 	<-ctx.Done()
 	return nil
+}
+
+// dashboardPortScanRange bounds how many consecutive ports single-instance
+// resolution will probe starting at the requested port before giving up.
+const dashboardPortScanRange = 10
+
+// resolveDashboardPort implements screpdb's single-instance policy. Starting at
+// the preferred port it scans a small range and returns either a free port to
+// bind (alreadyRunning=false) or the port of an existing screpdb to reconnect to
+// (alreadyRunning=true). A port held by a foreign process is skipped. It errors
+// only if the whole range is occupied by non-screpdb processes.
+func resolveDashboardPort(preferred int) (port int, alreadyRunning bool, err error) {
+	for p := preferred; p < preferred+dashboardPortScanRange; p++ {
+		addr := fmt.Sprintf("localhost:%d", p)
+		if netfacade.LocalPortAvailable(addr) {
+			return p, false, nil
+		}
+		if netfacade.IsLocalScrepdb(addr, 2*time.Second) {
+			return p, true, nil
+		}
+		log.Printf("Port %d is in use by another process; trying the next one.", p)
+	}
+	return 0, false, fmt.Errorf(
+		"no free port found in range %d-%d, and no existing screpdb to reconnect to",
+		preferred, preferred+dashboardPortScanRange-1)
 }
 
 // openDashboardBrowser opens the dashboard in the default browser. The

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -52,6 +52,14 @@ type Dashboard struct {
 	sampleSetAutoLoaded bool
 	pendingSampleIngest bool
 	headless            bool
+	shutdown            func()
+}
+
+// SetShutdownFunc registers the callback the /api/custom/quit endpoint invokes to
+// stop the process (typically the root context's cancel func). If unset, the
+// quit handler falls back to os.Exit(0).
+func (d *Dashboard) SetShutdownFunc(fn func()) {
+	d.shutdown = fn
 }
 
 func New(ctx context.Context, sqlitePath string, headless bool) (*Dashboard, error) {
@@ -206,6 +214,7 @@ func (d *Dashboard) setupRouter() *mux.Router {
 	r.HandleFunc("/api/custom/sample-set/load", d.handlerLoadSampleSet).Methods(http.MethodPost)
 	r.HandleFunc("/api/custom/update/status", d.handlerUpdateStatus).Methods(http.MethodGet)
 	r.HandleFunc("/api/custom/update/apply", d.handlerUpdateApply).Methods(http.MethodPost)
+	r.HandleFunc("/api/custom/quit", d.handlerQuit).Methods(http.MethodPost)
 	apigen.HandlerFromMux(strictHandler, r)
 	r.PathPrefix("/api/").Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/dashboard/endpoint_quit.go
+++ b/internal/dashboard/endpoint_quit.go
@@ -1,0 +1,35 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/marianogappa/screpdb/internal/crashreport"
+)
+
+// handlerQuit shuts screpdb down at the user's request (the dashboard "Quit"
+// button). It flushes a success response before tearing the process down so the
+// UI can show a clean "stopped" screen, mirroring the self-update apply handler.
+// The shutdown is deferred to a goroutine so the response reaches the client
+// first; it prefers the registered shutdown func (root context cancel, which
+// lets the Windows launcher drop its tray and exit) and falls back to os.Exit.
+func (d *Dashboard) handlerQuit(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"success": true, "shutting_down": true})
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+	go func() {
+		defer crashreport.GuardNonFatal(nil)
+		time.Sleep(500 * time.Millisecond)
+		log.Printf("quit requested from dashboard; shutting down")
+		if d.shutdown != nil {
+			d.shutdown()
+			return
+		}
+		os.Exit(0)
+	}()
+}

--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -1934,6 +1934,7 @@ function App() {
   const [updateError, setUpdateError] = useState('');
   const [quietUpdateDismissed, setQuietUpdateDismissed] = useState(false);
   const [loudUpdateDismissed, setLoudUpdateDismissed] = useState(false);
+  const [stopped, setStopped] = useState(false);
   const emptyDbAutoOpenRef = useRef(false);
   const [globalReplayFilterConfig, setGlobalReplayFilterConfig] = useState(null);
   const [globalReplayFilterSaving, setGlobalReplayFilterSaving] = useState(false);
@@ -2908,6 +2909,15 @@ function App() {
     } finally {
       setUpdateApplying(false);
     }
+  };
+
+  const handleQuit = () => {
+    if (stopped) return;
+    if (!window.confirm('Stop screpdb? The server will shut down and you can close this tab.')) return;
+    // The server dies ~500ms after acknowledging, so the request may resolve or
+    // error as the socket drops — either way it's on its way down. Show the
+    // stopped screen regardless.
+    api.quit().catch(() => {}).finally(() => setStopped(true));
   };
 
   const refreshStaleReplaysCount = useCallback(async () => {
@@ -5186,6 +5196,19 @@ function App() {
     return mainPlayersSortDir === 'asc' ? '↑' : '↓';
   };
 
+  if (stopped) {
+    return (
+      <div className="app app-stopped">
+        <div className="app-stopped-card">
+          <div className="app-stopped-icon">⏻</div>
+          <h1>screpdb has stopped</h1>
+          <p>The server has shut down. You can safely close this tab.</p>
+          <p className="app-stopped-hint">To use it again, launch screpdb from your terminal or app.</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="app">
       <div className="dashboard-container" style={mainGamesWideWidth ? { maxWidth: `${mainGamesWideWidth}px` } : undefined}>
@@ -5264,6 +5287,14 @@ function App() {
               {!showIngestPanel && ingestStatus === 'running' ? (
                 <span className="ingest-running-badge tip-below" data-tip="Ingestion in progress — click to view logs">Ingesting…</span>
               ) : null}
+            </button>
+            <button
+              type="button"
+              onClick={handleQuit}
+              className="workflow-nav-text-action workflow-nav-quit tip-below"
+              data-tip="Stop the screpdb server and quit"
+            >
+              ⏻ Quit
             </button>
             {staleReplaysCount > 0 && staleReplaysCount > dismissedStaleCount && ingestStatus !== 'running' ? (
               <span className="stale-replays-hint-wrap">

--- a/internal/dashboard/frontend/src/api.js
+++ b/internal/dashboard/frontend/src/api.js
@@ -120,6 +120,15 @@ export const api = {
     return response.json();
   },
 
+  quit: async () => {
+    const response = await fetch(`${API_CUSTOM}/quit`, { method: 'POST' });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || 'Failed to stop screpdb');
+    }
+    return response.json();
+  },
+
   getUpdateStatus: async () => {
     const response = await fetch(`${API_CUSTOM}/update/status`);
     if (!response.ok) {

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -2251,6 +2251,49 @@ button.workflow-nav-update-available:disabled {
   outline-offset: 2px;
 }
 
+.workflow-nav-quit:hover {
+  color: #ffd9d9;
+  background: rgba(220, 80, 80, 0.16);
+}
+
+.app-stopped {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.app-stopped-card {
+  max-width: 420px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.app-stopped-icon {
+  font-size: 44px;
+  line-height: 1;
+  margin-bottom: 16px;
+  opacity: 0.85;
+}
+
+.app-stopped-card h1 {
+  font-size: 22px;
+  margin: 0 0 12px;
+}
+
+.app-stopped-card p {
+  margin: 6px 0;
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.app-stopped-hint {
+  margin-top: 14px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .workflow-nav-active {
   background: rgba(100, 150, 255, 0.6);
 }

--- a/internal/dashboard/openapi_service_methods.go
+++ b/internal/dashboard/openapi_service_methods.go
@@ -329,6 +329,7 @@ func (d *Dashboard) Healthcheck(ctx context.Context, _ apigen.HealthcheckRequest
 		return nil, dashboardservice.WithStatus(http.StatusInternalServerError, err)
 	}
 	return map[string]any{
+		"app":           "screpdb",
 		"ok":            true,
 		"total_replays": totalReplays,
 		"version":       buildinfo.Version,

--- a/internal/netfacade/netfacade.go
+++ b/internal/netfacade/netfacade.go
@@ -1,8 +1,10 @@
 // Package netfacade is the sanctioned surface for general network operations in
 // screpdb's Go binary. Per issue #135 the binary's only network-client
-// operation here is a localhost TCP readiness probe (used to detect when the
-// embedded dashboard server has come up); the dashboard HTTP server binds to
-// localhost only.
+// operations here talk to the loopback interface: a localhost TCP readiness
+// probe (used to detect when the embedded dashboard server has come up) and a
+// localhost /api/health GET used for single-instance detection (deciding whether
+// a busy port is already served by another screpdb). The dashboard HTTP server
+// binds to localhost only.
 //
 // The one deliberate exception to "no outbound calls" is in-binary self-update
 // (issue #212): internal/selfupdate is a separate sanctioned surface that
@@ -17,8 +19,11 @@
 package netfacade
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -59,4 +64,48 @@ func WaitForLocalListener(addr string, attempts int, delay time.Duration) error 
 		time.Sleep(delay)
 	}
 	return fmt.Errorf("netfacade: %s did not start listening after %d attempts", addr, attempts)
+}
+
+// LocalPortAvailable reports whether nothing is currently listening on the given
+// loopback address, by attempting a short-lived bind. It refuses any
+// non-loopback address. Note the usual bind race: the port can be taken between
+// this check and an actual ListenAndServe, so callers must still handle a bind
+// failure downstream.
+func LocalPortAvailable(addr string) bool {
+	if !isLocalAddr(addr) {
+		return false
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = ln.Close()
+	return true
+}
+
+// IsLocalScrepdb reports whether the loopback address is served by a screpdb
+// instance, by GETting /api/health and checking for screpdb's identity marker.
+// It refuses any non-loopback address and makes no request off the loopback
+// interface. Used for single-instance detection: a busy port that answers as
+// screpdb should be reused rather than treated as a fatal conflict.
+func IsLocalScrepdb(addr string, timeout time.Duration) bool {
+	if !isLocalAddr(addr) {
+		return false
+	}
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get("http://" + addr + "/api/health")
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var body struct {
+		App string `json:"app"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
+		return false
+	}
+	return body.App == "screpdb"
 }

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -71,6 +71,16 @@ class Screpdb < Formula
     bin.install Dir["screpdb-*"].first => "screpdb"
   end
 
+  def caveats
+    dir = OS.mac? ? "~/Library/Application Support/screpdb" : "\${XDG_CONFIG_HOME:-\$HOME/.config}/screpdb"
+    <<~EOS
+      screpdb keeps its database and settings in a single folder:
+        #{dir}
+      This is left untouched on uninstall. To remove your data too, run:
+        rm -rf "#{dir}"
+    EOS
+  end
+
   test do
     assert_match "screpdb", shell_output("#{bin}/screpdb --help 2>&1")
   end

--- a/scripts/update-scoop-manifest.sh
+++ b/scripts/update-scoop-manifest.sh
@@ -38,6 +38,13 @@ cat > "$OUT" <<JSON
         "Run 'screpdb-gui' (or 'screpdb dashboard') to open the local dashboard in your browser.",
         "The binaries are not code-signed; SmartScreen/Defender may warn on first run. See the README."
     ],
+    "post_uninstall": [
+        "Write-Host ''",
+        "Write-Host 'screpdb kept its data (database, settings) at:'",
+        "Write-Host \"  \$env:LOCALAPPDATA\\\\screpdb\"",
+        "Write-Host 'To remove it too, run this (deletes your data):'",
+        "Write-Host \"  Remove-Item -Recurse -Force '\$env:LOCALAPPDATA\\\\screpdb'\""
+    ],
     "architecture": {
         "64bit": {
             "url": [


### PR DESCRIPTION
Reconnect to an already-running screpdb (or pick a free port past a foreign one) instead of failing on a busy port or starting an invisible second server, add a Quit button that shuts the server down cleanly, and document uninstall with brew/scoop printing the data-folder removal command.

<img width="836" height="171" alt="Screenshot 2026-07-10 at 19 36 37" src="https://github.com/user-attachments/assets/5409d873-7e54-4871-9a74-bd775c9bfc5f" />
<img width="818" height="89" alt="Screenshot 2026-07-10 at 19 31 39" src="https://github.com/user-attachments/assets/a34b841d-c7ce-4924-b56f-24d65693745c" />
<img width="573" height="77" alt="Screenshot 2026-07-10 at 19 31 30" src="https://github.com/user-attachments/assets/f4d2e1a6-c82f-4799-99f7-8db48786d59d" />
<img width="1141" height="638" alt="Screenshot 2026-07-10 at 19 31 19 1" src="https://github.com/user-attachments/assets/e74e57b8-1b95-4cba-86cd-d6a8f4cc0f4b" />

