### PR TITLE
fix(dashboard): keep games-list Featuring column on one cropped row

### DIFF
--- a/internal/dashboard/frontend/src/App.jsx
+++ b/internal/dashboard/frontend/src/App.jsx
@@ -967,6 +967,60 @@ const elideGenericDropLabels = (labels) => {
   return labels.filter((l) => !startsWith(l, 'Drop'));
 };
 
+// FeaturingCell keeps the games-list Featuring column on a single row, cropping
+// overflow. When the pills overflow, a trailing "…" toggle expands the cell to
+// wrap and show them all; the toggle stops click propagation so it doesn't open
+// the game the row links to.
+function FeaturingCell({ featuring }) {
+  const labels = elideGenericDropLabels(featuring || []);
+  const pillsRef = useRef(null);
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useLayoutEffect(() => {
+    if (expanded) return undefined;
+    const el = pillsRef.current;
+    if (!el) return undefined;
+    const measure = () => setOverflowing(el.scrollWidth > el.clientWidth + 1);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [labels, expanded]);
+
+  if (labels.length === 0) {
+    return <span className="workflow-empty-inline">-</span>;
+  }
+
+  const toggle = (e) => {
+    e.stopPropagation();
+    setExpanded((v) => !v);
+  };
+
+  return (
+    <div className={`workflow-featuring-wrap${expanded ? ' workflow-featuring-wrap--expanded' : ''}`}>
+      <div ref={pillsRef} className="workflow-pattern-pills">
+        {labels.map((pill, pillIdx) => (
+          <span key={`${pillIdx}-${pill}`} className="workflow-pattern-pill workflow-feature-pill">
+            <span>{pill}</span>
+          </span>
+        ))}
+      </div>
+      {(overflowing || expanded) && (
+        <button
+          type="button"
+          className="workflow-featuring-toggle"
+          onClick={toggle}
+          title={expanded ? 'Collapse' : 'Show all'}
+          aria-label={expanded ? 'Collapse featuring' : 'Show all featuring'}
+        >
+          {expanded ? '×' : '…'}
+        </button>
+      )}
+    </div>
+  );
+}
+
 const renderFeaturingPill = (pill, keyPrefix) => {
   const iconKeys = (Array.isArray(pill.iconKeys) && pill.iconKeys.length)
     ? pill.iconKeys
@@ -2011,7 +2065,6 @@ function App() {
   });
   const [mainGamesBORaceOpen, setMainGamesBORaceOpen] = useState('');
   const mainGamesTableRef = useRef(null);
-  const [mainGamesWideWidth, setMainGamesWideWidth] = useState(0);
   const [mainGameDetailLoading, setMainGameDetailLoading] = useState(false);
   const [mainPlayerLoading, setMainPlayerLoading] = useState(false);
   const [selectedReplayId, setSelectedReplayId] = useState(() => initialMainRoute.replayId);
@@ -4746,72 +4799,6 @@ function App() {
     return () => ro.disconnect();
   }, [mainEventMapPanelEl]);
 
-  // Once the games-list type has grown to the filter-bar font (handled in CSS by
-  // the width-driven clamp), wide viewports still leave horizontal slack beyond
-  // the capped container. If any row's Featuring pills wrap to a second line,
-  // widen the whole container into that slack — the auto table layout funnels the
-  // extra width to the flexible Featuring column, and nav/filters grow and stay
-  // left-aligned with the list — until no row wraps or we run out of viewport.
-  useLayoutEffect(() => {
-    const table = mainGamesTableRef.current;
-    if (activeView !== 'games' || !table) {
-      setMainGamesWideWidth(0);
-      return undefined;
-    }
-    if (mainGamesLoading) return undefined;
-    const container = table.closest('.dashboard-container');
-    if (!container) return undefined;
-
-    const applyWidth = (w) => {
-      container.style.maxWidth = w == null ? '' : `${w}px`;
-    };
-
-    const anyFeaturingWraps = () => {
-      const cells = table.querySelectorAll('td.workflow-games-list-featuring .workflow-pattern-pills');
-      for (const cell of cells) {
-        const pills = cell.children;
-        if (pills.length < 2) continue;
-        const top0 = pills[0].offsetTop;
-        for (let i = 1; i < pills.length; i += 1) {
-          if (pills[i].offsetTop > top0 + 1) return true;
-        }
-      }
-      return false;
-    };
-
-    const compute = () => {
-      applyWidth(null);
-      const base = container.offsetWidth;
-      const maxWidth = document.documentElement.clientWidth - 4;
-
-      if (!anyFeaturingWraps() || maxWidth <= base + 8) {
-        setMainGamesWideWidth(0);
-        return;
-      }
-
-      applyWidth(maxWidth);
-      if (anyFeaturingWraps()) {
-        applyWidth(null);
-        setMainGamesWideWidth(maxWidth);
-        return;
-      }
-
-      let lo = base;
-      let hi = maxWidth;
-      for (let i = 0; i < 8; i += 1) {
-        const mid = Math.round((lo + hi) / 2);
-        applyWidth(mid);
-        if (anyFeaturingWraps()) lo = mid; else hi = mid;
-      }
-      applyWidth(null);
-      setMainGamesWideWidth(hi);
-    };
-
-    compute();
-    const onResize = () => compute();
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [activeView, mainGames, mainGamesLoading]);
   const mainTimingCategoryConfig = useMemo(
     () => TIMING_CATEGORY_CONFIG.find((cfg) => cfg.id === mainTimingCategory) || TIMING_CATEGORY_CONFIG[0],
     [mainTimingCategory],
@@ -5211,7 +5198,7 @@ function App() {
 
   return (
     <div className="app">
-      <div className="dashboard-container" style={mainGamesWideWidth ? { maxWidth: `${mainGamesWideWidth}px` } : undefined}>
+      <div className={`dashboard-container${activeView === 'games' ? ' dashboard-container--full' : ''}`}>
         <div className="workflow-nav workflow-nav-app">
           <div className="workflow-nav-group">
             <button type="button" className={`btn-manage ${activeView === 'games' ? 'workflow-nav-active' : ''}`} onClick={() => navigateMainView('games')}>Games</button>
@@ -5509,21 +5496,7 @@ function App() {
                         <td className="workflow-games-list-map">{renderMapNameWithKind(game.map_name, game.map_kind)}</td>
                         <td className="workflow-games-list-duration">{formatDuration(game.duration_seconds)}</td>
                         <td className="workflow-games-list-featuring">
-                          {(() => {
-                            const featuring = elideGenericDropLabels(game.featuring || []);
-                            if (featuring.length === 0) {
-                              return <span className="workflow-empty-inline">-</span>;
-                            }
-                            return (
-                              <div className="workflow-pattern-pills">
-                                {featuring.map((pill, pillIdx) => (
-                                  <span key={`${game.replay_id}-${pillIdx}-${pill}`} className="workflow-pattern-pill workflow-feature-pill">
-                                    <span>{pill}</span>
-                                  </span>
-                                ))}
-                              </div>
-                            );
-                          })()}
+                          <FeaturingCell featuring={game.featuring} />
                         </td>
                       </tr>
                     ))}

--- a/internal/dashboard/frontend/src/styles.css
+++ b/internal/dashboard/frontend/src/styles.css
@@ -54,6 +54,12 @@ body {
   margin: 0 auto;
 }
 
+/* The games list uses the full viewport width so the flexible Featuring column
+   has the most room before it has to crop. */
+.dashboard-container--full {
+  max-width: none;
+}
+
 .dashboard-header {
   margin-bottom: 30px;
 }
@@ -2541,6 +2547,16 @@ button.workflow-nav-update-available:disabled {
 .workflow-games-list-table {
   font-size: clamp(0.8125rem, calc(0.8125rem + (100vw - 1300px) * 0.0037), 0.867rem);
   margin-top: 10px;
+  width: 100%;
+}
+
+/* Make Featuring the flexible column: max-width:0 + width:100% lets it absorb
+   whatever width is left after the other columns take their natural size, then
+   crop its single row to that. Without this the nowrap pills inflate the column
+   to their full content width and push it off the right edge of the screen. */
+.workflow-games-list-table td.workflow-games-list-featuring {
+  width: 100%;
+  max-width: 0;
 }
 
 .workflow-games-list-table td,
@@ -2605,6 +2621,49 @@ button.workflow-nav-update-available:disabled {
 
 .workflow-games-list-table .workflow-pattern-pills {
   gap: 3px;
+}
+
+/* Featuring column: keep the pills on a single cropped row with a trailing "…"
+   toggle; expanding wraps them to show all. */
+.workflow-featuring-wrap {
+  display: flex;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+.workflow-featuring-wrap .workflow-pattern-pills {
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-wrap: nowrap;
+  overflow: hidden;
+}
+
+.workflow-featuring-wrap--expanded .workflow-pattern-pills {
+  flex-wrap: wrap;
+  overflow: visible;
+}
+
+.workflow-featuring-wrap .workflow-feature-pill {
+  flex: 0 0 auto;
+}
+
+.workflow-featuring-toggle {
+  flex: 0 0 auto;
+  align-self: center;
+  min-width: 22px;
+  min-height: 20px;
+  padding: 0 6px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.workflow-featuring-toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
 }
 
 /* Roomy variant: applied (from App.jsx) only when every game on the page is a


### PR DESCRIPTION
The games-list Featuring column now stays on a single cropped row with a "…" toggle to expand it in place, instead of its pills pushing the whole table off the right edge of the screen.